### PR TITLE
reason --create-new-ontology-with-annotations

### DIFF
--- a/robot-command/src/main/java/org/obolibrary/robot/ReasonCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ReasonCommand.java
@@ -41,6 +41,8 @@ public class ReasonCommand implements Command {
                 true, "remove redundant subclass axioms");
         o.addOption("n", "create-new-ontology", true,
                 "switch to a new ontology containing only the inferences");
+        o.addOption("m", "create-new-ontology-with-annotations", true,
+                "switch to a new ontology containing only the inferences and annotation properties");
         o.addOption("a", "annotate-inferred-axioms", true,
                 "annotate all inferred axioms (only when -n is passed)");
         o.addOption("x", "exclude-duplicate-axioms", true,

--- a/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
@@ -185,13 +185,10 @@ public class ReasonOperation {
             // todo: set ontology id
             if (OptionsHelper.optionIsTrue(options, "create-new-ontology-with-annotations")) {
                 logger.info("Placing inferred axioms with annotations into a new ontology");
-                ontology.getAxioms(AxiomType.ANNOTATION_ASSERTION);
-
                 manager.removeAxioms(ontology,
                    ontology.getAxioms()
                        .stream()
                        .filter(nonap -> !(nonap instanceof OWLAnnotationAssertionAxiom) )
-                       .map(nonap -> nonap)
                        .collect(Collectors.toSet()));
 
             } else {

--- a/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
@@ -4,22 +4,11 @@ import org.geneontology.reasoner.ExpressionMaterializingReasoner;
 import org.obolibrary.robot.exceptions.OntologyLogicException;
 import org.obolibrary.robot.reason.EquivalentClassReasoning;
 import org.obolibrary.robot.reason.EquivalentClassReasoningMode;
+import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.search.Filters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLAnnotationValue;
-import org.semanticweb.owlapi.model.OWLAxiom;
-import org.semanticweb.owlapi.model.OWLClass;
-import org.semanticweb.owlapi.model.OWLClassExpression;
-import org.semanticweb.owlapi.model.OWLDataFactory;
-import org.semanticweb.owlapi.model.OWLImportsDeclaration;
-import org.semanticweb.owlapi.model.OWLNamedObject;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.model.OWLOntologyManager;
-import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
-import org.semanticweb.owlapi.model.RemoveImport;
 import org.semanticweb.owlapi.model.parameters.Imports;
 import org.semanticweb.owlapi.reasoner.InferenceType;
 import org.semanticweb.owlapi.reasoner.Node;
@@ -28,6 +17,8 @@ import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 import org.semanticweb.owlapi.util.InferredAxiomGenerator;
 import org.semanticweb.owlapi.util.InferredOntologyGenerator;
 import org.semanticweb.owlapi.util.InferredSubClassAxiomGenerator;
+
+import javax.annotation.Nonnull;
 
 import static org.obolibrary.robot.reason.EquivalentClassReasoningMode.ALL;
 
@@ -38,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Reason over an ontology and add axioms.
@@ -63,6 +55,7 @@ public class ReasonOperation {
         Map<String, String> options = new HashMap<String, String>();
         options.put("remove-redundant-subclass-axioms", "true");
         options.put("create-new-ontology", "false");
+        options.put("create-new-ontology-with-annotations", "false");
         options.put("annotate-inferred-axioms", "false");
         options.put("exclude-duplicate-axioms", "false");
         options.put("equivalent-classes-allowed", ALL.written());
@@ -105,7 +98,7 @@ public class ReasonOperation {
         logger.info("Ontology has {} axioms.", ontology.getAxioms().size());
 
         logger.info("Fetching labels...");
-        
+
         Function<OWLNamedObject, String> labelFunc =
                 OntologyHelper.getLabelFunction(ontology, false);
 
@@ -186,12 +179,25 @@ public class ReasonOperation {
                 newAxiomOntology.getAxioms().size());
 
 
-        if (OptionsHelper.optionIsTrue(options, "create-new-ontology")) {
+        if (OptionsHelper.optionIsTrue(options, "create-new-ontology") || OptionsHelper.optionIsTrue(options, "create-new-ontology-with-annotations")) {
             // because the ontology is passed by reference,
             // we manipulate it in place
-            logger.info("Placing inferred axioms into a new ontology");
             // todo: set ontology id
-            manager.removeAxioms(ontology, ontology.getAxioms());
+            if (OptionsHelper.optionIsTrue(options, "create-new-ontology-with-annotations")) {
+                logger.info("Placing inferred axioms with annotations into a new ontology");
+                ontology.getAxioms(AxiomType.ANNOTATION_ASSERTION);
+
+                manager.removeAxioms(ontology,
+                   ontology.getAxioms()
+                       .stream()
+                       .filter(nonap -> !(nonap instanceof OWLAnnotationAssertionAxiom) )
+                       .map(nonap -> nonap)
+                       .collect(Collectors.toSet()));
+
+            } else {
+                logger.info("Placing inferred axioms into a new ontology");
+                manager.removeAxioms(ontology, ontology.getAxioms());
+            }
 
             Set<OWLImportsDeclaration> oids =
                     ontology.getImportsDeclarations();


### PR DESCRIPTION
I want to create an inferred view, removing redundant subclasses, but keeping all the annotation properties. What do you think about supporting something like this? Or is there already another way to achieve this that I missed? 