### PR TITLE
Robot command timing

### DIFF
--- a/robot-command/src/main/java/org/obolibrary/robot/CommandManager.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandManager.java
@@ -159,6 +159,9 @@ public class CommandManager implements Command {
 
     while (arguments.size() > 0) {
       state = executeCommand(state, globalOptionArgs, arguments);
+      if (state.hadAnError()) {
+        System.exit(1);
+      }
     }
 
     return state;
@@ -216,7 +219,14 @@ public class CommandManager implements Command {
     optionArgs.addAll(globalOptionArgs);
     optionArgs.addAll(localOptionArgs);
 
-    return command.execute(state, asArgs(optionArgs));
+    long start = System.currentTimeMillis();
+
+    CommandState s = command.execute(state, asArgs(optionArgs));
+
+    double duration = (System.currentTimeMillis() - start) / 1000.0;
+    System.out.println(commandName + " took " + duration + " seconds");
+
+    return s;
   }
 
   /** Print general help plus a list of available commands. */

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandManager.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandManager.java
@@ -240,16 +240,16 @@ public class CommandManager implements Command {
       }
     }
 
+    long start = System.currentTimeMillis();
     try {
-      long start = System.currentTimeMillis();
-
       state = command.execute(state, asArgs(optionArgs));
 
-      double duration = (System.currentTimeMillis() - start) / 1000.0;
-      System.out.println(commandName + " took " + duration + " seconds");
     } catch (Exception e) {
       // Ensure command-specific usage info is returned
       CommandLineHelper.handleException(command.getUsage(), command.getOptions(), e);
+    } finally {
+      double duration = (System.currentTimeMillis() - start) / 1000.0;
+      System.out.println(commandName + " took " + duration + " seconds");
     }
 
     return state;

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandState.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandState.java
@@ -12,6 +12,21 @@ public class CommandState {
   private OWLOntology ontology = null;
 
   /**
+   * Represents an error in the previous chained command. If there was an error, this should be
+   * true.
+   */
+  private boolean hadAnError;
+
+  public CommandState(OWLOntology ontology, boolean hadAnError) {
+    this.ontology = ontology;
+    this.hadAnError = hadAnError;
+  }
+
+  public CommandState() {
+    this(null, false);
+  }
+
+  /**
    * Get the ontology (not a copy).
    *
    * @return the ontology
@@ -27,5 +42,18 @@ public class CommandState {
    */
   public void setOntology(OWLOntology ontology) {
     this.ontology = ontology;
+  }
+
+  public boolean hadAnError() {
+    return hadAnError;
+  }
+
+  /**
+   * Sets the flag that indicates the previous command had an error while running.
+   *
+   * @param hadAnError true if there was an error
+   */
+  public void setHadError(boolean hadAnError) {
+    this.hadAnError = hadAnError;
   }
 }

--- a/robot-command/src/main/java/org/obolibrary/robot/ReasonCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ReasonCommand.java
@@ -3,13 +3,10 @@ package org.obolibrary.robot;
 import java.util.Map;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
-import org.geneontology.reasoner.ExpressionMaterializingReasonerFactory;
-import org.semanticweb.elk.owlapi.ElkReasonerFactory;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.ac.manchester.cs.jfact.JFactFactory;
 
 /**
  * Handles inputs and outputs for the {@link ReasonOperation}.
@@ -141,8 +138,7 @@ public class ReasonCommand implements Command {
     }
 
     // Return true if successful, false if it was not succesful
-    boolean success = ReasonOperation.reason(ontology, reasonerFactory, reasonerOptions);
-    state.setHadError(!success);
+    ReasonOperation.reason(ontology, reasonerFactory, reasonerOptions);
 
     CommandLineHelper.maybeSaveOutput(line, ontology);
 

--- a/robot-command/src/main/java/org/obolibrary/robot/ReasonCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ReasonCommand.java
@@ -161,7 +161,9 @@ public class ReasonCommand implements Command {
     }
     logger.info("Reasoner: " + reasonerName);
 
-    ReasonOperation.reason(ontology, reasonerFactory, reasonerOptions);
+    // Return true if successful, false if it was not succesful
+    boolean success = ReasonOperation.reason(ontology, reasonerFactory, reasonerOptions);
+    state.setHadError(!success);
 
     CommandLineHelper.maybeSaveOutput(line, ontology);
 

--- a/robot-command/src/main/java/org/obolibrary/robot/VerifyCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/VerifyCommand.java
@@ -137,7 +137,9 @@ public class VerifyCommand implements Command {
     }
 
     boolean violationsExist = QueryOperation.execVerify(resultMap);
-    state.setHadError(violationsExist);
+    if (violationsExist) {
+      throw new VerifyException();
+    }
 
     return state;
   }
@@ -154,6 +156,12 @@ public class VerifyCommand implements Command {
       String message = "Cannot read from " + file + ": " + e.getMessage();
       // TODO: Is this necessary?
       throw new CannotReadQuery(message, e);
+    }
+  }
+
+  public static class VerifyException extends Exception {
+    public VerifyException() {
+      super();
     }
   }
 }

--- a/robot-command/src/main/java/org/obolibrary/robot/VerifyCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/VerifyCommand.java
@@ -126,9 +126,7 @@ public class VerifyCommand implements Command {
     }
 
     boolean violationsExist = QueryOperation.execVerify(resultMap);
-    if (violationsExist) {
-      System.exit(1);
-    }
+    state.setHadError(violationsExist);
 
     return state;
   }

--- a/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
@@ -408,7 +408,7 @@ public class QueryOperation {
    * @return true if there are any violations
    */
   public static boolean execVerify(
-      Map<File, Tuple<ResultSetRewindable, OutputStream>> queriesResults) throws IOException {
+      Map<File, Tuple<ResultSetRewindable, OutputStream>> queriesResults) throws Exception {
     boolean isViolation = false;
     for (File outFile : queriesResults.keySet()) {
       Tuple<ResultSetRewindable, OutputStream> resultAndStream = queriesResults.get(outFile);

--- a/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
@@ -14,6 +14,7 @@ import org.obolibrary.robot.checks.InvalidReferenceChecker;
 import org.obolibrary.robot.checks.InvalidReferenceViolation;
 import org.obolibrary.robot.exceptions.InvalidReferenceException;
 import org.obolibrary.robot.exceptions.OntologyLogicException;
+import org.obolibrary.robot.exceptions.ReasoningException;
 import org.obolibrary.robot.reason.EquivalentClassReasoning;
 import org.obolibrary.robot.reason.EquivalentClassReasoningMode;
 import org.semanticweb.owlapi.apibinding.OWLManager;
@@ -79,9 +80,10 @@ public class ReasonOperation {
    * @throws OntologyLogicException on inconsistency or incoherency
    * @throws InvalidReferenceException on unsatisfiable class(es)
    */
-  public static boolean reason(OWLOntology ontology, OWLReasonerFactory reasonerFactory)
-      throws OWLOntologyCreationException, OntologyLogicException, InvalidReferenceException {
-    return reason(ontology, reasonerFactory, getDefaultOptions());
+  public static void reason(OWLOntology ontology, OWLReasonerFactory reasonerFactory)
+      throws OWLOntologyCreationException, OntologyLogicException, InvalidReferenceException,
+          ReasoningException {
+    reason(ontology, reasonerFactory, getDefaultOptions());
   }
 
   /**
@@ -96,9 +98,10 @@ public class ReasonOperation {
    * @throws OntologyLogicException on inconsistency or incoherency
    * @throws InvalidReferenceException on unsatisfiable class(es)
    */
-  public static boolean reason(
+  public static void reason(
       OWLOntology ontology, OWLReasonerFactory reasonerFactory, Map<String, String> options)
-      throws OWLOntologyCreationException, OntologyLogicException, InvalidReferenceException {
+      throws OWLOntologyCreationException, OntologyLogicException, InvalidReferenceException,
+          ReasoningException {
     logger.info("Ontology has {} axioms.", ontology.getAxioms().size());
 
     logger.info("Fetching labels...");
@@ -152,7 +155,7 @@ public class ReasonOperation {
     boolean passesEquivalenceTests = equivalentReasoning.reason();
     equivalentReasoning.logReport(logger);
     if (!passesEquivalenceTests) {
-      return false;
+      throw new ReasoningException();
     }
     // cache the complete set of asserted axioms at the initial state.
     // we will later use this if the -x option is passed, to avoid
@@ -270,8 +273,6 @@ public class ReasonOperation {
     elapsedTime = System.currentTimeMillis() - startTime;
     seconds = (int) Math.ceil(elapsedTime / 1000);
     logger.info("Filling took {} seconds.", seconds);
-
-    return true;
   }
 
   /**

--- a/robot-core/src/main/java/org/obolibrary/robot/exceptions/ReasoningException.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/exceptions/ReasoningException.java
@@ -1,0 +1,12 @@
+package org.obolibrary.robot.exceptions;
+
+public class ReasoningException extends Exception {
+
+  public ReasoningException() {
+    super();
+  }
+
+  public ReasoningException(String message) {
+    super(message);
+  }
+}

--- a/robot-core/src/test/java/org/obolibrary/robot/QueryOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/QueryOperationTest.java
@@ -77,7 +77,7 @@ public class QueryOperationTest extends CoreTest {
   }
 
   @Test
-  public void testExecVerifyWithViolations() throws IOException, OWLOntologyStorageException {
+  public void testExecVerifyWithViolations() throws Exception {
 
     OWLOntology ontology = loadOntology("/simple.owl");
     DatasetGraph graph = QueryOperation.loadOntology(ontology);
@@ -95,7 +95,7 @@ public class QueryOperationTest extends CoreTest {
   }
 
   @Test
-  public void testExecVerifyNoViolations() throws IOException, OWLOntologyStorageException {
+  public void testExecVerifyNoViolations() throws Exception {
     OWLOntology ontology = loadOntology("/simple.owl");
     DatasetGraph graph = QueryOperation.loadOntology(ontology);
     String allViolations = "SELECT ?s ?p ?o\n" + "WHERE {\n" + "    \n" + "}\n" + "LIMIT 0";

--- a/robot-core/src/test/java/org/obolibrary/robot/ReasonOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ReasonOperationTest.java
@@ -10,6 +10,7 @@ import org.geneontology.reasoner.ExpressionMaterializingReasonerFactory;
 import org.junit.Test;
 import org.obolibrary.robot.exceptions.InvalidReferenceException;
 import org.obolibrary.robot.exceptions.OntologyLogicException;
+import org.obolibrary.robot.exceptions.ReasoningException;
 import org.semanticweb.elk.owlapi.ElkReasonerFactory;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
@@ -29,7 +30,7 @@ public class ReasonOperationTest extends CoreTest {
   @Test
   public void testStructural()
       throws IOException, OWLOntologyCreationException, OntologyLogicException,
-          InvalidReferenceException {
+          InvalidReferenceException, ReasoningException {
     OWLOntology reasoned = loadOntology("/simple.owl");
     OWLReasonerFactory reasonerFactory =
         new org.semanticweb.owlapi.reasoner.structural.StructuralReasonerFactory();
@@ -48,7 +49,7 @@ public class ReasonOperationTest extends CoreTest {
   @Test
   public void testELK()
       throws IOException, OWLOntologyCreationException, OntologyLogicException,
-          InvalidReferenceException {
+          InvalidReferenceException, ReasoningException {
     OWLOntology reasoned = loadOntology("/simple.owl");
     OWLReasonerFactory reasonerFactory = new ElkReasonerFactory();
     ReasonOperation.reason(reasoned, reasonerFactory);
@@ -66,7 +67,7 @@ public class ReasonOperationTest extends CoreTest {
   @Test
   public void testHermit()
       throws IOException, OWLOntologyCreationException, OntologyLogicException,
-          InvalidReferenceException {
+          InvalidReferenceException, ReasoningException {
     OWLOntology reasoned = loadOntology("/simple.owl");
     OWLReasonerFactory reasonerFactory = new org.semanticweb.HermiT.Reasoner.ReasonerFactory();
     ReasonOperation.reason(reasoned, reasonerFactory);
@@ -85,7 +86,7 @@ public class ReasonOperationTest extends CoreTest {
   @Test
   public void testJFact()
       throws IOException, OWLOntologyCreationException, OntologyLogicException,
-          InvalidReferenceException {
+          InvalidReferenceException, ReasoningException {
     OWLOntology reasoned = loadOntology("/simple.owl");
     OWLReasonerFactory reasonerFactory = new JFactFactory();
     ReasonOperation.reason(reasoned, reasonerFactory);
@@ -104,7 +105,7 @@ public class ReasonOperationTest extends CoreTest {
   @Test
   public void testInferIntoNewOntology()
       throws IOException, OWLOntologyCreationException, OntologyLogicException,
-          InvalidReferenceException {
+          InvalidReferenceException, ReasoningException {
     OWLOntology reasoned = loadOntology("/simple.owl");
     OWLReasonerFactory reasonerFactory = new org.semanticweb.HermiT.Reasoner.ReasonerFactory();
     Map<String, String> opts = new HashMap<>();
@@ -128,7 +129,7 @@ public class ReasonOperationTest extends CoreTest {
   @Test
   public void testInferIntoNewOntologyNonTrivial()
       throws IOException, OWLOntologyCreationException, OntologyLogicException,
-          InvalidReferenceException {
+          InvalidReferenceException, ReasoningException {
     OWLOntology reasoned = loadOntology("/relax_equivalence_axioms_test.obo");
     OWLReasonerFactory reasonerFactory = new org.semanticweb.HermiT.Reasoner.ReasonerFactory();
     Map<String, String> opts = new HashMap<>();
@@ -156,7 +157,7 @@ public class ReasonOperationTest extends CoreTest {
   @Test
   public void testInferIntoNewOntologyNoDupes()
       throws IOException, OWLOntologyCreationException, OntologyLogicException,
-          InvalidReferenceException {
+          InvalidReferenceException, ReasoningException {
     OWLOntology reasoned = loadOntology("/relax_equivalence_axioms_test.obo");
     OWLReasonerFactory reasonerFactory = new org.semanticweb.HermiT.Reasoner.ReasonerFactory();
     Map<String, String> opts = new HashMap<>();
@@ -179,7 +180,7 @@ public class ReasonOperationTest extends CoreTest {
   @Test
   public void testRemoveRedundantSubClassAxioms()
       throws IOException, OWLOntologyCreationException, OntologyLogicException,
-          InvalidReferenceException {
+          InvalidReferenceException, ReasoningException {
     OWLOntology reasoned = loadOntology("/redundant_subclasses.owl");
     OWLReasonerFactory reasonerFactory = new org.semanticweb.elk.owlapi.ElkReasonerFactory();
     ReasonOperation.reason(reasoned, reasonerFactory, Collections.emptyMap());
@@ -206,7 +207,7 @@ public class ReasonOperationTest extends CoreTest {
   @Test
   public void testEMRBasic()
       throws IOException, OWLOntologyCreationException, OntologyLogicException,
-          InvalidReferenceException {
+          InvalidReferenceException, ReasoningException {
     OWLOntology reasoned = loadOntology("/simple.owl");
     OWLReasonerFactory coreReasonerFactory = new ElkReasonerFactory();
     OWLReasonerFactory reasonerFactory =
@@ -228,7 +229,7 @@ public class ReasonOperationTest extends CoreTest {
   @Test
   public void testEMRRelax()
       throws IOException, OWLOntologyCreationException, OntologyLogicException,
-          InvalidReferenceException {
+          InvalidReferenceException, ReasoningException {
     OWLOntology reasoned = loadOntology("/relax_equivalence_axioms_test.obo");
     OWLReasonerFactory coreReasonerFactory = new ElkReasonerFactory();
     OWLReasonerFactory reasonerFactory =


### PR DESCRIPTION
This adds in a timing output statement for each subcommand in robot. 

I made the addition to `CommandState` in order to convey that a command had fatally erred. The existing way that we used to do this was just to `System.exit()`, but when that would happen (say with the verify command) the command wouldn't actually complete, and how long it took wouldn't be known. So the `CommandManager` now inspects if the `CommandState` has an error flag set, and if it does, then it calls System.exit, only after displaying the duration.