### PR TITLE
Update for Mac OS X 10.12

### DIFF
--- a/bin/robot
+++ b/bin/robot
@@ -6,9 +6,20 @@ if uname | grep -iq cygwin; then
     IS_CYGWIN="TRUE"
 fi
 
+# Check if Mac OS X
+IS_MAC="FALSE"
+if uname | grep -iq Darwin; then
+	IS_MAC="TRUE"
+fi
+	
 # Variable to hold path to this script
 # Start by assuming it was the path invoked.
-ROBOT_SCRIPT="$0"
+if [ $IS_MAC = "TRUE" ]
+then
+	ROBOT_SCRIPT=$0
+else
+	ROBOT_SCRIPT="$0"
+fi
 
 # Handle resolving symlinks to this script.
 # Using ls instead of readlink, because bsd and gnu flavors
@@ -25,7 +36,12 @@ while [ -h "$ROBOT_SCRIPT" ] ; do
 done
 
 # Directory that contains the this script
-DIR="$(dirname $ROBOT_SCRIPT)"
+if [ $IS_MAC = "TRUE" ]
+then
+	DIR=$(dirname "$ROBOT_SCRIPT")
+else
+	DIR="$(dirname $ROBOT_SCRIPT)"
+fi
 
 if [ $IS_CYGWIN = "TRUE" ]
 then

--- a/bin/robot
+++ b/bin/robot
@@ -6,20 +6,9 @@ if uname | grep -iq cygwin; then
     IS_CYGWIN="TRUE"
 fi
 
-# Check if Mac OS X
-IS_MAC="FALSE"
-if uname | grep -iq Darwin; then
-	IS_MAC="TRUE"
-fi
-	
 # Variable to hold path to this script
 # Start by assuming it was the path invoked.
-if [ $IS_MAC = "TRUE" ]
-then
-	ROBOT_SCRIPT=$0
-else
-	ROBOT_SCRIPT="$0"
-fi
+ROBOT_SCRIPT="$0"
 
 # Handle resolving symlinks to this script.
 # Using ls instead of readlink, because bsd and gnu flavors
@@ -36,12 +25,7 @@ while [ -h "$ROBOT_SCRIPT" ] ; do
 done
 
 # Directory that contains the this script
-if [ $IS_MAC = "TRUE" ]
-then
-	DIR=$(dirname "$ROBOT_SCRIPT")
-else
-	DIR="$(dirname $ROBOT_SCRIPT)"
-fi
+DIR=$(dirname "$ROBOT_SCRIPT")
 
 if [ $IS_CYGWIN = "TRUE" ]
 then


### PR DESCRIPTION
The following changes were required to run the robot script on the Mac (OS X 10.12).

I needed to change this:
  ROBOT_SCRIPT="$0"
  DIR="$(dirname $ROBOT_SCRIPT)"
to this:
  ROBOT_SCRIPT=$0
  DIR=$(dirname "$ROBOT_SCRIPT")

Note that I did not test this on any other systems but I added a test to the script to see if it's running on a Mac and if so then the following changes are implemented. If not running on a Mac then there should be no change in behavior.
