### PR TITLE
Initial dockerfile with "robot" entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM maven:3-jdk-8
+FROM maven:3-jdk-8-alpine
 
-RUN adduser robot
+RUN adduser -D robot
 RUN mkdir -p /usr/src/app
 RUN chown robot /usr/src/app
-
 
 COPY pom.xml /usr/src/app
 COPY robot-command /usr/src/app/robot-command

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM maven:3-jdk-8
+
+RUN adduser robot
+RUN mkdir -p /usr/src/app
+RUN chown robot /usr/src/app
+
+
+COPY pom.xml /usr/src/app
+COPY robot-command /usr/src/app/robot-command
+COPY robot-core /usr/src/app/robot-core
+COPY bin/robot /usr/local/bin/
+RUN chown -R robot:robot /usr/src/app
+
+USER robot
+WORKDIR /usr/src/app
+RUN mvn install -DskipTests
+
+USER root
+RUN cp bin/robot.jar /usr/local/bin
+USER robot
+ENTRYPOINT ["robot"]


### PR DESCRIPTION
This dockerfile builds the robot jar and installs
it under /usr/local/bin along with the "robot"
script which is used as the entrypoint. Once built,
"docker run --rm robot ..." is equivalent to running
the command-line.