### PR TITLE
Optionally fail if NC equivalency detected. 

### DIFF
--- a/robot-command/src/main/java/org/obolibrary/robot/ReasonCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ReasonCommand.java
@@ -44,6 +44,8 @@ public class ReasonCommand implements Command {
                 "annotate all inferred axioms (only when -n is passed)");
         o.addOption("x", "exclude-duplicate-axioms",     true,
                 "do not add an axiom if it exists in import chain");
+        o.addOption("e", "equivalent-classes-allowed",     true,
+                "if false then detecting equivalent classes exits with error");
         o.addOption("i", "input",     true, "reason ontology from a file");
         o.addOption("I", "input-iri", true, "reason ontology from an IRI");
         o.addOption("o", "output",    true, "save reasoned ontology to a file");

--- a/robot-core/src/main/java/org/obolibrary/robot/OntologyHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/OntologyHelper.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +24,7 @@ import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLDatatype;
 import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLLiteral;
+import org.semanticweb.owlapi.model.OWLNamedObject;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.model.OWLOntologyID;
@@ -41,7 +43,7 @@ public class OntologyHelper {
      * Logger.
      */
     private static final Logger logger =
-        LoggerFactory.getLogger(OntologyHelper.class);
+            LoggerFactory.getLogger(OntologyHelper.class);
 
     /**
      * Set the ontology IRI and version IRI using strings.
@@ -205,7 +207,7 @@ public class OntologyHelper {
     public static Set<OWLAnnotationAssertionAxiom> getAnnotationAxioms(
             OWLOntology ontology, OWLAnnotationProperty property) {
         Set<OWLAnnotationProperty> properties =
-            new HashSet<OWLAnnotationProperty>();
+                new HashSet<OWLAnnotationProperty>();
         properties.add(property);
         Set<IRI> subjects = null;
         return getAnnotationAxioms(ontology, properties, subjects);
@@ -226,7 +228,7 @@ public class OntologyHelper {
             OWLOntology ontology, OWLAnnotationProperty property,
             IRI subject) {
         Set<OWLAnnotationProperty> properties =
-            new HashSet<OWLAnnotationProperty>();
+                new HashSet<OWLAnnotationProperty>();
         properties.add(property);
         Set<IRI> subjects = null;
         if (subject != null) {
@@ -253,14 +255,14 @@ public class OntologyHelper {
             OWLOntology ontology, Set<OWLAnnotationProperty> properties,
             Set<IRI> subjects) {
         Set<OWLAnnotationAssertionAxiom> results =
-            new HashSet<OWLAnnotationAssertionAxiom>();
+                new HashSet<OWLAnnotationAssertionAxiom>();
 
         for (OWLAxiom axiom: ontology.getAxioms()) {
             if (!(axiom instanceof OWLAnnotationAssertionAxiom)) {
                 continue;
             }
             OWLAnnotationAssertionAxiom aaa =
-                (OWLAnnotationAssertionAxiom) axiom;
+                    (OWLAnnotationAssertionAxiom) axiom;
             if (properties != null && !properties.contains(aaa.getProperty())) {
                 continue;
             }
@@ -268,7 +270,7 @@ public class OntologyHelper {
             if (subjects == null) {
                 results.add(aaa);
             } else if (subject instanceof IRI
-                       && subjects.contains((IRI) subject)) {
+                    && subjects.contains((IRI) subject)) {
                 results.add(aaa);
             }
         }
@@ -290,7 +292,7 @@ public class OntologyHelper {
             OWLOntology ontology, OWLAnnotationProperty property,
             IRI subject) {
         Set<OWLAnnotationProperty> properties =
-            new HashSet<OWLAnnotationProperty>();
+                new HashSet<OWLAnnotationProperty>();
         properties.add(property);
         Set<IRI> subjects = new HashSet<IRI>();
         subjects.add(subject);
@@ -315,7 +317,7 @@ public class OntologyHelper {
             Set<IRI> subjects) {
         Set<OWLAnnotationValue> results = new HashSet<OWLAnnotationValue>();
         Set<OWLAnnotationAssertionAxiom> axioms =
-            getAnnotationAxioms(ontology, properties, subjects);
+                getAnnotationAxioms(ontology, properties, subjects);
         for (OWLAnnotationAssertionAxiom axiom: axioms) {
             results.add(axiom.getValue());
         }
@@ -336,7 +338,7 @@ public class OntologyHelper {
             OWLOntology ontology, OWLAnnotationProperty property,
             IRI subject) {
         Set<OWLAnnotationProperty> properties =
-            new HashSet<OWLAnnotationProperty>();
+                new HashSet<OWLAnnotationProperty>();
         properties.add(property);
         Set<IRI> subjects = new HashSet<IRI>();
         subjects.add(subject);
@@ -360,7 +362,7 @@ public class OntologyHelper {
             Set<IRI> subjects) {
         Set<String> results = new HashSet<String>();
         Set<OWLAnnotationValue> values =
-            getAnnotationValues(ontology, properties, subjects);
+                getAnnotationValues(ontology, properties, subjects);
         for (OWLAnnotationValue value: values) {
             results.add(getValue(value));
         }
@@ -381,7 +383,7 @@ public class OntologyHelper {
             OWLOntology ontology, OWLAnnotationProperty property,
             IRI subject) {
         Set<OWLAnnotationProperty> properties =
-            new HashSet<OWLAnnotationProperty>();
+                new HashSet<OWLAnnotationProperty>();
         properties.add(property);
         Set<IRI> subjects = new HashSet<IRI>();
         subjects.add(subject);
@@ -405,7 +407,7 @@ public class OntologyHelper {
             OWLOntology ontology, Set<OWLAnnotationProperty> properties,
             Set<IRI> subjects) {
         Set<String> valueSet =
-            getAnnotationStrings(ontology, properties, subjects);
+                getAnnotationStrings(ontology, properties, subjects);
         List<String> valueList = new ArrayList<String>(valueSet);
         Collections.sort(valueList);
         String value = null;
@@ -427,11 +429,11 @@ public class OntologyHelper {
         Map<IRI, String> results = new HashMap<IRI, String>();
         OWLOntologyManager manager = ontology.getOWLOntologyManager();
         OWLAnnotationProperty rdfsLabel =
-            manager.getOWLDataFactory().getRDFSLabel();
+                manager.getOWLDataFactory().getRDFSLabel();
         Set<OWLOntology> ontologies = new HashSet<OWLOntology>();
         ontologies.add(ontology);
         ReferencedEntitySetProvider resp =
-            new ReferencedEntitySetProvider(ontologies);
+                new ReferencedEntitySetProvider(ontologies);
         for (OWLEntity entity: resp.getEntities()) {
             String value = getAnnotationString(
                     ontology, rdfsLabel, entity.getIRI());
@@ -454,9 +456,9 @@ public class OntologyHelper {
         Map<String, IRI> results = new HashMap<String, IRI>();
         OWLOntologyManager manager = ontology.getOWLOntologyManager();
         OWLAnnotationProperty rdfsLabel =
-            manager.getOWLDataFactory().getRDFSLabel();
+                manager.getOWLDataFactory().getRDFSLabel();
         Set<OWLAnnotationAssertionAxiom> axioms =
-            getAnnotationAxioms(ontology, rdfsLabel);
+                getAnnotationAxioms(ontology, rdfsLabel);
         for (OWLAnnotationAssertionAxiom axiom: axioms) {
             String value = getValue(axiom);
             if (value == null) {
@@ -468,14 +470,38 @@ public class OntologyHelper {
             }
             if (results.containsKey(value)) {
                 logger.warn("Duplicate rdfs:label \""
-                           + value
-                           + "\" for subject "
-                           + subject);
+                        + value
+                        + "\" for subject "
+                        + subject);
             }
             results.put(value, (IRI) subject);
         }
         return results;
     }
+
+    /**
+     * Generates a function that returns a label string for any named
+     * object in the ontology
+     * 
+     * @param ontology
+     * @param useIriAsDefault
+     * @return function mapping object to label
+     */
+    public static Function<OWLNamedObject,String> getLabelFunction(OWLOntology ontology, boolean useIriAsDefault) {
+        Map<IRI, String> labelMap = getLabels(ontology);
+        return (obj) -> {
+            String label;
+            if (labelMap.containsKey(obj.getIRI()))
+                label = labelMap.get(obj.getIRI());
+            else if (useIriAsDefault)
+                label = obj.getIRI().toString();
+            else
+                label = null;
+                
+            return label;
+        };
+    }
+
 
     /**
      * Given an ontology and a set of term IRIs,
@@ -508,7 +534,7 @@ public class OntologyHelper {
         Set<OWLOntology> ontologies = new HashSet<OWLOntology>();
         ontologies.add(ontology);
         ReferencedEntitySetProvider resp =
-            new ReferencedEntitySetProvider(ontologies);
+                new ReferencedEntitySetProvider(ontologies);
         return resp.getEntities();
     }
 
@@ -538,7 +564,7 @@ public class OntologyHelper {
         OWLOntologyManager manager = ontology.getOWLOntologyManager();
         for (OWLAnnotation annotation: ontology.getAnnotations()) {
             RemoveOntologyAnnotation remove =
-                new RemoveOntologyAnnotation(ontology, annotation);
+                    new RemoveOntologyAnnotation(ontology, annotation);
             manager.applyChange(remove);
         }
     }
@@ -557,7 +583,7 @@ public class OntologyHelper {
         OWLDataFactory df = manager.getOWLDataFactory();
 
         OWLAnnotationProperty property =
-            df.getOWLAnnotationProperty(propertyIRI);
+                df.getOWLAnnotationProperty(propertyIRI);
         OWLAnnotation annotation = df.getOWLAnnotation(property, value);
         addOntologyAnnotation(ontology, annotation);
     }
@@ -571,7 +597,7 @@ public class OntologyHelper {
             OWLAnnotation annotation) {
         OWLOntologyManager manager = ontology.getOWLOntologyManager();
         AddOntologyAnnotation addition =
-            new AddOntologyAnnotation(ontology, annotation);
+                new AddOntologyAnnotation(ontology, annotation);
         manager.applyChange(addition);
     }
 


### PR DESCRIPTION
 * Adds option to `ReasonOperation` that will `exit(1)` if named class equivalence detected
 * Adds `-e` option to `reason`

Note the ultimate behavior (exit vs throw) will be revisited after #40, allowing a test to be written

Fixes #123 
