### PR TITLE
Throw exception on reasoner errs, and test RBox for incoherency

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/ReasonerHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReasonerHelper.java
@@ -1,0 +1,106 @@
+package org.obolibrary.robot;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.obolibrary.robot.exceptions.IncoherentTBoxException;
+import org.obolibrary.robot.exceptions.IncoherentRBoxException;
+import org.obolibrary.robot.exceptions.InconsistentOntologyException;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLObjectProperty;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.parameters.Imports;
+import org.semanticweb.owlapi.reasoner.InferenceType;
+import org.semanticweb.owlapi.reasoner.Node;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * 
+ * Provides convenience methods for working with OWL reasoning.
+ * 
+ * @author cjm
+ *
+ */
+public class ReasonerHelper {
+
+    /**
+     * Logger.
+     */
+    private static final Logger logger =
+            LoggerFactory.getLogger(ReasonerHelper.class);
+
+
+    public static void validate(OWLReasoner reasoner) throws IncoherentTBoxException, InconsistentOntologyException, IncoherentRBoxException {
+
+        OWLOntology ont = reasoner.getRootOntology();
+        OWLOntologyManager manager = ont.getOWLOntologyManager();
+        OWLDataFactory dataFactory = manager.getOWLDataFactory();
+        OWLClass nothing = dataFactory.getOWLNothing();
+        OWLClass thing = dataFactory.getOWLThing();
+        logger.info("Checking for inconsistencies");
+        if (!reasoner.isConsistent()) {
+            throw new InconsistentOntologyException();
+        }
+
+        logger.info("Checking for unsatisfiable classes...");
+        Set<OWLClass> unsatisfiableClasses =
+                reasoner.getUnsatisfiableClasses().getEntitiesMinus(nothing);
+        if (unsatisfiableClasses.size() > 0) {
+            logger.error("There are {} unsatisfiable classes in the ontology.",
+                    unsatisfiableClasses.size());
+            for (OWLClass cls : unsatisfiableClasses) {
+                logger.error("    unsatisfiable: " + cls.getIRI());
+            }
+            throw new IncoherentTBoxException(unsatisfiableClasses);
+        }
+        
+        logger.info("Checking for unsatisfiable object properties...");
+
+        Set<OWLAxiom>tempAxioms = new HashSet<>();
+        Map<OWLClass, OWLObjectProperty> probeFor = new HashMap<>();
+        for (OWLObjectProperty p : ont.getObjectPropertiesInSignature(Imports.INCLUDED)) {
+            UUID uuid = UUID.randomUUID();
+            IRI probeIRI = IRI.create(p.getIRI().toString() + "-" + uuid.toString());
+            OWLClass probe = dataFactory.getOWLClass(probeIRI);
+            probeFor.put(probe, p);
+            tempAxioms.add(dataFactory.getOWLDeclarationAxiom(probe));
+            tempAxioms.add(dataFactory.getOWLSubClassOfAxiom(probe, 
+                    dataFactory.getOWLObjectSomeValuesFrom(p, thing)));
+        }
+        manager.addAxioms(ont, tempAxioms);
+        reasoner.flush();
+ 
+        Set<OWLClass> unsatisfiableProbeClasses =
+                reasoner.getUnsatisfiableClasses().getEntitiesMinus(nothing);
+        
+        // leave no trace
+        manager.removeAxioms(ont, tempAxioms);
+        reasoner.flush();
+        
+         if (unsatisfiableProbeClasses.size() > 0) {
+            logger.error("There are {} unsatisfiable properties in the ontology.",
+                    unsatisfiableProbeClasses.size());
+            Set<OWLObjectProperty> unsatPs = new HashSet<>();
+            for (OWLClass cls : unsatisfiableProbeClasses) {
+                OWLObjectProperty unsatP = probeFor.get(cls);
+                unsatPs.add(unsatP);
+                logger.error("    unsatisfiable property: " + unsatP.getIRI());
+            }
+            throw new IncoherentRBoxException(unsatPs);
+        }
+
+
+    }
+    
+   
+
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/exceptions/IncoherentRBoxException.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/exceptions/IncoherentRBoxException.java
@@ -1,0 +1,22 @@
+package org.obolibrary.robot.exceptions;
+
+import java.util.Set;
+
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLEntity;
+import org.semanticweb.owlapi.model.OWLObject;
+import org.semanticweb.owlapi.model.OWLObjectProperty;
+
+/**
+ * Ontology contains unsatisfiable properties
+ * 
+ * @author cjm
+ *
+ */
+public class IncoherentRBoxException extends OntologyLogicException {
+
+    public IncoherentRBoxException(Set<OWLObjectProperty> unsatisfiableProperties) {
+        // TODO Auto-generated constructor stub
+    }
+
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/exceptions/IncoherentTBoxException.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/exceptions/IncoherentTBoxException.java
@@ -1,0 +1,21 @@
+package org.obolibrary.robot.exceptions;
+
+import java.util.Set;
+
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLEntity;
+import org.semanticweb.owlapi.model.OWLObject;
+
+/**
+ * Ontology contains unsatisfiable classes
+ * 
+ * @author cjm
+ *
+ */
+public class IncoherentTBoxException extends OntologyLogicException {
+
+    public IncoherentTBoxException(Set<OWLClass> unsatisfiableClasses) {
+        // TODO Auto-generated constructor stub
+    }
+
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/exceptions/InconsistentOntologyException.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/exceptions/InconsistentOntologyException.java
@@ -1,0 +1,13 @@
+package org.obolibrary.robot.exceptions;
+
+/**
+ * Ontology contains logical inconsistencies
+ * 
+ * Note inconsistency is not the same as incoherency
+ * 
+ * @author cjm
+ *
+ */
+public class InconsistentOntologyException extends OntologyLogicException {
+
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/exceptions/OntologyLogicException.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/exceptions/OntologyLogicException.java
@@ -1,0 +1,11 @@
+package org.obolibrary.robot.exceptions;
+
+/**
+ * Ontology contains unsatisfiable classes, properties or inconsistencies
+ * 
+ * @author cjm
+ *
+ */
+public class OntologyLogicException extends Exception {
+
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/exceptions/package-info.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/exceptions/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * 
+ */
+/**
+ * @author cjm
+ *
+ */
+package org.obolibrary.robot.exceptions;

--- a/robot-core/src/test/java/org/obolibrary/robot/MaterializeOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/MaterializeOperationTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.apache.commons.io.IOUtils;
 import org.geneontology.reasoner.ExpressionMaterializingReasonerFactory;
 import org.junit.Test;
+import org.obolibrary.robot.exceptions.OntologyLogicException;
 import org.semanticweb.elk.owlapi.ElkReasonerFactory;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
@@ -33,7 +34,7 @@ public class MaterializeOperationTest extends CoreTest {
      */
     @Test
     public void testMaterialize()
-            throws IOException, OWLOntologyCreationException {
+            throws IOException, OWLOntologyCreationException, OntologyLogicException {
         OWLOntology reasoned = loadOntology("/relax_equivalence_axioms_test.obo");
         OWLReasonerFactory coreReasonerFactory = new ElkReasonerFactory();
         Map<String, String> opts = ReasonOperation.getDefaultOptions();
@@ -53,7 +54,7 @@ public class MaterializeOperationTest extends CoreTest {
      */
     @Test
     public void testMaterializeWithReflexivity()
-            throws IOException, OWLOntologyCreationException {
+            throws IOException, OWLOntologyCreationException, OntologyLogicException {
         OWLOntology reasoned = loadOntology("/mat_reflexivity_test.obo");
         OWLReasonerFactory coreReasonerFactory = new ElkReasonerFactory();
         Map<String, String> opts = ReasonOperation.getDefaultOptions();
@@ -73,7 +74,7 @@ public class MaterializeOperationTest extends CoreTest {
      */
     @Test
     public void testMaterializeGCIs()
-            throws IOException, OWLOntologyCreationException {
+            throws IOException, OWLOntologyCreationException, OntologyLogicException {
         OWLOntology reasoned = loadOntology("/gci_example.obo");
         OWLReasonerFactory coreReasonerFactory = new ElkReasonerFactory();
         Map<String, String> opts = ReasonOperation.getDefaultOptions();
@@ -93,7 +94,7 @@ public class MaterializeOperationTest extends CoreTest {
      */
     @Test
     public void testMaterializeWithImports()
-            throws IOException, OWLOntologyCreationException, URISyntaxException {
+            throws IOException, OWLOntologyCreationException, OntologyLogicException, URISyntaxException {
         
         // TODO: minor, simplify this once https://github.com/ontodev/robot/issues/121 implemeted
         

--- a/robot-core/src/test/java/org/obolibrary/robot/ReasonOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ReasonOperationTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import org.geneontology.reasoner.ExpressionMaterializingReasonerFactory;
 import org.junit.Test;
+import org.obolibrary.robot.exceptions.OntologyLogicException;
 import org.semanticweb.elk.owlapi.ElkReasonerFactory;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
@@ -23,11 +24,11 @@ public class ReasonOperationTest extends CoreTest {
      * Test reasoning with StructuralReasoner.
      *
      * @throws IOException on file problem
-     * @throws OWLOntologyCreationException on ontology problem
+     * @throws OWLOntologyCreationException, OntologyLogicException on ontology problem
      */
     @Test
     public void testStructural()
-            throws IOException, OWLOntologyCreationException {
+            throws IOException, OWLOntologyCreationException, OntologyLogicException, OntologyLogicException {
         OWLOntology reasoned = loadOntology("/simple.owl");
         OWLReasonerFactory reasonerFactory = new org.semanticweb
             .owlapi.reasoner.structural.StructuralReasonerFactory();
@@ -39,10 +40,10 @@ public class ReasonOperationTest extends CoreTest {
      * Test reasoning with ELK.
      *
      * @throws IOException on file problem
-     * @throws OWLOntologyCreationException on ontology problem
+     * @throws OWLOntologyCreationException, OntologyLogicException on ontology problem
      */
     @Test
-    public void testELK() throws IOException, OWLOntologyCreationException {
+    public void testELK() throws IOException, OWLOntologyCreationException, OntologyLogicException, OntologyLogicException {
         OWLOntology reasoned = loadOntology("/simple.owl");
         OWLReasonerFactory reasonerFactory = new org.semanticweb
             .elk.owlapi.ElkReasonerFactory();
@@ -54,10 +55,10 @@ public class ReasonOperationTest extends CoreTest {
      * Test reasoning with HermiT.
      *
      * @throws IOException on file problem
-     * @throws OWLOntologyCreationException on ontology problem
+     * @throws OWLOntologyCreationException, OntologyLogicException on ontology problem
      */
     @Test
-    public void testHermit() throws IOException, OWLOntologyCreationException {
+    public void testHermit() throws IOException, OWLOntologyCreationException, OntologyLogicException, OntologyLogicException {
         OWLOntology reasoned = loadOntology("/simple.owl");
         OWLReasonerFactory reasonerFactory = new org.semanticweb
             .HermiT.Reasoner.ReasonerFactory();
@@ -70,10 +71,10 @@ public class ReasonOperationTest extends CoreTest {
      * Test reasoning with JFact.
      *
      * @throws IOException on file problem
-     * @throws OWLOntologyCreationException on ontology problem
+     * @throws OWLOntologyCreationException, OntologyLogicException on ontology problem
      */
     @Test
-    public void testJFact() throws IOException, OWLOntologyCreationException {
+    public void testJFact() throws IOException, OWLOntologyCreationException, OntologyLogicException {
         OWLOntology reasoned = loadOntology("/simple.owl");
         OWLReasonerFactory reasonerFactory = new JFactFactory();
         ReasonOperation.reason(reasoned, reasonerFactory);
@@ -85,11 +86,11 @@ public class ReasonOperationTest extends CoreTest {
      * Test inferring into new ontology.
      *
      * @throws IOException on file problem
-     * @throws OWLOntologyCreationException on ontology problem
+     * @throws OWLOntologyCreationException, OntologyLogicException on ontology problem
      */
     @Test
     public void testInferIntoNewOntology()
-            throws IOException, OWLOntologyCreationException {
+            throws IOException, OWLOntologyCreationException, OntologyLogicException {
         OWLOntology reasoned = loadOntology("/simple.owl");
         OWLReasonerFactory reasonerFactory = new org.semanticweb
             .HermiT.Reasoner.ReasonerFactory();
@@ -107,11 +108,11 @@ public class ReasonOperationTest extends CoreTest {
      * Test inferring into new ontology.
      *
      * @throws IOException on file problem
-     * @throws OWLOntologyCreationException on ontology problem
+     * @throws OWLOntologyCreationException, OntologyLogicException on ontology problem
      */
     @Test
     public void testInferIntoNewOntologyNonTrivial()
-            throws IOException, OWLOntologyCreationException {
+            throws IOException, OWLOntologyCreationException, OntologyLogicException {
         OWLOntology reasoned =
             loadOntology("/relax_equivalence_axioms_test.obo");
         OWLReasonerFactory reasonerFactory = new org.semanticweb
@@ -131,11 +132,11 @@ public class ReasonOperationTest extends CoreTest {
      * Test inferring into new ontology.
      *
      * @throws IOException on file problem
-     * @throws OWLOntologyCreationException on ontology problem
+     * @throws OWLOntologyCreationException, OntologyLogicException on ontology problem
      */
     @Test
     public void testInferIntoNewOntologyNoDupes()
-            throws IOException, OWLOntologyCreationException {
+            throws IOException, OWLOntologyCreationException, OntologyLogicException {
         OWLOntology reasoned =
             loadOntology("/relax_equivalence_axioms_test.obo");
         OWLReasonerFactory reasonerFactory = new org.semanticweb
@@ -153,11 +154,11 @@ public class ReasonOperationTest extends CoreTest {
      * Test removing redundant subclass axioms.
      *
      * @throws IOException on file problem
-     * @throws OWLOntologyCreationException on ontology problem
+     * @throws OWLOntologyCreationException, OntologyLogicException on ontology problem
      */
     @Test
     public void testRemoveRedundantSubClassAxioms()
-            throws IOException, OWLOntologyCreationException {
+            throws IOException, OWLOntologyCreationException, OntologyLogicException {
         OWLOntology reasoned = loadOntology("/redundant_subclasses.owl");
         OWLReasonerFactory reasonerFactory = new org.semanticweb
             .elk.owlapi.ElkReasonerFactory();
@@ -178,11 +179,11 @@ public class ReasonOperationTest extends CoreTest {
      * This test should return the same results as running any other reasoner
      *
      * @throws IOException on file problem
-     * @throws OWLOntologyCreationException on ontology problem
+     * @throws OWLOntologyCreationException, OntologyLogicException on ontology problem
      */
     @Test
     public void testEMRBasic()
-            throws IOException, OWLOntologyCreationException {
+            throws IOException, OWLOntologyCreationException, OntologyLogicException {
         OWLOntology reasoned = loadOntology("/simple.owl");
         OWLReasonerFactory coreReasonerFactory = new ElkReasonerFactory();
         OWLReasonerFactory reasonerFactory = new ExpressionMaterializingReasonerFactory(coreReasonerFactory);
@@ -196,11 +197,11 @@ public class ReasonOperationTest extends CoreTest {
      * This test effectively relaxes an equivalence axiom
      *
      * @throws IOException on file problem
-     * @throws OWLOntologyCreationException on ontology problem
+     * @throws OWLOntologyCreationException, OntologyLogicException on ontology problem
      */
     @Test
     public void testEMRRelax()
-            throws IOException, OWLOntologyCreationException {
+            throws IOException, OWLOntologyCreationException, OntologyLogicException {
         OWLOntology reasoned = loadOntology("/relax_equivalence_axioms_test.obo");
         OWLReasonerFactory coreReasonerFactory = new ElkReasonerFactory();
         OWLReasonerFactory reasonerFactory = new ExpressionMaterializingReasonerFactory(coreReasonerFactory);

--- a/robot-core/src/test/java/org/obolibrary/robot/ReasonerHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ReasonerHelperTest.java
@@ -1,0 +1,110 @@
+package org.obolibrary.robot;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.obolibrary.robot.exceptions.IncoherentRBoxException;
+import org.obolibrary.robot.exceptions.IncoherentTBoxException;
+import org.obolibrary.robot.exceptions.InconsistentOntologyException;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
+import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
+
+public class ReasonerHelperTest extends CoreTest {
+
+    /**
+     * Test checking for incoherent OPs.
+     * 
+     * See https://github.com/ontodev/robot/issues/104
+     *
+     * @throws IOException
+     * @throws IncoherentTBoxException
+     * @throws InconsistentOntologyException
+     */
+    @Test
+    public void testIncoherentRBox() throws IOException, IncoherentTBoxException, InconsistentOntologyException {
+        OWLOntology ontology = loadOntology("/incoherent-rbox.owl");
+        OWLReasonerFactory reasonerFactory = new org.semanticweb
+                .elk.owlapi.ElkReasonerFactory();
+        OWLReasoner reasoner = reasonerFactory.createReasoner(ontology);
+        boolean isCaughtException = false;
+        try {
+            ReasonerHelper.validate(reasoner);
+        }
+        catch (IncoherentRBoxException e) {
+            isCaughtException = true;
+        }
+        assertTrue(isCaughtException);
+    }
+    
+    /**
+     * Test checking for incoherent classes.
+     * 
+     * @throws IOException
+     * @throws IncoherentTBoxException
+     * @throws InconsistentOntologyException
+     * @throws IncoherentRBoxException 
+     */
+    @Test
+    public void testIncoherentTBox() throws IOException, IncoherentTBoxException, InconsistentOntologyException, IncoherentRBoxException {
+        OWLOntology ontology = loadOntology("/incoherent-tbox.owl");
+        OWLReasonerFactory reasonerFactory = new org.semanticweb
+                .elk.owlapi.ElkReasonerFactory();
+        OWLReasoner reasoner = reasonerFactory.createReasoner(ontology);
+        boolean isCaughtException = false;
+        try {
+            ReasonerHelper.validate(reasoner);
+        }
+        catch (IncoherentTBoxException e) {
+            isCaughtException = true;
+        }
+        assertTrue(isCaughtException);
+    }
+    
+    /**
+     * Test checking for inconsistencies.
+     * 
+     * @throws IOException
+     * @throws IncoherentTBoxException
+     * @throws InconsistentOntologyException
+     * @throws IncoherentRBoxException 
+     */
+    @Test
+    public void testInconsistentOntology() throws IOException, IncoherentTBoxException, InconsistentOntologyException, IncoherentRBoxException {
+        OWLOntology ontology = loadOntology("/inconsistent.owl");
+        OWLReasonerFactory reasonerFactory = new org.semanticweb
+                .elk.owlapi.ElkReasonerFactory();
+        OWLReasoner reasoner = reasonerFactory.createReasoner(ontology);
+        boolean isCaughtException = false;
+        try {
+            ReasonerHelper.validate(reasoner);
+        }
+        catch (InconsistentOntologyException e) {
+            isCaughtException = true;
+        }
+        assertTrue(isCaughtException);
+    }
+    
+    /**
+     * Test for no false positives in validation
+     * 
+     * @throws IOException
+     * @throws IncoherentTBoxException
+     * @throws InconsistentOntologyException
+     * @throws IncoherentRBoxException 
+     */
+    @Test
+    public void testNoFalsePositives() throws IOException, IncoherentTBoxException, InconsistentOntologyException, IncoherentRBoxException {
+        OWLOntology ontology = loadOntology("/simple.owl");
+        OWLReasonerFactory reasonerFactory = new org.semanticweb
+                .elk.owlapi.ElkReasonerFactory();
+        OWLReasoner reasoner = reasonerFactory.createReasoner(ontology);
+        ReasonerHelper.validate(reasoner);
+        
+        // trivially true, if no exceptions are caught
+        assertTrue(true);
+    }
+}

--- a/robot-core/src/test/resources/incoherent-rbox.owl
+++ b/robot-core/src/test/resources/incoherent-rbox.owl
@@ -1,0 +1,15 @@
+Prefix: : <http://x.org/>
+
+Ontology: <http://purl.obolibrary.org/obo/test>
+
+Class: C
+Class: O
+   DisjointWith: C
+
+ObjectProperty: P
+  Domain: C
+ObjectProperty: Q
+  Domain: O
+    SubPropertyOf: P
+
+

--- a/robot-core/src/test/resources/incoherent-tbox.owl
+++ b/robot-core/src/test/resources/incoherent-tbox.owl
@@ -1,0 +1,11 @@
+Prefix: : <http://x.org/>
+
+Ontology: <http://purl.obolibrary.org/obo/test>
+
+Class: C
+Class: O
+   DisjointWith: C
+
+Class: D
+  SubClassOf: C
+  SubClassOf: O

--- a/robot-core/src/test/resources/inconsistent.owl
+++ b/robot-core/src/test/resources/inconsistent.owl
@@ -1,0 +1,11 @@
+Prefix: : <http://x.org/>
+
+Ontology: <http://purl.obolibrary.org/obo/test>
+
+Class: C
+Class: O
+   DisjointWith: C
+
+Individual: I
+  Types: C
+  Types: O


### PR DESCRIPTION
 * Throws exceptions if ontology logically incoherent, fixes #40
 * Includes incoherent OPs in logical tests, fixes #104

Note that the output is somewhat unfriendly, e.g.

```
$ robot materialize -i ./robot-core/src/test/resources/incoherent-rbox.owl 
ERROR There are 1 unsatisfiable properties in the ontology.
ERROR     unsatisfiable property: http://x.org/Q
org.obolibrary.robot.exceptions.IncoherentRBoxException
        at org.obolibrary.robot.ReasonerHelper.validate(ReasonerHelper.java:98)
        at org.obolibrary.robot.MaterializeOperation.materialize(MaterializeOperation.java:132)
        at org.obolibrary.robot.MaterializeOperation.materialize(MaterializeOperation.java:85)
        at org.obolibrary.robot.MaterializeCommand.execute(MaterializeCommand.java:168)
        at org.obolibrary.robot.CommandManager.executeCommand(CommandManager.java:242)
        at org.obolibrary.robot.CommandManager.execute(CommandManager.java:177)
        at org.obolibrary.robot.CommandManager.main(CommandManager.java:135)
        at org.obolibrary.robot.CommandLineInterface.main(CommandLineInterface.java:54)
usage: robot [command] [options] <arguments>
 -h,--help                  print usage information
 -noprefixes                do not use default prefixes
 -p,--prefix <arg>          add a prefix 'foo: http://bar'
 -P,--prefixes <arg>        use prefixes from JSON-LD file
 -V,--version               print version information
 -v,--verbose               increased logging
 -vv,--very-verbose         high logging
 -vvv,--very-very-verbose   maximum logging
 -x,--xml-entities          use entity substitution with ontology XML
                            output
commands:
 help             print help for command
 annotate         annotate ontology
 convert          convert ontology
 diff             find the differences between two ontologies
 export-prefixes  export prefixes to a file
 extract          extract terms from an ontology
 filter           filter ontology axioms
 materialize      materialize ontology
 merge            merge ontologies
 query            query an ontology
 reason           reason ontology
 reduce           reduce ontology
 relax            relax ontology
 template         build an ontology from a template
 unmerge          unmerge ontologies
 validate-profile validate ontology against an OWL profile
```

but being unfriendly is better than silently progressing with an incoherent ontology
