### PR TITLE
Fix copy AnnotationProperty superproperties

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/MireotOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/MireotOperation.java
@@ -147,7 +147,7 @@ public class MireotOperation {
             }
         } else if (entity.isOWLAnnotationProperty()) {
             Collection<OWLAnnotationProperty> superproperies =
-                EntitySearcher.getSubProperties(
+                EntitySearcher.getSuperProperties(
                     entity.asOWLAnnotationProperty(), inputOntology, true);
             for (OWLAnnotationProperty superproperty: superproperies) {
                 copy(inputOntology, outputOntology, superproperty,


### PR DESCRIPTION
@cmungall: I think this was accidentally broken in 95d5602f2aed3834adc5b1f9a6c0895ca98a8cd7. Now my AnnotationProperty hierarchies aren't coming out as expected when MIREOTing.