### PR TITLE
Improve error messages and CLI output

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -16,9 +16,25 @@ The command line option provided only accepts `true` or `false` as input.
 
 [Chained commands](/chaining) take the output of the last command as the input of the next. Because of this, `--input` should only be used with the first command in the chain. This excludes [merge](/merge) and [unmerge](/unmerge), which allow multiple inputs.
 
+### File Does Not Exist Error
+
+One of the required files (often `--input`) could not be found. This is often caused by a typo.
+
 ### Invalid Format Error
 
 When specifying the `--output` (or `--format` for converting), make sure the file has a valid extension. See [convert](/convert) for a current list of ontology formats.
+
+### Invalid Ontology File Error
+
+ROBOT was expecting an ontology file, and the file exists, but is not in a recognized format. Adding the `-vvv` option will print a stack trace that shows how the underlying OWLAPI library tried to parse the ontology file. This will include details and line numbers that can help isolate the problem.
+
+### Invalid Ontology IRI Error
+
+Either the ontology could not be loaded from the provided IRI, or the file at that IRI was in an unrecognized format. Adding the `-vvv` option may provide helpful details.
+
+### Invalid Ontology Stream Error
+
+Either the ontology could not be loaded from the provided input stream, or the input stream was in an unrecognized format. Adding the `-vvv` option may provide helpful details.
 
 ### Invalid IRI Error
 
@@ -33,6 +49,14 @@ Prefixes (added with `--prefix`) should be strings in the following format: `"fo
 ### Invalid Reasoner Error
 
 [Reason](/reason), [materialize](/materialize), and [reduce](/reduce) all expect `--reasoner` options. All three commands support `structural`, `hermit`, `jfact`, and `elk`. Only the reason command supports `emr`. Click on the command for more details
+
+### JSON-LD Context Creation Error
+
+There was an error creating a JSON-LD context. This could be caused by a bad prefix.
+
+### JSON-LD Context Parsing Error
+
+There was an error parsing a JSON-LD context. Add the `-vvv` option to see more details, and refer to <https://json-ld.org> for information about that format.
 
 ### Missing Command Error
 
@@ -53,6 +77,10 @@ Some commands ([extract](/extract) and [filter](/filter)) require terms as input
 ### Multiple Inputs Error
 
 For all commands other than [merge](/merge) and [unmerge](/unmerge), only one `--input` may be specified.
+
+### Ontology Storage Error
+
+The ontology could not be saved to the specified IRI. The most common reasons are: the IRI is not a valid file path; ROBOT does not have write permissions; there is not enough space on the storage device.
 
 ### Options Error
 

--- a/robot-command/src/main/java/org/obolibrary/robot/AnnotateCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/AnnotateCommand.java
@@ -203,7 +203,7 @@ public class AnnotateCommand implements Command {
         property = linkItems.remove(0);
         value = linkItems.remove(0);
       } catch (IndexOutOfBoundsException e) {
-        throw new IllegalArgumentException(linkAnnotationFormatError,e );
+        throw new IllegalArgumentException(linkAnnotationFormatError, e);
       }
       IRI propIRI = CommandLineHelper.maybeCreateIRI(ioHelper, property, "property");
       IRI valueIRI = CommandLineHelper.maybeCreateIRI(ioHelper, value, "value");

--- a/robot-command/src/main/java/org/obolibrary/robot/AnnotateCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/AnnotateCommand.java
@@ -188,7 +188,7 @@ public class AnnotateCommand implements Command {
         property = annotationItems.remove(0);
         value = annotationItems.remove(0);
       } catch (IndexOutOfBoundsException e) {
-        throw new IllegalArgumentException(annotationFormatError);
+        throw new IllegalArgumentException(annotationFormatError, e);
       }
       IRI iri = CommandLineHelper.maybeCreateIRI(ioHelper, property, "property");
       OntologyHelper.addOntologyAnnotation(ontology, iri, IOHelper.createLiteral(value));
@@ -203,7 +203,7 @@ public class AnnotateCommand implements Command {
         property = linkItems.remove(0);
         value = linkItems.remove(0);
       } catch (IndexOutOfBoundsException e) {
-        throw new IllegalArgumentException(linkAnnotationFormatError);
+        throw new IllegalArgumentException(linkAnnotationFormatError,e );
       }
       IRI propIRI = CommandLineHelper.maybeCreateIRI(ioHelper, property, "property");
       IRI valueIRI = CommandLineHelper.maybeCreateIRI(ioHelper, value, "value");
@@ -221,7 +221,7 @@ public class AnnotateCommand implements Command {
         value = langItems.remove(0);
         lang = langItems.remove(0);
       } catch (IndexOutOfBoundsException e) {
-        throw new IllegalArgumentException(langAnnotationFormatError);
+        throw new IllegalArgumentException(langAnnotationFormatError, e);
       }
       IRI iri = CommandLineHelper.maybeCreateIRI(ioHelper, property, "property");
       OntologyHelper.addOntologyAnnotation(
@@ -239,7 +239,7 @@ public class AnnotateCommand implements Command {
         value = typedItems.remove(0);
         type = typedItems.remove(0);
       } catch (IndexOutOfBoundsException e) {
-        throw new IllegalArgumentException(typedAnnotationFormatError);
+        throw new IllegalArgumentException(typedAnnotationFormatError, e);
       }
       IRI iri = CommandLineHelper.maybeCreateIRI(ioHelper, property, "property");
       OntologyHelper.addOntologyAnnotation(ontology, iri, ioHelper.createTypedLiteral(value, type));
@@ -254,7 +254,7 @@ public class AnnotateCommand implements Command {
         property = axiomItems.remove(0);
         value = axiomItems.remove(0);
       } catch (IndexOutOfBoundsException e) {
-        throw new IllegalArgumentException(axiomAnnotationFormatError);
+        throw new IllegalArgumentException(axiomAnnotationFormatError, e);
       }
       IRI iri = CommandLineHelper.maybeCreateIRI(ioHelper, property, "property");
       OntologyHelper.addAxiomAnnotations(ontology, iri, IOHelper.createLiteral(value));

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
@@ -43,22 +43,9 @@ public class CommandLineHelper {
   private static final String chainedInputError =
       NS + "CHAINED INPUT ERROR do not use an --input option for chained commands";
 
-  /**
-   * Error message when an invalid extension is provided (file format). Expects file format. This
-   * message is duplicated in IOHelper without the NS and ID.
-   */
-  private static final String invalidFormatError = NS + "INVALID FORMAT ERROR unknown format: %s";
-
   /** Error message when an invalid IRI is provided. Expects the entry field and term. */
   private static final String invalidIRIError =
       NS + "INVALID IRI ERROR %1$s \"%2$s\" is not a valid CURIE or IRI";
-
-  /**
-   * Error message when an invalid prefix is provided. Expects the combined prefix. This message is
-   * duplicated in IOHelper without the NS and ID.
-   */
-  private static final String invalidPrefixError =
-      NS + "INVALID PREFIX ERROR invalid prefix string: %s";
 
   /** Error message when user provides an invalid reasoner. Expects reasonerName in formatting. */
   private static final String invalidReasonerError =
@@ -336,7 +323,7 @@ public class CommandLineHelper {
       try {
         ioHelper.addPrefix(prefix);
       } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException(String.format(invalidPrefixError, prefix));
+        throw new IllegalArgumentException(String.format(IOHelper.invalidPrefixError, prefix));
       }
     }
 
@@ -542,7 +529,7 @@ public class CommandLineHelper {
       } catch (IllegalArgumentException e) {
         // Exception from getFormat -- invalid format
         throw new IllegalArgumentException(
-            String.format(invalidFormatError, path.substring(path.lastIndexOf(".") + 1)));
+            String.format(IOHelper.invalidFormatError, path.substring(path.lastIndexOf(".") + 1)));
       }
     }
   }

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
@@ -323,7 +323,7 @@ public class CommandLineHelper {
       try {
         ioHelper.addPrefix(prefix);
       } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException(String.format(IOHelper.invalidPrefixError, prefix));
+        throw new IllegalArgumentException(String.format(IOHelper.invalidPrefixError, prefix), e);
       }
     }
 
@@ -529,7 +529,8 @@ public class CommandLineHelper {
       } catch (IllegalArgumentException e) {
         // Exception from getFormat -- invalid format
         throw new IllegalArgumentException(
-            String.format(IOHelper.invalidFormatError, path.substring(path.lastIndexOf(".") + 1)));
+            String.format(IOHelper.invalidFormatError, path.substring(path.lastIndexOf(".") + 1)),
+            e);
       }
     }
   }

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
@@ -764,7 +764,6 @@ public class CommandLineHelper {
    */
   public static void handleException(String usage, Options options, Exception exception) {
     ExceptionHelper.handleException(exception);
-    printHelp(usage, options);
     System.exit(1);
   }
 }

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandManager.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandManager.java
@@ -110,7 +110,7 @@ public class CommandManager implements Command {
   /**
    * Given some Options and some arguments, collect all the options until the first non-option
    * argument, then remove those used argument strings from the arguments list and return the used
-   * arguments as a new list.
+   * arguments as a new list. WARN: Mutates the `arguments` list.
    *
    * @param options the options to collect
    * @param arguments a list of remaining command-line arguments; used option strings are removed
@@ -164,11 +164,11 @@ public class CommandManager implements Command {
     }
 
     List<String> arguments = new ArrayList<String>(Arrays.asList(args));
+    List<String> globalOptionArgs = getOptionArgs(globalOptions, arguments);
+
     if (arguments.size() == 0) {
       throw new IllegalArgumentException(missingCommandError);
     }
-
-    List<String> globalOptionArgs = getOptionArgs(globalOptions, arguments);
 
     while (arguments.size() > 0) {
       state = executeCommand(state, globalOptionArgs, arguments);

--- a/robot-command/src/main/java/org/obolibrary/robot/ConvertCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ConvertCommand.java
@@ -169,7 +169,7 @@ public class ConvertCommand implements Command {
       // specific feedback for writing to OBO
       if (e.getMessage().contains("FrameStructureException")) {
         logger.debug(e.getMessage());
-        throw new Exception(oboStructureError);
+        throw new Exception(oboStructureError, e);
       } else {
         throw e;
       }

--- a/robot-command/src/main/java/org/obolibrary/robot/ExceptionHelper.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ExceptionHelper.java
@@ -25,15 +25,14 @@ public class ExceptionHelper {
     if (msg != null) {
       String exceptionID = getExceptionID(msg);
       System.out.println(trimExceptionID(msg));
-      System.out.println("For details see: http://robot.obolibrary.org/" + exceptionID + "\n");
+      System.out.println("For details see: http://robot.obolibrary.org/" + exceptionID);
     }
     // Will only print with --very-very-verbose (DEBUG level)
     if (logger.isDebugEnabled()) {
-      StackTraceElement[] trace = exception.getStackTrace();
-      for (StackTraceElement t : trace) {
-        logger.debug(t.toString());
-      }
-      System.out.println();
+      exception.printStackTrace();
+    } else {
+      System.out.println("Use the -vvv option to show the stack trace.");
+      System.out.println("Use the --help option to see usage information.");
     }
   }
 

--- a/robot-core/src/main/java/org/obolibrary/robot/CatalogXmlIRIMapper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/CatalogXmlIRIMapper.java
@@ -151,7 +151,7 @@ public class CatalogXmlIRIMapper implements OWLOntologyIRIMapper {
       SAXParser saxParser = factory.newSAXParser();
       saxParser.parse(inputStream, new CatalogElementHandler(parentFolder, mappings));
       return mappings;
-    } catch (ParserConfigurationException|SAXException e) {
+    } catch (ParserConfigurationException | SAXException e) {
       throw new IOException(e);
     } finally {
       inputStream.close();

--- a/robot-core/src/main/java/org/obolibrary/robot/CatalogXmlIRIMapper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/CatalogXmlIRIMapper.java
@@ -151,9 +151,7 @@ public class CatalogXmlIRIMapper implements OWLOntologyIRIMapper {
       SAXParser saxParser = factory.newSAXParser();
       saxParser.parse(inputStream, new CatalogElementHandler(parentFolder, mappings));
       return mappings;
-    } catch (ParserConfigurationException e) {
-      throw new IOException(e);
-    } catch (SAXException e) {
+    } catch (ParserConfigurationException|SAXException e) {
       throw new IOException(e);
     } finally {
       inputStream.close();

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -678,7 +678,7 @@ public class IOHelper {
       Object jsonContext = jsonMap.get("@context");
       return new Context().parse(jsonContext);
     } catch (Exception e) {
-      throw new IOException(jsonldContextParseError);
+      throw new IOException(jsonldContextParseError, e);
     }
   }
 
@@ -858,7 +858,7 @@ public class IOHelper {
               JsonUtils.fromString("{}"), context.getPrefixes(false), new JsonLdOptions());
       return JsonUtils.toPrettyString(compact);
     } catch (Exception e) {
-      throw new IOException(jsonldContextCreationError);
+      throw new IOException(jsonldContextCreationError, e);
     }
   }
 

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -317,9 +317,9 @@ public class IOHelper {
       }
       return manager.loadOntologyFromOntologyDocument(ontologyFile);
     } catch (JsonLdError e) {
-      throw new IOException(String.format(invalidOntologyFileError, ontologyFile.getName()));
+      throw new IOException(String.format(invalidOntologyFileError, ontologyFile.getName()), e);
     } catch (OWLOntologyCreationException e) {
-      throw new IOException(String.format(invalidOntologyFileError, ontologyFile.getName()));
+      throw new IOException(String.format(invalidOntologyFileError, ontologyFile.getName()), e);
     }
   }
 
@@ -336,7 +336,7 @@ public class IOHelper {
       OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
       ontology = manager.loadOntologyFromOntologyDocument(ontologyStream);
     } catch (OWLOntologyCreationException e) {
-      throw new IOException(invalidOntologyStreamError);
+      throw new IOException(invalidOntologyStreamError, e);
     }
     return ontology;
   }
@@ -354,7 +354,7 @@ public class IOHelper {
       OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
       ontology = manager.loadOntologyFromOntologyDocument(ontologyIRI);
     } catch (OWLOntologyCreationException e) {
-      throw new IOException(String.format(invalidOntologyIRIError, ontologyIRI.toString()));
+      throw new IOException(String.format(invalidOntologyIRIError, ontologyIRI.toString()), e);
     }
     return ontology;
   }
@@ -436,7 +436,7 @@ public class IOHelper {
       OWLDocumentFormat format = getFormat(formatName);
       return saveOntology(ontology, format, ontologyIRI, true);
     } catch (Exception e) {
-      throw new IOException(String.format(ontologyStorageError, ontologyIRI.toString()));
+      throw new IOException(String.format(ontologyStorageError, ontologyIRI.toString()), e);
     }
   }
 
@@ -514,7 +514,7 @@ public class IOHelper {
       try {
         ontology.getOWLOntologyManager().saveOntology(ontology, format, ontologyIRI);
       } catch (OWLOntologyStorageException e) {
-        throw new IOException(String.format(ontologyStorageError, ontologyIRI.toString()));
+        throw new IOException(String.format(ontologyStorageError, ontologyIRI.toString()), e);
       }
     }
     return ontology;

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -65,6 +65,43 @@ public class IOHelper {
   /** Logger. */
   private static final Logger logger = LoggerFactory.getLogger(IOHelper.class);
 
+  /** Namespace for error messages. */
+  private static final String NS = "errors#";
+
+  /** Error message when the specified file does not exist. Expects file name. */
+  private static final String fileDoesNotExistError =
+      NS + "FILE DOES NOT EXIST ERROR File does not exist: %s";
+
+  /** Error message when an invalid extension is provided (file format). Expects the file format. */
+  static final String invalidFormatError = NS + "INVALID FORMAT ERROR unknown format: %s";
+
+  /** Error message when the specified file cannot be loaded. Expects the file name. */
+  private static final String invalidOntologyFileError =
+      NS + "INVALID ONTOLOGY FILE ERROR Could not load a valid ontology from file: %s";
+
+  /** Error message when the specified IRI cannot be loaded. Expects the IRI string. */
+  private static final String invalidOntologyIRIError =
+      NS + "INVALID ONTOLOGY IRI ERROR Could not load a valid ontology from IRI: %s";
+
+  /** Error message when the specified input stream cannot be loaded. */
+  private static final String invalidOntologyStreamError =
+      NS + "INVALID ONTOLOGY STREAM ERROR Could not load a valid ontology from InputStream.";
+
+  /** Error message when an invalid prefix is provided. Expects the combined prefix. */
+  static final String invalidPrefixError = NS + "INVALID PREFIX ERROR Invalid prefix string: %s";
+
+  /** Error message when a JSON-LD context cannot be created, for any reason. */
+  private static final String jsonldContextCreationError =
+      NS + "JSONLD CONTEXT CREATION ERROR Could not create the JSON-LD context.";
+
+  /** Error message when a JSON-LD context cannot be read, for any reason. */
+  private static final String jsonldContextParseError =
+      NS + "JSONLD CONTEXT PARSE ERROR Could not parse the JSON-LD context.";
+
+  /** Error message when the ontology cannot be saved. Expects the IRI string. */
+  private static final String ontologyStorageError =
+      NS + "ONTOLOGY STORAGE ERROR Could not save ontology to IRI: %s";
+
   /** Path to default context as a resource. */
   private static String defaultContextPath = "/obo_context.jsonld";
 
@@ -241,7 +278,8 @@ public class IOHelper {
     logger.debug("Loading ontology {} with catalog file {}", ontologyFile, catalogFile);
 
     if (!ontologyFile.exists()) {
-      throw new IllegalArgumentException("File " + ontologyFile.getName() + " does not exist");
+      throw new IllegalArgumentException(
+          String.format(fileDoesNotExistError, ontologyFile.getName()));
     }
 
     Object jsonObject = null;
@@ -279,9 +317,9 @@ public class IOHelper {
       }
       return manager.loadOntologyFromOntologyDocument(ontologyFile);
     } catch (JsonLdError e) {
-      throw new IOException("File " + ontologyFile.getName() + " is not a valid ontology", e);
+      throw new IOException(String.format(invalidOntologyFileError, ontologyFile.getName()));
     } catch (OWLOntologyCreationException e) {
-      throw new IOException("File " + ontologyFile.getName() + " is not a valid ontology", e);
+      throw new IOException(String.format(invalidOntologyFileError, ontologyFile.getName()));
     }
   }
 
@@ -298,7 +336,7 @@ public class IOHelper {
       OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
       ontology = manager.loadOntologyFromOntologyDocument(ontologyStream);
     } catch (OWLOntologyCreationException e) {
-      throw new IOException(e);
+      throw new IOException(invalidOntologyStreamError);
     }
     return ontology;
   }
@@ -316,7 +354,7 @@ public class IOHelper {
       OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
       ontology = manager.loadOntologyFromOntologyDocument(ontologyIRI);
     } catch (OWLOntologyCreationException e) {
-      throw new IOException(e);
+      throw new IOException(String.format(invalidOntologyIRIError, ontologyIRI.toString()));
     }
     return ontology;
   }
@@ -356,7 +394,7 @@ public class IOHelper {
     } else if (formatName.equals("json")) {
       return new OboGraphJsonDocumentFormat();
     } else {
-      throw new IllegalArgumentException("Invalid ontology format: " + formatName);
+      throw new IllegalArgumentException(String.format(invalidFormatError, formatName));
     }
   }
 
@@ -397,8 +435,8 @@ public class IOHelper {
       String formatName = FilenameUtils.getExtension(ontologyIRI.toString());
       OWLDocumentFormat format = getFormat(formatName);
       return saveOntology(ontology, format, ontologyIRI, true);
-    } catch (IllegalArgumentException e) {
-      throw new IOException(e);
+    } catch (Exception e) {
+      throw new IOException(String.format(ontologyStorageError, ontologyIRI.toString()));
     }
   }
 
@@ -476,7 +514,7 @@ public class IOHelper {
       try {
         ontology.getOWLOntologyManager().saveOntology(ontology, format, ontologyIRI);
       } catch (OWLOntologyStorageException e) {
-        throw new IOException(e);
+        throw new IOException(String.format(ontologyStorageError, ontologyIRI.toString()));
       }
     }
     return ontology;
@@ -640,7 +678,7 @@ public class IOHelper {
       Object jsonContext = jsonMap.get("@context");
       return new Context().parse(jsonContext);
     } catch (Exception e) {
-      throw new IOException(e);
+      throw new IOException(jsonldContextParseError);
     }
   }
 
@@ -766,7 +804,7 @@ public class IOHelper {
   public void addPrefix(String combined) throws IllegalArgumentException {
     String[] results = combined.split(":", 2);
     if (results.length < 2) {
-      throw new IllegalArgumentException("Invalid prefix string: " + combined);
+      throw new IllegalArgumentException(String.format(invalidPrefixError, combined));
     }
     addPrefix(results[0], results[1]);
   }
@@ -820,7 +858,7 @@ public class IOHelper {
               JsonUtils.fromString("{}"), context.getPrefixes(false), new JsonLdOptions());
       return JsonUtils.toPrettyString(compact);
     } catch (Exception e) {
-      throw new IOException(e);
+      throw new IOException(jsonldContextCreationError);
     }
   }
 

--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateOperation.java
@@ -593,7 +593,7 @@ public class TemplateOperation {
         } catch (ParserException e) {
           throw new Exception(
               String.format(
-                  parseError, tableName, row + 1, id, column + 1, header, sub, e.getMessage()));
+                  parseError, tableName, row + 1, id, column + 1, header, sub, e.getMessage()), e);
         }
         classExpressions.add(lastExpression);
       } else if (template.startsWith("CI")) {

--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateOperation.java
@@ -593,7 +593,8 @@ public class TemplateOperation {
         } catch (ParserException e) {
           throw new Exception(
               String.format(
-                  parseError, tableName, row + 1, id, column + 1, header, sub, e.getMessage()), e);
+                  parseError, tableName, row + 1, id, column + 1, header, sub, e.getMessage()),
+              e);
         }
         classExpressions.add(lastExpression);
       } else if (template.startsWith("CI")) {


### PR DESCRIPTION
This PR improves CLI output on exceptions by:

1. not printing usage information or stack traces by default
2. always printing an error ID, brief friendly message, and link to our online docs
3. reminding the user that `-vvv` will show the stack trace; ensuring that the full stack trace is printed; adding more information to stack traces
4. reminding the user that `--help` will show usage information

Example (from #304):

```
$ bin/robot convert --input foo.omn
[Fatal Error] :1:1: Content is not allowed in prolog.
INVALID ONTOLOGY FILE ERROR Could not load a valid ontology from file: foo.omn
For details see: http://robot.obolibrary.org/errors#invalid-ontology-file-error
Use the -vvv option to show the stack trace.
Use the --help option to see usage information.
```