### PR TITLE
WIP: Detailed reporting

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -309,7 +309,7 @@ ROBOT can repair certain problems encountered in ontologies. So far this is limi
 ## Reporting
 
     robot report \
-      --input need-of-repair.owl \
+      --input edit.owl \
       --output report.yaml
 
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -306,6 +306,12 @@ ROBOT can repair certain problems encountered in ontologies. So far this is limi
       --input need-of-repair.owl \
       --output results/repaired.owl
 
+## Reporting
+
+    robot report \
+      --input need-of-repair.owl \
+      --output report.yaml
+
 
 ## Chaining
 

--- a/robot-command/pom.xml
+++ b/robot-command/pom.xml
@@ -12,7 +12,6 @@
     <description>Command-line interface for ROBOT, the OBO tool</description>
 
     <build>
-      <pluginManagement>
         <plugins>
             <!-- Build a bin/robot.jar file with all dependencies -->
 
@@ -96,7 +95,6 @@
                 </executions>
             </plugin>
         </plugins>
-      </pluginManagement>
     </build>
 
     <dependencies>

--- a/robot-core/src/main/java/org/obolibrary/robot/LabelShortFormProvider.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/LabelShortFormProvider.java
@@ -1,0 +1,71 @@
+package org.obolibrary.robot;
+
+import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLEntity;
+import org.semanticweb.owlapi.model.OWLLiteral;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.util.ShortFormProvider;
+
+import com.google.common.base.Optional;
+
+public class LabelShortFormProvider implements ShortFormProvider  {
+
+    OWLOntology ontology;
+    boolean hideIds = false;
+    boolean quoteLabels = true;
+    IOHelper iohelper;
+
+
+    public LabelShortFormProvider(OWLOntology ont) {
+      super();
+      this.ontology = ont;
+    }
+    
+   
+    public LabelShortFormProvider(OWLOntology ontology, IOHelper iohelper) {
+      super();
+      this.ontology = ontology;
+      this.iohelper = iohelper;
+    }
+
+
+    public String getShortForm(OWLEntity entity) {
+      String label = getLabel(entity);
+      if (label == null) {
+        return getTruncatedId(entity);
+      }
+      else {
+        if (hideIds) {
+          return label;
+        }
+        return getTruncatedId(entity) + " "+ label;
+      }
+    }
+
+    public String getLabel(OWLEntity entity) {
+
+      for (OWLAnnotationAssertionAxiom a : ontology.getAnnotationAssertionAxioms(entity.getIRI())) {
+        if (a.getProperty().isLabel()) {
+          Optional<OWLLiteral> v = a.getValue().asLiteral();
+         
+          if (v.isPresent()) {
+            
+            return v.get().getLiteral();
+          }
+        }
+      }
+      return null;
+    }
+
+    public String getTruncatedId(OWLEntity entity) {
+      // TODO : use iohelper to reduce to CURIE
+      return entity.getIRI().getFragment();
+    }
+
+
+    @Override
+    public void dispose() {
+      // TODO Auto-generated method stub
+      
+    }
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/OntologyHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/OntologyHelper.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+
+import org.semanticweb.owlapi.io.OWLObjectRenderer;
 import org.semanticweb.owlapi.model.AddOntologyAnnotation;
 import org.semanticweb.owlapi.model.AxiomType;
 import org.semanticweb.owlapi.model.IRI;
@@ -29,6 +31,7 @@ import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
 import org.semanticweb.owlapi.model.RemoveOntologyAnnotation;
 import org.semanticweb.owlapi.model.SetOntologyID;
 import org.semanticweb.owlapi.util.ReferencedEntitySetProvider;
+import org.semanticweb.owlapi.util.SimpleRenderer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -502,6 +505,21 @@ public class OntologyHelper {
       iris.add(entity.getIRI());
     }
     return iris;
+  }
+  
+  
+  
+  /**
+   * Creates a renderer for pretty-printing of axioms and entities
+   * 
+   * @param ontology
+   * @return renderer
+   */
+  public static OWLObjectRenderer getRenderer(OWLOntology ontology) {
+    OWLObjectRenderer renderer = new SimpleRenderer();
+    renderer.setShortFormProvider(new LabelShortFormProvider(ontology));
+    return renderer;
+    
   }
 
   /**

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -69,7 +69,7 @@ public class ReportOperation {
     Map<Integer, Set<CheckViolation>> violationsBySeverity = new HashMap<>();
 
     Set<InvalidReferenceViolation> refViolations =
-        InvalidReferenceChecker.getInvalidReferenceViolations(ontology, true);
+        InvalidReferenceChecker.getInvalidReferenceViolations(ontology, false);
     for (InvalidReferenceViolation v : refViolations) {
       logger.warn("REFERENCE VIOLATION: " + v);
     }

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -4,6 +4,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.obolibrary.robot.checks.CURIEChecker;
+import org.obolibrary.robot.checks.CURIEViolation;
 import org.obolibrary.robot.checks.CheckViolation;
 import org.obolibrary.robot.checks.ClassMetadataViolation;
 import org.obolibrary.robot.checks.InvalidReferenceChecker;
@@ -75,6 +78,15 @@ public class ReportOperation {
     }
     violations.addAll(refViolations);
     problemsReport.invalidReferenceViolations = refViolations;
+
+    Set<CURIEViolation> curieViolations =
+        CURIEChecker.getInvalidCURIEs(ontology, null);
+    for (CURIEViolation v : curieViolations) {
+      logger.warn("REFERENCE VIOLATION: " + v);
+    }
+    violations.addAll(curieViolations);
+    problemsReport.curieViolations = curieViolations;
+
 
     Set<ClassMetadataViolation> classMetadataViolations =
         MetadataChecker.getClassMetadataViolations(ontology);

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -71,6 +71,7 @@ public class ReportOperation {
     Set<CheckViolation> violations = new HashSet<>();
     Map<Integer, Set<CheckViolation>> violationsBySeverity = new HashMap<>();
 
+    logger.info("Checking owl object references...");
     Set<InvalidReferenceViolation> refViolations =
         InvalidReferenceChecker.getInvalidReferenceViolations(ontology, false);
     for (InvalidReferenceViolation v : refViolations) {
@@ -79,7 +80,8 @@ public class ReportOperation {
     violations.addAll(refViolations);
     problemsReport.invalidReferenceViolations = refViolations;
 
-    Set<CURIEViolation> curieViolations =
+    logger.info("Checking CURIEs...");
+        Set<CURIEViolation> curieViolations =
         CURIEChecker.getInvalidCURIEs(ontology, null);
     for (CURIEViolation v : curieViolations) {
       logger.warn("REFERENCE VIOLATION: " + v);
@@ -88,6 +90,7 @@ public class ReportOperation {
     problemsReport.curieViolations = curieViolations;
 
 
+    logger.info("Checking class metadata...");
     Set<ClassMetadataViolation> classMetadataViolations =
         MetadataChecker.getClassMetadataViolations(ontology);
     if (classMetadataViolations.size() > 0) {
@@ -98,7 +101,8 @@ public class ReportOperation {
     violations.addAll(classMetadataViolations);
     problemsReport.classMetadataViolations = classMetadataViolations;
 
-    Set<OntologyMetadataViolation> ontologyMetadataViolations =
+    logger.info("Checking ontology header metadata...");
+       Set<OntologyMetadataViolation> ontologyMetadataViolations =
         MetadataChecker.getOntologyMetadataViolations(ontology);
     if (ontologyMetadataViolations.size() > 0) {
       for (OntologyMetadataViolation v : ontologyMetadataViolations) {
@@ -108,6 +112,8 @@ public class ReportOperation {
     violations.addAll(ontologyMetadataViolations);
     problemsReport.ontologyMetadataViolations = ontologyMetadataViolations;
 
+    logger.info("Summarizing...");
+    
     if (violations.size() > 0) {
       for (int s = 1; s <= 5; s++) {
         violationsBySeverity.put(s, new HashSet<>());

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/AbstractCheckViolation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/AbstractCheckViolation.java
@@ -1,0 +1,25 @@
+package org.obolibrary.robot.checks;
+
+public abstract class AbstractCheckViolation implements CheckViolation {
+  private final String description;
+  private final int severity;
+
+  public AbstractCheckViolation(String desc, int severity) {
+    super();
+    this.description = desc;
+    this.severity = severity;
+  }
+  /** @return the type */
+  public String getType() {
+    return "TBD";
+  }
+
+  /** @return the description */
+  public String getDescription() {
+    return description;
+  }
+  /** @return the severity */
+  public int getSeverity() {
+    return severity;
+  }
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/AbstractCheckViolation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/AbstractCheckViolation.java
@@ -3,16 +3,28 @@ package org.obolibrary.robot.checks;
 public abstract class AbstractCheckViolation implements CheckViolation {
   private final String description;
   private final int severity;
+  private final String axiomLabel;
 
   public AbstractCheckViolation(String desc, int severity) {
     super();
     this.description = desc;
     this.severity = severity;
+    axiomLabel = null;
   }
-  /** @return the type */
-  public String getType() {
-    return "TBD";
+  
+  
+ 
+
+  public AbstractCheckViolation(String axiomLabel, String description, int severity) {
+    super();
+    this.description = description;
+    this.severity = severity;
+    this.axiomLabel = axiomLabel;
   }
+
+
+
+
 
   /** @return the description */
   public String getDescription() {
@@ -22,4 +34,15 @@ public abstract class AbstractCheckViolation implements CheckViolation {
   public int getSeverity() {
     return severity;
   }
+
+
+
+
+  /**
+   * @return the axiomLabel
+   */
+  public String getAxiomLabel() {
+  return axiomLabel;}
+  
+  
 }

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/AbstractChecker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/AbstractChecker.java
@@ -1,0 +1,30 @@
+package org.obolibrary.robot.checks;
+
+import org.obolibrary.robot.IOHelper;
+import org.obolibrary.robot.OntologyHelper;
+import org.semanticweb.owlapi.io.OWLObjectRenderer;
+import org.semanticweb.owlapi.model.OWLOntology;
+
+public abstract class AbstractChecker implements Checker {
+  
+  OWLOntology ontology;
+  IOHelper iohelper;
+  private OWLObjectRenderer renderer;
+  
+  
+  public AbstractChecker(OWLOntology ontology, IOHelper iohelper) {
+    super();
+    this.ontology = ontology;
+    this.iohelper = iohelper;
+    this.renderer = OntologyHelper.getRenderer(ontology);
+  }
+
+
+  /**
+   * @return the renderer
+   */
+  public OWLObjectRenderer getRenderer() {
+  return renderer;}
+  
+  
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/CURIEChecker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/CURIEChecker.java
@@ -1,0 +1,141 @@
+package org.obolibrary.robot.checks;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.obolibrary.robot.IOHelper;
+import org.obolibrary.robot.OntologyHelper;
+import org.semanticweb.owlapi.io.OWLObjectRenderer;
+import org.semanticweb.owlapi.model.AxiomType;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotation;
+import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+import org.semanticweb.owlapi.model.OWLAnnotationSubject;
+import org.semanticweb.owlapi.model.OWLAnnotationValue;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLLiteral;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.parameters.Imports;
+
+/**
+ * Check all CURIEs/IDs
+ * 
+ * Note that in theory CURIEs are syntactic-level entities that should be expanded
+ * to URIs in parsing by the OWLAPI. In practice many ontologies denote external
+ * entities using a CURIE in a string literal.
+ * 
+ * The prefix of a CURIE typically comes from a standard registry. For example
+ * 
+ * - https://github.com/geneontology/go-site/blob/master/metadata/db-xrefs.yaml
+ * - https://github.com/prefixcommons/biocontext
+ * 
+ * The checks here are intended for
+ * 
+ *  - checking syntax of CURIE - e.g. no unintential spaces
+ *  - checking prefix is within allowed subset and can be expanded
+ * 
+ * TODO: many of these operations can be repaired. Implement corresponding RepairOperation
+ * 
+ * @author cjm
+ *
+ */
+public class CURIEChecker extends AbstractChecker implements Checker {
+  
+  public CURIEChecker(OWLOntology ontology, IOHelper iohelper) {
+    super(ontology, iohelper);
+  }
+  
+  public static Set<CURIEViolation> getInvalidCURIEs(OWLOntology ontology, IOHelper iohelper) {
+    CURIEChecker checker = new CURIEChecker(ontology, iohelper);
+    return checker.getInvalidCURIEs();
+  }
+  public Set<CURIEViolation> getInvalidCURIEs() {
+
+    Set<CURIEViolation> violations = new HashSet<>();
+    for (OWLAnnotationAssertionAxiom axiom : ontology.getAxioms(AxiomType.ANNOTATION_ASSERTION)) {
+      OWLAnnotationSubject s = axiom.getSubject();
+      
+      OWLAnnotationProperty p = axiom.getProperty();
+      if (isCURIEValuedProperty(p)) {
+        OWLAnnotationValue v = axiom.getValue();
+        violations.addAll(checkCURIE(v, axiom));  
+      }
+    }
+    for (OWLAxiom axiom : ontology.getAxioms(Imports.EXCLUDED)) {
+      for (OWLAnnotation a : axiom.getAnnotations()) {
+        OWLAnnotationValue v = a.getValue();
+        violations.addAll(checkCURIE(v, axiom));          
+      }
+    }
+    return violations;
+    
+  }
+  
+  public static boolean isCURIEValuedProperty(OWLAnnotationProperty p) {
+    IRI pIRI = p.getIRI();
+    return (pIRI.toString().equals("http://www.geneontology.org/formats/oboInOwl#hasDbXref"));
+  }
+  
+  public Collection<CURIEViolation> checkCURIE(OWLAnnotationValue v, OWLAxiom axiom ) {
+    Set<CURIEViolation> violations = new HashSet<>();
+    if (v.asLiteral().isPresent()) {
+      OWLLiteral vlit = v.asLiteral().get();
+      String id = vlit.getLiteral();
+      violations.addAll(checkCURIE(id, axiom)); 
+    }
+    return violations;
+  }
+
+  public Collection<CURIEViolation> checkCURIE(String id, OWLAxiom axiom) {
+    Set<CURIEViolation> violations = new HashSet<>();
+    
+    String axiomLabel = getRenderer().render(axiom);
+    
+    // consider bringing in guava.
+    // See https://stackoverflow.com/questions/4067809/how-can-i-find-whitespace-space-in-a-string
+    Pattern pattern = Pattern.compile("\\s");
+    Matcher matcher = pattern.matcher(id);
+    boolean found = matcher.find();
+    if (found) {
+      violations.add(new CURIEViolation(axiomLabel, "id/curie contains whitespace: '"+id+"'", 4));
+    }
+    if (id.contains(":")) {
+      String[] idparts = id.split(":");
+      if (idparts.length == 2) {
+        String prefix = idparts[0];
+        String frag = idparts[1];
+        // TODO - check prefix against registry
+        if (prefix.equals("")) {
+          violations.add(new CURIEViolation(axiomLabel, "blank prefix in '"+id+"'", 4));                             
+        }
+        
+        // hardcoded checks for particular prefix types
+        // this could be made more generic and driven by metadata,
+        // for now encode common classes of error here
+        if (prefix.equals("PMID")) {
+          if (frag.replaceAll("[0-9]+", "").length() > 0) {
+            violations.add(new CURIEViolation(axiomLabel, "local id must be numeric '"+id+"'", 4));                                        
+          }
+        }
+      }
+      else {
+        violations.add(new CURIEViolation(axiomLabel, "id/curie should contain exactly one ':' separator - '"+id+"'", 3));                   
+      }
+    }
+    else {
+      violations.add(new CURIEViolation(axiomLabel, "id/curie does not contain ':' separator - '"+id+"'", 3));            
+    }
+    return violations;
+  }
+
+  @Override
+  public String getName() {
+    return "CURIE checker";
+  }
+  
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/CURIEChecker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/CURIEChecker.java
@@ -68,8 +68,11 @@ public class CURIEChecker extends AbstractChecker implements Checker {
     }
     for (OWLAxiom axiom : ontology.getAxioms(Imports.EXCLUDED)) {
       for (OWLAnnotation a : axiom.getAnnotations()) {
-        OWLAnnotationValue v = a.getValue();
-        violations.addAll(checkCURIE(v, axiom));          
+        OWLAnnotationProperty p = a.getProperty();
+        if (isCURIEValuedProperty(p)) {
+          OWLAnnotationValue v = a.getValue();
+          violations.addAll(checkCURIE(v, axiom));
+        }
       }
     }
     return violations;

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/CURIEViolation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/CURIEViolation.java
@@ -1,0 +1,24 @@
+package org.obolibrary.robot.checks;
+
+import org.semanticweb.owlapi.model.OWLClass;
+
+public class CURIEViolation extends AbstractCheckViolation implements CheckViolation {
+
+  public CURIEViolation(String axiomLabel, String name, int severity) {
+    super(axiomLabel, name, severity);
+  }
+
+  /* (non-Javadoc)
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    return "MetadataViolation [getSeverity()=" + getSeverity() + ", getDesc()=" + getDescription() + "]";
+  }
+  
+
+  /** @return the type */
+  public String getType() {
+    return "CURIE violation";
+  }
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/CheckAnnotationsHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/CheckAnnotationsHelper.java
@@ -91,7 +91,7 @@ public class CheckAnnotationsHelper {
     if (num < minCardinality) {
       return new InvalidCardinality(p, num, Op.LESS_THAN, minCardinality);
     }
-    if (num > maxCardinality) {
+    if (maxCardinality != null && num > maxCardinality) {
       return new InvalidCardinality(p, num, Op.MORE_THAN, maxCardinality);
     }
     return null;

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/CheckAnnotationsHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/CheckAnnotationsHelper.java
@@ -1,0 +1,99 @@
+package org.obolibrary.robot.checks;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.obolibrary.robot.IOHelper;
+import org.obolibrary.robot.checks.InvalidCardinality.Op;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotation;
+import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+import org.semanticweb.owlapi.model.OWLAnnotationValue;
+import org.semanticweb.owlapi.model.OWLOntology;
+
+/**
+ * Utils for checking annotations
+ *
+ * @author cjm
+ */
+public class CheckAnnotationsHelper {
+
+  /**
+   * @param anns
+   * @return Map keyed by property
+   */
+  public static Map<OWLAnnotationProperty, Set<OWLAnnotationValue>> collectAnnotations(
+      Set<OWLAnnotation> anns) {
+    Map<OWLAnnotationProperty, Set<OWLAnnotationValue>> m = new HashMap<>();
+    for (OWLAnnotation ann : anns) {
+      OWLAnnotationProperty p = ann.getProperty();
+      OWLAnnotationValue v = ann.getValue();
+      if (!m.containsKey(p)) m.put(p, new HashSet<>());
+      m.get(p).add(v);
+    }
+    return m;
+  }
+
+  public static Map<OWLAnnotationProperty, Set<OWLAnnotationValue>> collectAnnotationsFromAxioms(
+      Set<OWLAnnotationAssertionAxiom> aas) {
+    Map<OWLAnnotationProperty, Set<OWLAnnotationValue>> m = new HashMap<>();
+    for (OWLAnnotationAssertionAxiom ax : aas) {
+      OWLAnnotationProperty p = ax.getProperty();
+      OWLAnnotationValue v = ax.getValue();
+      if (!m.containsKey(p)) m.put(p, new HashSet<>());
+      m.get(p).add(v);
+    }
+    return m;
+  }
+
+  /**
+   * @param ontology
+   * @param pname
+   * @param minCardinality
+   * @param maxCardinality
+   * @param amap
+   * @return InvalidCardinality or null
+   */
+  public static InvalidCardinality checkCardinality(
+      IOHelper helper,
+      OWLOntology ontology,
+      String pname,
+      int minCardinality,
+      Integer maxCardinality,
+      Map<OWLAnnotationProperty, Set<OWLAnnotationValue>> amap) {
+
+    IRI iri = helper.createIRI(pname);
+    OWLAnnotationProperty p =
+        ontology.getOWLOntologyManager().getOWLDataFactory().getOWLAnnotationProperty(iri);
+    return checkCardinality(p, minCardinality, maxCardinality, amap);
+  }
+
+  /**
+   * @param p
+   * @param minCardinality
+   * @param maxCardinality
+   * @param amap
+   * @return InvalidCardinality or null
+   */
+  public static InvalidCardinality checkCardinality(
+      OWLAnnotationProperty p,
+      int minCardinality,
+      Integer maxCardinality,
+      Map<OWLAnnotationProperty, Set<OWLAnnotationValue>> amap) {
+    if (!amap.containsKey(p)) {
+      if (minCardinality > 0) {
+        return new InvalidCardinality(p, 0, Op.LESS_THAN, minCardinality);
+      } else return null;
+    }
+    int num = amap.get(p).size();
+    if (num < minCardinality) {
+      return new InvalidCardinality(p, num, Op.LESS_THAN, minCardinality);
+    }
+    if (num > maxCardinality) {
+      return new InvalidCardinality(p, num, Op.MORE_THAN, maxCardinality);
+    }
+    return null;
+  }
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/CheckViolation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/CheckViolation.java
@@ -1,0 +1,16 @@
+package org.obolibrary.robot.checks;
+
+/**
+ * Common methods for all objects representing an instance of a violation of an ontology check
+ *
+ * @author cjm
+ */
+public interface CheckViolation {
+
+  /** @return number between 0 and 5 */
+  public int getSeverity();
+  
+  public String getType();
+  
+  public String getDescription();
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/Checker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/Checker.java
@@ -5,6 +5,4 @@ public interface Checker {
   /** @return name of the checker */
   public String getName();
 
-  /** @return number of instances of the check being violated */
-  public int getNumberOfViolations();
 }

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/Checker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/Checker.java
@@ -1,0 +1,10 @@
+package org.obolibrary.robot.checks;
+
+public interface Checker {
+
+  /** @return name of the checker */
+  public String getName();
+
+  /** @return number of instances of the check being violated */
+  public int getNumberOfViolations();
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/ClassMetadataViolation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/ClassMetadataViolation.java
@@ -1,0 +1,49 @@
+package org.obolibrary.robot.checks;
+
+import org.semanticweb.owlapi.model.OWLClass;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
+/**
+ * A {@link MetadataViolation} where annotations at the level of a class are
+ * problematic
+ * 
+ * @author cjm
+ *
+ */public class ClassMetadataViolation extends MetadataViolation implements CheckViolation {
+
+  @JsonSerialize(using = ToStringSerializer.class)
+  OWLClass cls;
+
+  public ClassMetadataViolation(OWLClass cls, String name, int severity) {
+    super(name, severity);
+    this.cls = cls;
+  }
+  
+  @Override
+  public String getType() {
+    return "class metadata violation";
+  }
+  
+  /**
+   * @return OWLClass that has the problematic annotation / lack of annotations
+   */
+  public OWLClass getCls() {
+    return cls;
+  }
+
+  /* (non-Javadoc)
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    return "ClassMetadataViolation [cls="
+        + cls
+        + ", getSeverity()="
+        + getSeverity()
+        + ", getName()="
+        + getDescription()
+        + "]";
+  }
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/ClassMetadataViolation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/ClassMetadataViolation.java
@@ -1,5 +1,6 @@
 package org.obolibrary.robot.checks;
 
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLClass;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -11,14 +12,20 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
  * 
  * @author cjm
  *
- */public class ClassMetadataViolation extends MetadataViolation implements CheckViolation {
+ */
+public class ClassMetadataViolation extends MetadataViolation implements CheckViolation {
 
   @JsonSerialize(using = ToStringSerializer.class)
-  OWLClass cls;
+  final OWLClass cls;
+  final String label;
+  
+  String property;
 
-  public ClassMetadataViolation(OWLClass cls, String name, int severity) {
-    super(name, severity);
+  public ClassMetadataViolation(OWLClass cls, String label, String p, String desc, int severity) {
+    super(desc, severity);
     this.cls = cls;
+    this.label = label;
+    this.property = p;
   }
   
   @Override
@@ -32,6 +39,28 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
   public OWLClass getCls() {
     return cls;
   }
+  
+  
+
+  /**
+   * @return the property
+   */
+  public String getProperty() {
+    return property;
+  }
+
+  /**
+   * @param property the property to set
+   */
+  public void setProperty(String property) {
+    this.property = property;
+  }
+
+  /**
+   * @return the label
+   */
+  public String getLabel() {
+  return label;}
 
   /* (non-Javadoc)
    * @see java.lang.Object#toString()

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidCardinality.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidCardinality.java
@@ -1,0 +1,35 @@
+package org.obolibrary.robot.checks;
+
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+
+public class InvalidCardinality {
+  public enum Op {
+    LESS_THAN,
+    MORE_THAN
+  };
+
+  private final OWLAnnotationProperty property;
+  private final int num;
+  private final Op op;
+  private final int expected;
+
+  public InvalidCardinality(OWLAnnotationProperty property, int num, Op op, int expected) {
+    super();
+    this.property = property;
+    this.num = num;
+    this.op = op;
+    this.expected = expected;
+  }
+
+  /* (non-Javadoc)
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    return 
+        "|"+property+"|=" + num +" " + op +" " + expected;
+       
+  }
+  
+  
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidReferenceChecker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidReferenceChecker.java
@@ -135,7 +135,7 @@ public class InvalidReferenceChecker extends AbstractChecker implements Checker 
         }
       }
       // 2. NON-LOGICAL AXIOM CHECK
-      if (axiom.isAnnotationAxiom()) {
+      if (axiom instanceof OWLAnnotationAssertionAxiom) {
         // check object/value:
         // annotation axioms should not point to deprecated axioms
         OWLAnnotationAssertionAxiom aa = (OWLAnnotationAssertionAxiom)axiom;
@@ -183,7 +183,7 @@ public class InvalidReferenceChecker extends AbstractChecker implements Checker 
   public static Set<InvalidReferenceViolation> getInvalidReferenceViolations(
       OWLOntology ontology, boolean ignoreDangling) {
     return getInvalidReferenceViolations(
-        ontology, ontology.getAxioms(Imports.INCLUDED), ignoreDangling);
+        ontology, ontology.getAxioms(Imports.EXCLUDED), ignoreDangling);
   }
 
   /**
@@ -197,7 +197,7 @@ public class InvalidReferenceChecker extends AbstractChecker implements Checker 
   public static Set<InvalidReferenceViolation> checkImportModule(
       OWLOntology importModule, OWLOntology baseOntology) {
     return getInvalidReferenceViolations(
-        importModule, baseOntology.getAxioms(Imports.INCLUDED), true);
+        importModule, baseOntology.getAxioms(Imports.EXCLUDED), true);
   }
   
   @Override

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidReferenceChecker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidReferenceChecker.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.*;
 
 import java.util.HashSet;
 import java.util.Set;
+
+import org.obolibrary.robot.IOHelper;
 import org.obolibrary.robot.checks.InvalidReferenceViolation.Category;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
@@ -28,7 +30,12 @@ import org.semanticweb.owlapi.model.parameters.Imports;
  *
  * @author cjm
  */
-public class InvalidReferenceChecker {
+public class InvalidReferenceChecker extends AbstractChecker implements Checker {
+
+  public InvalidReferenceChecker(OWLOntology ontology, IOHelper iohelper) {
+    super(ontology,iohelper);
+    // TODO Auto-generated constructor stub
+  }
 
   /**
    * Checks if entity is dangling.
@@ -191,5 +198,10 @@ public class InvalidReferenceChecker {
       OWLOntology importModule, OWLOntology baseOntology) {
     return getInvalidReferenceViolations(
         importModule, baseOntology.getAxioms(Imports.INCLUDED), true);
+  }
+  
+  @Override
+  public String getName() {
+    return "CURIE checker";
   }
 }

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidReferenceViolation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidReferenceViolation.java
@@ -86,7 +86,22 @@ public class InvalidReferenceViolation implements CheckViolation {
      * 
      * (in the OBO universe, "obsolete" classes all have deprecation axioms)
      */
-    DEPRECATED
+    DEPRECATED,
+    
+    /**
+     * This category is specific to ontologies such as GO, HP, UBERON, CL
+     * that follow metadata design patterns originating in OBO Format.
+     * 
+     * Here, a special category of deprecated class is a merged class. In obo
+     * format this is represented as an alt_id tag on the replacement class, with
+     * the merged/deprecated class not appearing as a stanza in its own right. This
+     * means we should avoid placing any information about the merged class or
+     * it will be lost in the obo roundtrip.
+     * 
+     * See https://github.com/owlcs/owlapi/issues/317
+     * 
+     */
+    ALT_ID
   }
 
   /* (non-Javadoc)

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidReferenceViolation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidReferenceViolation.java
@@ -3,17 +3,31 @@ package org.obolibrary.robot.checks;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLEntity;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
 /**
  * Represents a reference violation
+ * 
+ * An axiom is in violation if it references an OWL entity that is either
+ * 
+ *  - deprecated
+ *  - non-existent (dangling) within the current import closure
+ *  
+ * It is important for the ontology maintainer to be aware of these as they
+ * can cause incomplete results
  *
  * <p>TODO: we may want to make warnings if a class is slated for deprecation in the future: see
  * https://github.com/information-artifact-ontology/ontology-metadata/issues/22
  *
  * @author cjm
  */
-public class InvalidReferenceViolation {
+public class InvalidReferenceViolation implements CheckViolation {
 
+  @JsonSerialize(using = ToStringSerializer.class)
   private final OWLAxiom axiom;
+  
+  @JsonSerialize(using = ToStringSerializer.class)
   private final OWLEntity referencedObject;
   private final Category category;
 
@@ -58,7 +72,20 @@ public class InvalidReferenceViolation {
    * @author cjm
    */
   public enum Category {
+    /**
+     * A dangling reference violation - the axiom points to a class/entity
+     * for which there are no axioms ABOUT this class/entity in the imports closure
+     * 
+     * Here ABOUTS means either a logical axiom with the entity as subject or
+     * an annotation axiom with the entity IRI as subject
+     */
     DANGLING,
+    
+    /**
+     * Axiom points to a class/entity that has an owl:deprecation axiom
+     * 
+     * (in the OBO universe, "obsolete" classes all have deprecation axioms)
+     */
     DEPRECATED
   }
 
@@ -75,5 +102,24 @@ public class InvalidReferenceViolation {
         + ", category="
         + category
         + "]";
+  }
+
+  @Override
+  public int getSeverity() {
+    if (getCategory().equals(Category.DEPRECATED)) {
+      return 2;
+    } else {
+      return 1;
+    }
+  }
+
+  @Override
+  public String getType() {
+    return "reference violation";
+  }
+
+  @Override
+  public String getDescription() {
+    return getAxiom().toString();
   }
 }

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/MetadataChecker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/MetadataChecker.java
@@ -1,0 +1,205 @@
+package org.obolibrary.robot.checks;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.obolibrary.robot.IOHelper;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotation;
+import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+import org.semanticweb.owlapi.model.OWLAnnotationValue;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLLiteral;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.parameters.Imports;
+
+/**
+ * Checks metadata for ontology headers and all classes.
+ * 
+ * This is typically called from within a ReportOperation
+ *
+ * <p>See: https://github.com/ontodev/robot/issues/205
+ *
+ * @author cjm
+ */
+public class MetadataChecker {
+
+  /**
+   * Profile/Style for an ontology
+   *
+   * <p>This defines specific conformance checks
+   */
+  public enum Profile {
+    /** Generic lax style for a non-foundry ontology */
+    LAX,
+    
+    /** Profile used by the GO and GO-lineage ontologies */
+    GO_STRICT,
+
+    /** Profile used by OBI and OBI-lineage ontologies */
+    OBI_STRICT
+  }
+
+  private OWLOntology ontology;
+  private IOHelper helper;
+  private Set<OntologyMetadataViolation> ontologyMetadataViolations = new HashSet<>();
+  private Set<ClassMetadataViolation> classMetadataViolations = new HashSet<>();
+  private Profile profile = Profile.LAX;
+
+  /** @param ontology */
+  public MetadataChecker(OWLOntology ontology) {
+    super();
+    this.ontology = ontology;
+    helper = getIOHelper();
+  }
+
+  /**
+   * Convenience static method for checking ontology header
+   *
+   * @param ontology
+   * @return violations in ontology header
+   */
+  public static Set<OntologyMetadataViolation> getOntologyMetadataViolations(OWLOntology ontology) {
+    MetadataChecker checker = new MetadataChecker(ontology);
+    checker.runOntologyMetadataChecks();
+    return checker.ontologyMetadataViolations;
+  }
+
+  /**
+   * Convenience static method for checking metadata on classes
+   *
+   * @param ontology
+   * @return violations in class metadata for all classes in ontology
+   */
+  public static Set<ClassMetadataViolation> getClassMetadataViolations(OWLOntology ontology) {
+    MetadataChecker checker = new MetadataChecker(ontology);
+    checker.runClassMetadataChecks();
+    return checker.classMetadataViolations;
+  }
+
+  /** run all ontology header checks */
+  public void runOntologyMetadataChecks() {
+    Set<OWLAnnotation> anns = ontology.getAnnotations();
+    Map<OWLAnnotationProperty, Set<OWLAnnotationValue>> amap =
+        CheckAnnotationsHelper.collectAnnotations(anns);
+
+    checkHeaderCardinality("dc:description", 1, 1, amap);
+    checkHeaderCardinality("dc:title", 1, 1, amap);
+    checkHeaderCardinality("dc:license", 1, 1, amap, 5);
+    checkHeaderCardinality("dc:creator", 1, null, amap);
+  }
+
+  /** run all class metadata checks */
+  public void runClassMetadataChecks() {
+
+    for (OWLClass c : ontology.getClassesInSignature(Imports.EXCLUDED)) {
+      // check header
+      Set<OWLAnnotationAssertionAxiom> aas = ontology.getAnnotationAssertionAxioms(c.getIRI());
+      Map<OWLAnnotationProperty, Set<OWLAnnotationValue>> amap =
+          CheckAnnotationsHelper.collectAnnotationsFromAxioms(aas);
+
+      checkClassCardinality("rdfs:label", 1, 1, amap, c);
+      checkClassCardinality("definition:", 1, 1, amap, c);
+
+      // check definition has provenance
+      OWLAnnotationProperty defp = getProperty("definition:");
+      Set<OWLAnnotation> defAnns = new HashSet<>();
+
+      // GO-style: axiom annotation
+      for (OWLAnnotationAssertionAxiom aax : ontology.getAnnotationAssertionAxioms(c.getIRI())) {
+        if (aax.getProperty().equals(defp)) {
+          defAnns.addAll(aax.getAnnotations());
+        }
+      }
+      if (defAnns.size() == 0) {
+        // OBI-style
+        checkClassCardinality("obo:IAO_0000117", 1, null, amap, c);
+      }
+
+      String defn = getStringPropertyValue("definition:", amap);
+      if (defn != null) {
+        // TODO - style checks on text definition
+      }
+
+      // Checks for 'GO lineage' ontologies
+
+      int minNS = 0;
+      if (profile.equals(Profile.GO_STRICT)) {
+        minNS = 1;
+      }
+      checkClassCardinality("oboInOwl:hasOBONamespace:", minNS, 1, amap, c);
+      checkClassCardinality("oboInOwl:created_by", 0, 1, amap, c);
+      checkClassCardinality("oboInOwl:creation_date", 0, 1, amap, c);
+    }
+  }
+
+  /**
+   * @param pname
+   * @return property with the same CURIE
+   */
+  private OWLAnnotationProperty getProperty(String pname) {
+    IRI iri = helper.createIRI(pname);
+    return ontology.getOWLOntologyManager().getOWLDataFactory().getOWLAnnotationProperty(iri);
+  }
+
+  private String getStringPropertyValue(
+      String pname, Map<OWLAnnotationProperty, Set<OWLAnnotationValue>> amap) {
+    OWLAnnotationProperty p = getProperty(pname);
+    if (amap.containsKey(p)) {
+      if (amap.get(p).size() == 1) {
+        OWLAnnotationValue v = amap.get(p).iterator().next();
+        if (v instanceof OWLLiteral) {
+          return v.asLiteral().toString();
+        }
+      }
+    }
+    return null;
+  }
+
+  private void checkHeaderCardinality(
+      String p,
+      int minCardinality,
+      Integer maxCardinality,
+      Map<OWLAnnotationProperty, Set<OWLAnnotationValue>> amap) {
+    checkHeaderCardinality(p, minCardinality, maxCardinality, amap, 1);
+  }
+
+  private void checkHeaderCardinality(
+      String p,
+      int minCardinality,
+      Integer maxCardinality,
+      Map<OWLAnnotationProperty, Set<OWLAnnotationValue>> amap,
+      Integer severity) {
+    InvalidCardinality inv =
+        CheckAnnotationsHelper.checkCardinality(
+            helper, ontology, p, minCardinality, maxCardinality, amap);
+    if (inv != null) {
+      ontologyMetadataViolations.add(
+          new OntologyMetadataViolation(ontology, "cardinality of " + p, severity));
+    }
+  }
+
+  private void checkClassCardinality(
+      String p,
+      int minCardinality,
+      Integer maxCardinality,
+      Map<OWLAnnotationProperty, Set<OWLAnnotationValue>> amap,
+      OWLClass c) {
+    InvalidCardinality inv =
+        CheckAnnotationsHelper.checkCardinality(
+            helper, ontology, p, minCardinality, maxCardinality, amap);
+    if (inv != null) {
+      classMetadataViolations.add(new ClassMetadataViolation(c, inv.toString(), 1));
+    }
+  }
+
+  private static IOHelper getIOHelper() {
+    IOHelper helper = new IOHelper();
+    helper.addPrefix("dc", "http://purl.org/dc/elements/1.1/");
+    helper.addPrefix("definition", "http://purl.obolibrary.org/obo/IAO_0000115");
+    helper.addPrefix("obo", "http://purl.obolibrary.org/obo/");
+    helper.addPrefix("oboInOwl", "http://www.geneontology.org/formats/oboInOwl#");
+    return helper;
+  }
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/MetadataViolation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/MetadataViolation.java
@@ -1,6 +1,6 @@
 package org.obolibrary.robot.checks;
 
-public class MetadataViolation extends AbstractCheckViolation implements CheckViolation {
+public abstract class MetadataViolation extends AbstractCheckViolation implements CheckViolation {
 
   public MetadataViolation(String desc, int severity) {
     super(desc, severity);

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/MetadataViolation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/MetadataViolation.java
@@ -1,0 +1,16 @@
+package org.obolibrary.robot.checks;
+
+public class MetadataViolation extends AbstractCheckViolation implements CheckViolation {
+
+  public MetadataViolation(String desc, int severity) {
+    super(desc, severity);
+  }
+
+  /* (non-Javadoc)
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    return "MetadataViolation [getSeverity()=" + getSeverity() + ", getDesc()=" + getDescription() + "]";
+  }
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/OntologyMetadataViolation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/OntologyMetadataViolation.java
@@ -18,8 +18,8 @@ public class OntologyMetadataViolation extends MetadataViolation implements Chec
   @JsonIgnore
   private final OWLOntology ontology;
 
-  public OntologyMetadataViolation(OWLOntology ontology, String name, int severity) {
-    super(name, severity);
+  public OntologyMetadataViolation(OWLOntology ontology, String desc, int severity) {
+    super(desc, severity);
     this.ontology = ontology;
   }
 

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/OntologyMetadataViolation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/OntologyMetadataViolation.java
@@ -1,0 +1,39 @@
+package org.obolibrary.robot.checks;
+
+import org.semanticweb.owlapi.model.OWLOntology;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
+/**
+ * A {@link MetadataViolation} where annotations at the level of the ontology are
+ * problematic
+ * 
+ * @author cjm
+ *
+ */
+public class OntologyMetadataViolation extends MetadataViolation implements CheckViolation {
+
+  @JsonIgnore
+  private final OWLOntology ontology;
+
+  public OntologyMetadataViolation(OWLOntology ontology, String name, int severity) {
+    super(name, severity);
+    this.ontology = ontology;
+  }
+
+  /**
+   * @return the ontology that has the problem
+   */
+  public OWLOntology getOntology() {
+    return ontology;
+  }
+  
+  @Override
+  public String getType() {
+    return "ontology metadata violation";
+  }
+  
+  
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/report/ProblemsReport.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/report/ProblemsReport.java
@@ -1,0 +1,33 @@
+package org.obolibrary.robot.report;
+
+import java.util.Set;
+import org.obolibrary.robot.checks.ClassMetadataViolation;
+import org.obolibrary.robot.checks.InvalidReferenceViolation;
+import org.obolibrary.robot.checks.OntologyMetadataViolation;
+
+/**
+ * Set of all problems of varying severity
+ * 
+ * This list will be extended over time
+ * 
+ * 
+ * @author cjm
+ *
+ */
+public class ProblemsReport {
+
+  /**
+   * references from axioms to deprecated or non-existent classes
+   */
+  public Set<InvalidReferenceViolation> invalidReferenceViolations;
+  
+  /**
+   * problems with ontology header
+   */
+  public Set<OntologyMetadataViolation> ontologyMetadataViolations;
+  
+  /**
+   * problems with metadata on classes
+   */
+  public Set<ClassMetadataViolation> classMetadataViolations;
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/report/ProblemsReport.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/report/ProblemsReport.java
@@ -1,6 +1,8 @@
 package org.obolibrary.robot.report;
 
 import java.util.Set;
+
+import org.obolibrary.robot.checks.CURIEViolation;
 import org.obolibrary.robot.checks.ClassMetadataViolation;
 import org.obolibrary.robot.checks.InvalidReferenceViolation;
 import org.obolibrary.robot.checks.OntologyMetadataViolation;
@@ -30,4 +32,9 @@ public class ProblemsReport {
    * problems with metadata on classes
    */
   public Set<ClassMetadataViolation> classMetadataViolations;
+
+  /**
+   * problems with CURIEs (ids)
+   */
+  public Set<CURIEViolation> curieViolations;
 }

--- a/robot-core/src/main/java/org/obolibrary/robot/report/ReportCard.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/report/ReportCard.java
@@ -1,0 +1,26 @@
+package org.obolibrary.robot.report;
+
+import org.obolibrary.robot.ReportOperation;
+
+/**
+ * The output of a {@link ReportOperation} is a ReportCard. This provides
+ * 
+ *  - a list of all problems/violations (graded by severity)
+ *  - statistics on use of various properties in the ontology (TODO)
+ * 
+ * 
+ * Developer Note: this is designed to be serializable via Jackson; we
+ * use mostly POJOs and use jackson annotations to serialize OWL objects
+ * using toString
+ *
+ * @author cjm
+ */
+public class ReportCard {
+
+  /**
+   * All issues (of varying severity) with the ontology
+   */
+  public ProblemsReport problemsReport;
+  
+  // TODO: aggregate statistics
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/report/package-info.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/report/package-info.java
@@ -1,0 +1,3 @@
+/** */
+/** @author cjm */
+package org.obolibrary.robot.report;

--- a/robot-core/src/test/java/org/obolibrary/robot/RepairOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/RepairOperationTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
-/** Tests for MergeOperation. */
+/** Tests RepairOperation. */
 public class RepairOperationTest extends CoreTest {
 
   /**

--- a/robot-core/src/test/java/org/obolibrary/robot/ReportOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ReportOperationTest.java
@@ -1,5 +1,7 @@
 package org.obolibrary.robot;
 
+import static org.junit.Assert.*;
+
 import java.io.IOException;
 
 import org.junit.Test;
@@ -27,11 +29,32 @@ public class ReportOperationTest extends CoreTest {
     OWLOntology ontology = loadOntology("/need-of-repair.owl");
     IOHelper iohelper = new IOHelper();
     ReportCard reportCard = ReportOperation.report(ontology, iohelper);
+    assertEquals(1, reportCard.problemsReport.invalidReferenceViolations.size());
+    assertEquals(4, reportCard.problemsReport.classMetadataViolations.size());
     writeReport( new ObjectMapper(new JsonFactory()),
         reportCard);
     writeReport( new ObjectMapper(new YAMLFactory()),
         reportCard);
   }
+  
+  /**
+   * See https://github.com/owlcs/owlapi/issues/317#issuecomment-359025467
+   * 
+   * https://github.com/Phenomics/hpo-obo-qc/issues/1
+   * 
+   * @throws IOException
+   * @throws OWLOntologyCreationException
+   */
+  @Test
+  public void testOboAltIds() throws IOException, OWLOntologyCreationException {
+    OWLOntology ontology = loadOntology("/obo_altid_test.obo");
+    IOHelper iohelper = new IOHelper();
+    ReportCard reportCard = ReportOperation.report(ontology, iohelper);
+    assertEquals(1, reportCard.problemsReport.invalidReferenceViolations.size());
+    writeReport( new ObjectMapper(new YAMLFactory()),
+        reportCard);
+  }
+
   
   public void writeReport(ObjectMapper mapper, ReportCard reportCard) throws JsonProcessingException {
     ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();

--- a/robot-core/src/test/java/org/obolibrary/robot/ReportOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ReportOperationTest.java
@@ -55,6 +55,21 @@ public class ReportOperationTest extends CoreTest {
         reportCard);
   }
 
+  /**
+   * 
+   * 
+   * @throws IOException
+   * @throws OWLOntologyCreationException
+   */
+  @Test
+  public void testCURIEchecks() throws IOException, OWLOntologyCreationException {
+    OWLOntology ontology = loadOntology("/bad_dbxref_test.obo");
+    IOHelper iohelper = new IOHelper();
+    ReportCard reportCard = ReportOperation.report(ontology, iohelper);
+    writeReport( new ObjectMapper(new YAMLFactory()),
+        reportCard);
+    assertEquals(3, reportCard.problemsReport.curieViolations.size());
+  }
   
   public void writeReport(ObjectMapper mapper, ReportCard reportCard) throws JsonProcessingException {
     ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();

--- a/robot-core/src/test/java/org/obolibrary/robot/ReportOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ReportOperationTest.java
@@ -30,7 +30,9 @@ public class ReportOperationTest extends CoreTest {
     IOHelper iohelper = new IOHelper();
     ReportCard reportCard = ReportOperation.report(ontology, iohelper);
     assertEquals(1, reportCard.problemsReport.invalidReferenceViolations.size());
-    assertEquals(4, reportCard.problemsReport.classMetadataViolations.size());
+    
+    // TODO: test-non-lax mode
+    assertEquals(0, reportCard.problemsReport.classMetadataViolations.size());
     writeReport( new ObjectMapper(new JsonFactory()),
         reportCard);
     writeReport( new ObjectMapper(new YAMLFactory()),

--- a/robot-core/src/test/java/org/obolibrary/robot/ReportOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ReportOperationTest.java
@@ -1,0 +1,41 @@
+package org.obolibrary.robot;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.obolibrary.robot.report.ReportCard;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/** Tests for ReportOperation. */
+public class ReportOperationTest extends CoreTest {
+
+  /**
+   * Test reporting on an ontology
+   *
+   * @throws IOException on file problem
+   * @throws OWLOntologyCreationException on ontology problem
+   */
+  @Test
+  public void testReport() throws IOException, OWLOntologyCreationException {
+    OWLOntology ontology = loadOntology("/need-of-repair.owl");
+    IOHelper iohelper = new IOHelper();
+    ReportCard reportCard = ReportOperation.report(ontology, iohelper);
+    writeReport( new ObjectMapper(new JsonFactory()),
+        reportCard);
+    writeReport( new ObjectMapper(new YAMLFactory()),
+        reportCard);
+  }
+  
+  public void writeReport(ObjectMapper mapper, ReportCard reportCard) throws JsonProcessingException {
+    ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();
+    System.out.println(writer.writeValueAsString(reportCard));
+  }
+  
+}

--- a/robot-core/src/test/resources/bad_dbxref_test.obo
+++ b/robot-core/src/test/resources/bad_dbxref_test.obo
@@ -1,0 +1,9 @@
+ontology: bad
+
+[Term]
+id: A
+name: a
+def: "foo" [FOO: 1]
+xref: FOO: 2
+xref: FOO:3
+xref: BAR

--- a/robot-core/src/test/resources/obo_altid_test.obo
+++ b/robot-core/src/test/resources/obo_altid_test.obo
@@ -1,0 +1,12 @@
+ontology: bad
+
+[Term]
+id: A
+name: a
+alt_id: B
+
+[Term]
+id: B
+name: b
+is_obsolete: true
+


### PR DESCRIPTION
Adds a ReportCard object

Adds additional metadata checks (currently only cardinality)

This adds a `-o` option to `report` for writing a YAML report file.

See #205