### PR TITLE
Fix concurrent modification bug

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/OntologyHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/OntologyHelper.java
@@ -155,14 +155,15 @@ public class OntologyHelper {
    */
   public static Set<IRI> filterExistingTerms(
       OWLOntology ontology, Set<IRI> IRIs, boolean allowEmpty) {
+    Set<IRI> missingIRIs = new HashSet<>();
     for (IRI iri : IRIs) {
       if (!ontology.containsEntityInSignature(iri)) {
         logger.warn("Ontology does not contain term {}", iri.toString());
-        IRIs.remove(iri);
+        missingIRIs.add(iri);
       }
     }
 
-    if (IRIs.isEmpty() && !allowEmpty) {
+    if (missingIRIs.containsAll(IRIs) && !allowEmpty) {
       throw new IllegalArgumentException(emptyTermsError);
     }
     return IRIs;


### PR DESCRIPTION
Concurrent modification in `filterExistingterms()` threw an exception if a missing term was found.