### PR TITLE
Add --check option to convert

### DIFF
--- a/docs/convert.md
+++ b/docs/convert.md
@@ -13,9 +13,9 @@ The file format is determined by the extension of the output file (e.g. `.obo`),
   - owx - [OWL/XML](https://www.w3.org/TR/owl2-xml-serialization/)
   - ttl - [Turtle](https://www.w3.org/TR/turtle/)
 
-By default, the OBO writer strictly enforces <a href="http://owlcollab.github.io/oboformat/doc/obo-syntax.html#4" target="_blank">document structure rules</a>. If an ontology violates these, the convert to OBO operation will fail. These checks can be ignored by including `--check false`.
+By default, the OBO writer strictly enforces [document structure rules](http://owlcollab.github.io/oboformat/doc/obo-syntax.html#4). If an ontology violates these, the convert to OBO operation will fail. These checks can be ignored by including `--check false`.
 
-As a document is converted to OBO, you may see `ERROR MASKING ERROR` exceptions. This does not indicate failure, but it should be noted that these axioms will not be translated to OBO format. Rather, they will be included in the ontology header under `owl-axioms`. See <a href="http://owlcollab.github.io/oboformat/doc/obo-syntax.html#5.0.4" target="_blank">Untranslatable OWL axioms</a> for more details.
+As a document is converted to OBO, you may see `ERROR MASKING ERROR` exceptions. This does not indicate failure, but it should be noted that these axioms will not be translated to OBO format. Rather, they will be included in the ontology header under `owl-axioms`. See [Untranslatable OWL axioms](http://owlcollab.github.io/oboformat/doc/obo-syntax.html#5.0.4) for more details.
 
 You can choose to keep these in the file, or remove them with:
 ```
@@ -32,7 +32,7 @@ grep -v ^owl-axioms
 
 ### OBO Structure Error
 
-If `--check` is true (which, by default, it is), the <a href="http://owlcollab.github.io/oboformat/doc/obo-syntax.html#4" target="_blank">document structure rules</a> are strictly enforced. You may choose to review the exception message by running the command again with `--very-very-verbose`, or run `convert` with the `--check false` option to ignore the errors.
+If `--check` is true (which, by default, it is), the [document structure rules](http://owlcollab.github.io/oboformat/doc/obo-syntax.html#4) are strictly enforced. You may choose to review the exception message by running the command again with `--very-very-verbose`, or run `convert` with the `--check false` option to ignore the errors.
 
 Please note that `--check false` may result in some unintended output. For example, for terms with more than one definition annotation, a defintion will be chosen at random.
 

--- a/docs/convert.md
+++ b/docs/convert.md
@@ -12,3 +12,5 @@ The file format is determined by the extension of the output file (e.g. `.obo`),
   - owl - [RDF/XML](https://www.w3.org/TR/rdf-syntax-grammar/)
   - owx - [OWL/XML](https://www.w3.org/TR/owl2-xml-serialization/)
   - ttl - [Turtle](https://www.w3.org/TR/turtle/)
+
+By default, the OBO writer strictly enforces <a href="http://owlcollab.github.io/oboformat/doc/obo-syntax.html#4" target="_blank">document structure rules</a>. If an ontology violates these, the convert to OBO operation will fail. These checks can be ignored by including `--check false`.

--- a/robot-command/src/main/java/org/obolibrary/robot/ConvertCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ConvertCommand.java
@@ -27,6 +27,7 @@ public class ConvertCommand implements Command {
     o.addOption("I", "input-iri", true, "convert ontology from an IRI");
     o.addOption("o", "output", true, "save ontology to a file");
     o.addOption("f", "format", true, "the format: obo, owl, ttl, owx, omn, ofn, json");
+    o.addOption("c", "check", true, "if false, ignore OBO document structure checks");
     options = o;
   }
 
@@ -127,8 +128,17 @@ public class ConvertCommand implements Command {
       formatName = FilenameUtils.getExtension(outputFile.getName());
     }
 
-    ioHelper.saveOntology(ontology, ioHelper.getFormat(formatName), outputFile);
+    boolean checkOBO = true;
+    String check = CommandLineHelper.getDefaultValue(line, "check", "true");
+    if ("false".equals(check.toLowerCase())) {
+      checkOBO = false;
+      // TODO: Align with detailed error reporting
+    } else if (!"true".equals(check.toLowerCase())) {
+      throw new IllegalArgumentException("the arg to --check should be either TRUE or FALSE");
+    }
 
+    // TODO: Error handling for FrameStructureException
+    ioHelper.saveOntology(ontology, IOHelper.getFormat(formatName), outputFile, checkOBO);
     return state;
   }
 }


### PR DESCRIPTION
`--check false` allows the user to ignore the OBO document structure rules, see #64 

By default, `--check` is true.

Updated documentation included.