### PR TITLE
Add explicit Java 7 version requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven-deploy-plugin-version>2.8.2</maven-deploy-plugin-version>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
 
     <modules>


### PR DESCRIPTION
Some maven clients assume Java 4 or 5 as default, this makes it Java 7 as default clear and prevents problematic compile errors.