### PR TITLE
Added validate-profile command.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -151,6 +151,15 @@ ROBOT can also create ontology files from templates. See [template.md](../docs/t
       --output results/template.owl
 
 
+## Validating Profiles
+
+OWL 2 has a number of [profiles](https://www.w3.org/TR/owl2-profiles/) that strike different balances between expressive power and reasoning efficiency. ROBOT can validate an input ontology against a profile (EL, DL, RL, QL, and Full) and generate a report. For example:
+
+    robot validate-profile -profile EL \
+      --input merged.owl \
+      --output results/merged-validation.txt
+
+
 ## Chaining
 
 On Unix platforms it's common to "chain" a series of commands, creating "pipeline" that combines several simple commands to accomplish a complex task. This works because most Unix tools communicate with streams of text. Unfortunately this doesn't work as well for OWL ontologies, because they cannot be streamed between commands, but we can achieve a similar result within ROBOT.

--- a/examples/merged-validation.txt
+++ b/examples/merged-validation.txt
@@ -1,0 +1,1 @@
+OWL 2 EL Profile Report: [Ontology and imports closure in profile]

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineInterface.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineInterface.java
@@ -21,19 +21,20 @@ public class CommandLineInterface {
      */
     private static CommandManager initManager() {
         CommandManager m = new CommandManager();
-        m.addCommand("annotate",        new AnnotateCommand());
-        m.addCommand("convert",         new ConvertCommand());
-        m.addCommand("diff",            new DiffCommand());
-        m.addCommand("export-prefixes", new ExportPrefixesCommand());
-        m.addCommand("extract",         new ExtractCommand());
-        m.addCommand("filter",          new FilterCommand());
-        m.addCommand("materialize",     new MaterializeCommand());
-        m.addCommand("merge",           new MergeCommand());
-        m.addCommand("query",           new QueryCommand());
-        m.addCommand("reason",          new ReasonCommand());
-        m.addCommand("reduce",          new ReduceCommand());
-        m.addCommand("relax",           new RelaxCommand());
-        m.addCommand("template",        new TemplateCommand());
+        m.addCommand("annotate",         new AnnotateCommand());
+        m.addCommand("convert",          new ConvertCommand());
+        m.addCommand("diff",             new DiffCommand());
+        m.addCommand("export-prefixes",  new ExportPrefixesCommand());
+        m.addCommand("extract",          new ExtractCommand());
+        m.addCommand("filter",           new FilterCommand());
+        m.addCommand("materialize",      new MaterializeCommand());
+        m.addCommand("merge",            new MergeCommand());
+        m.addCommand("query",            new QueryCommand());
+        m.addCommand("reason",           new ReasonCommand());
+        m.addCommand("reduce",           new ReduceCommand());
+        m.addCommand("relax",            new RelaxCommand());
+        m.addCommand("template",         new TemplateCommand());
+        m.addCommand("validate-profile", new ValidateProfileCommand());
         return m;
     }
 

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandManager.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandManager.java
@@ -270,7 +270,7 @@ public class CommandManager implements Command {
      * @param description a brief description of the command
      */
     public void printHelpEntry(String name, String description) {
-        System.out.println(String.format(" %-15s %s", name, description));
+        System.out.println(String.format(" %-16s %s", name, description));
     }
 
 }

--- a/robot-command/src/main/java/org/obolibrary/robot/ValidateProfileCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ValidateProfileCommand.java
@@ -1,0 +1,88 @@
+package org.obolibrary.robot;
+
+import java.io.File;
+import java.io.FileWriter;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.profiles.OWLProfile;
+import org.semanticweb.owlapi.profiles.OWLProfileReport;
+import org.semanticweb.owlapi.profiles.Profiles;
+
+public class ValidateProfileCommand implements Command  {
+	
+	private final Options options;
+	
+	public ValidateProfileCommand() {
+        Options o = CommandLineHelper.getCommonOptions();
+        o.addOption("o", "output", true, "save validation report to a file");
+        o.addOption("p", "profile", true, "OWL profile to validate (DL, EL, RL, QL, or Full)");
+        o.addOption("i", "input",     true, "validate ontology from a file");
+        o.addOption("I", "input-iri", true, "validate ontology from an IRI");
+        options = o;
+    }
+
+	@Override
+	public String getName() {
+		return "validate-profile";
+	}
+
+	@Override
+	public String getDescription() {
+		return "validate ontology against an OWL profile";
+	}
+
+	@Override
+	public String getUsage() {
+		return "robot validate-profile --profile <profile> --output <file>";
+	}
+
+	@Override
+	public Options getOptions() {
+		return options;
+	}
+
+	@Override
+	public void main(String[] args) {
+        try {
+            execute(null, args);
+        } catch (Exception e) {
+            CommandLineHelper.handleException(getUsage(), getOptions(), e);
+        }
+    }
+
+	@Override
+	public CommandState execute(CommandState state, String[] args)
+			throws Exception {
+		CommandLine line = CommandLineHelper
+				.getCommandLine(getUsage(), getOptions(), args);
+		if (line == null) {
+			return null;
+		}
+		IOHelper ioHelper = CommandLineHelper.getIOHelper(line);
+        state = CommandLineHelper.updateInputOntology(ioHelper, state, line);
+        OWLOntology ontology = state.getOntology();
+		String profile = CommandLineHelper.getOptionalValue(line, "profile").toUpperCase();
+		final OWLProfile owlProfile;
+		switch(profile) {
+		case "DL": owlProfile = Profiles.OWL2_DL; break;
+		case "EL": owlProfile = Profiles.OWL2_EL; break;
+		case "RL": owlProfile = Profiles.OWL2_RL; break;
+		case "QL": owlProfile = Profiles.OWL2_QL; break;
+		case "FULL": owlProfile = Profiles.OWL2_FULL; break;
+		default: owlProfile = null;
+		}
+		OWLProfileReport report = owlProfile.checkOntology(ontology);
+		File outputFile = CommandLineHelper.getOutputFile(line);
+		if (outputFile != null) {
+	        FileWriter writer = new FileWriter(outputFile);
+	        writer.write(report.toString());
+	        writer.close();
+	    } else {
+			System.out.println(report.toString());
+		}
+		return state;
+	}
+
+}


### PR DESCRIPTION
I added a command to validate an ontology against an OWL 2 profile. For example:

```
$ ./bin/robot validate-profile -profile EL --input pato.owl 
OWL 2 EL Profile Report: [Ontology and imports closure in profile]

```