### PR TITLE
Require Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk7
 script: "mvn verify"

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven-deploy-plugin-version>2.8.2</maven-deploy-plugin-version>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <modules>


### PR DESCRIPTION
I'm pulling this out of PR #102 to avoid confusion. The dependency introduced in #102 requires Java 8.

Java 8 was released in early 2014. My main reservation about increasing this requirement is that Travis does not yet provide an `openjdk8` testing environment.