### PR TITLE
Ensure backwards compatibility

### DIFF
--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -27,6 +27,41 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- Ensure backward compatibility -->
+      <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+        <version>0.12.0</version>
+        <configuration>
+          <oldVersion>
+            <dependency>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>${project.artifactId}</artifactId>
+              <version>1.0.0</version>
+              <type>jar</type>
+            </dependency>
+          </oldVersion>
+          <newVersion>
+            <file>
+              <path>${project.build.directory}/${project.artifactId}-${project.version}.${project.packaging}</path>
+            </file>
+          </newVersion>
+          <parameter>
+            <!-- see documentation: http://siom79.github.io/japicmp/MavenPlugin.html -->
+            <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+            <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+          </parameter>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>cmp</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -9,20 +9,16 @@ import com.github.jsonldjava.utils.JsonUtils;
 import com.google.common.collect.Sets;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
-import com.opencsv.CSVReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -940,7 +936,7 @@ public class IOHelper {
    * @throws IOException on file or reading problems
    */
   public static List<List<String>> readCSV(String path) throws IOException {
-    return readCSV(new FileReader(path));
+    return TemplateHelper.readCSV(path);
   }
 
   /**
@@ -951,7 +947,7 @@ public class IOHelper {
    * @throws IOException on file or reading problems
    */
   public static List<List<String>> readCSV(InputStream stream) throws IOException {
-    return readCSV(new InputStreamReader(stream));
+    return TemplateHelper.readCSV(stream);
   }
 
   /**
@@ -962,14 +958,7 @@ public class IOHelper {
    * @throws IOException on file or reading problems
    */
   public static List<List<String>> readCSV(Reader reader) throws IOException {
-    CSVReader csv = new CSVReader(reader);
-    List<List<String>> rows = new ArrayList<List<String>>();
-    String[] nextLine;
-    while ((nextLine = csv.readNext()) != null) {
-      rows.add(new ArrayList<String>(Arrays.asList(nextLine)));
-    }
-    csv.close();
-    return rows;
+    return TemplateHelper.readCSV(reader);
   }
 
   /**
@@ -980,7 +969,7 @@ public class IOHelper {
    * @throws IOException on file or reading problems
    */
   public static List<List<String>> readTSV(String path) throws IOException {
-    return readTSV(new FileReader(path));
+    return TemplateHelper.readTSV(path);
   }
 
   /**
@@ -991,7 +980,7 @@ public class IOHelper {
    * @throws IOException on file or reading problems
    */
   public static List<List<String>> readTSV(InputStream stream) throws IOException {
-    return readTSV(new InputStreamReader(stream));
+    return TemplateHelper.readTSV(stream);
   }
 
   /**
@@ -1002,14 +991,7 @@ public class IOHelper {
    * @throws IOException on file or reading problems
    */
   public static List<List<String>> readTSV(Reader reader) throws IOException {
-    CSVReader csv = new CSVReader(reader, '\t');
-    List<List<String>> rows = new ArrayList<List<String>>();
-    String[] nextLine;
-    while ((nextLine = csv.readNext()) != null) {
-      rows.add(new ArrayList<String>(Arrays.asList(nextLine)));
-    }
-    csv.close();
-    return rows;
+    return TemplateHelper.readTSV(reader);
   }
 
   /**
@@ -1020,15 +1002,6 @@ public class IOHelper {
    * @throws IOException on file or reading problems
    */
   public static List<List<String>> readTable(String path) throws IOException {
-    File file = new File(path);
-    String extension = FilenameUtils.getExtension(file.getName());
-    extension = extension.trim().toLowerCase();
-    if (extension.equals("csv")) {
-      return readCSV(new FileReader(path));
-    } else if (extension.equals("tsv") || extension.equals("tab")) {
-      return readTSV(new FileReader(path));
-    } else {
-      throw new IOException("Unrecognized file type for: " + path);
-    }
+    return TemplateHelper.readTable(path);
   }
 }

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -9,15 +9,20 @@ import com.github.jsonldjava.utils.JsonUtils;
 import com.google.common.collect.Sets;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
+import com.opencsv.CSVReader;
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -500,6 +505,20 @@ public class IOHelper {
   }
 
   /**
+   * Save an ontology in the given format to an IRI.
+   *
+   * @param ontology the ontology to save
+   * @param format the ontology format to use
+   * @param ontologyIRI the IRI to save the ontology to
+   * @return the saved ontology
+   * @throws IOException on any problem
+   */
+  public OWLOntology saveOntology(
+      final OWLOntology ontology, OWLDocumentFormat format, IRI ontologyIRI) throws IOException {
+    return saveOntology(ontology, format, ontologyIRI, true);
+  }
+
+  /**
    * Save an ontology in the given format to an IRI, with the option to ignore OBO document checks.
    *
    * @param ontology the ontology to save
@@ -911,5 +930,105 @@ public class IOHelper {
     FileWriter writer = new FileWriter(file);
     writer.write(getContextString());
     writer.close();
+  }
+
+  /**
+   * Read comma-separated values from a path to a list of lists of strings.
+   *
+   * @param path file path to the CSV file
+   * @return a list of lists of strings
+   * @throws IOException on file or reading problems
+   */
+  public static List<List<String>> readCSV(String path) throws IOException {
+    return readCSV(new FileReader(path));
+  }
+
+  /**
+   * Read comma-separated values from a stream to a list of lists of strings.
+   *
+   * @param stream the stream to read from
+   * @return a list of lists of strings
+   * @throws IOException on file or reading problems
+   */
+  public static List<List<String>> readCSV(InputStream stream) throws IOException {
+    return readCSV(new InputStreamReader(stream));
+  }
+
+  /**
+   * Read comma-separated values from a reader to a list of lists of strings.
+   *
+   * @param reader a reader to read data from
+   * @return a list of lists of strings
+   * @throws IOException on file or reading problems
+   */
+  public static List<List<String>> readCSV(Reader reader) throws IOException {
+    CSVReader csv = new CSVReader(reader);
+    List<List<String>> rows = new ArrayList<List<String>>();
+    String[] nextLine;
+    while ((nextLine = csv.readNext()) != null) {
+      rows.add(new ArrayList<String>(Arrays.asList(nextLine)));
+    }
+    csv.close();
+    return rows;
+  }
+
+  /**
+   * Read tab-separated values from a path to a list of lists of strings.
+   *
+   * @param path file path to the CSV file
+   * @return a list of lists of strings
+   * @throws IOException on file or reading problems
+   */
+  public static List<List<String>> readTSV(String path) throws IOException {
+    return readTSV(new FileReader(path));
+  }
+
+  /**
+   * Read tab-separated values from a stream to a list of lists of strings.
+   *
+   * @param stream the stream to read from
+   * @return a list of lists of strings
+   * @throws IOException on file or reading problems
+   */
+  public static List<List<String>> readTSV(InputStream stream) throws IOException {
+    return readTSV(new InputStreamReader(stream));
+  }
+
+  /**
+   * Read tab-separated values from a reader to a list of lists of strings.
+   *
+   * @param reader a reader to read data from
+   * @return a list of lists of strings
+   * @throws IOException on file or reading problems
+   */
+  public static List<List<String>> readTSV(Reader reader) throws IOException {
+    CSVReader csv = new CSVReader(reader, '\t');
+    List<List<String>> rows = new ArrayList<List<String>>();
+    String[] nextLine;
+    while ((nextLine = csv.readNext()) != null) {
+      rows.add(new ArrayList<String>(Arrays.asList(nextLine)));
+    }
+    csv.close();
+    return rows;
+  }
+
+  /**
+   * Read a table from a path to a list of lists of strings.
+   *
+   * @param path file path to the CSV file
+   * @return a list of lists of strings
+   * @throws IOException on file or reading problems
+   */
+  public static List<List<String>> readTable(String path) throws IOException {
+    File file = new File(path);
+    String extension = FilenameUtils.getExtension(file.getName());
+    extension = extension.trim().toLowerCase();
+    if (extension.equals("csv")) {
+      return readCSV(new FileReader(path));
+    } else if (extension.equals("tsv") || extension.equals("tab")) {
+      return readTSV(new FileReader(path));
+    } else {
+      throw new IOException("Unrecognized file type for: " + path);
+    }
   }
 }

--- a/robot-core/src/main/java/org/obolibrary/robot/MergeOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/MergeOperation.java
@@ -118,6 +118,23 @@ public class MergeOperation {
   }
 
   /**
+   * Given a source ontology and a target ontology, add all the axioms from the source ontology and
+   * its import closure into the target ontology. The target ontology is not itself merged, so any
+   * of its imports remain distinct.
+   *
+   * @param ontology the source ontology to merge
+   * @param targetOntology the ontology to merge axioms into
+   * @param includeAnnotations true if ontology annotations should be merged; annotations on imports
+   *     are not merged
+   */
+  public static void mergeInto(
+      OWLOntology ontology, OWLOntology targetOntology, boolean includeAnnotations) {
+    List<OWLOntology> ontologies = new ArrayList<OWLOntology>();
+    ontologies.add(ontology);
+    mergeInto(ontologies, targetOntology, includeAnnotations);
+  }
+
+  /**
    * Given a source ontology and a target ontology, add all the axioms from the source ontology into
    * the target ontology. Optionally, include annotations from the source and/or collapse the
    * imports closures.

--- a/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
@@ -319,6 +319,21 @@ public class ReasonOperation {
    *
    * @param reasoner an OWL reasoner, initialized with a root ontology; the ontology will be
    *     modified
+   */
+  public static void removeRedundantSubClassAxioms(OWLReasoner reasoner) {
+    removeRedundantSubClassAxioms(reasoner, null);
+  }
+
+  /**
+   * Remove subClassAxioms where there is a more direct axiom, and the subClassAxiom does not have
+   * any annotations.
+   *
+   * <p>Example: genotyping assay - asserted in dev: assay - inferred by reasoner: analyte assay -
+   * asserted after fill: assay, analyte assay - asserted after removeRedundantSubClassAxioms:
+   * analyte assay
+   *
+   * @param reasoner an OWL reasoner, initialized with a root ontology; the ontology will be
+   *     modified
    * @param options map of options for reasoning
    */
   public static void removeRedundantSubClassAxioms(

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -64,6 +64,48 @@ public class ReportOperation {
   private static final String ERROR = "ERROR";
 
   /**
+   * Return a map from option name to default option value, for all the available report options.
+   *
+   * @return a map with default values for all available options
+   */
+  public static Map<String, String> getDefaultOptions() {
+    Map<String, String> options = new HashMap<String, String>();
+
+    return options;
+  }
+
+  /**
+   * Report on the ontology using the rules within the profile and print results. Prefer
+   * report(OWLOntology ontology, String profilePath, String outputPath, String format, String
+   * failOn).
+   *
+   * @param ontology the OWLOntology to report
+   * @param iohelper IOHelper to work with ontology
+   */
+  public static void report(OWLOntology ontology, IOHelper iohelper) {
+    try {
+      report(ontology, null, null, null, null);
+    } catch (Exception e) {
+    }
+  }
+
+  /**
+   * Report on the ontology using the rules within the profile and print results. Prefer
+   * report(OWLOntology ontology, String profilePath, String outputPath, String format, String
+   * failOn).
+   *
+   * @param ontology the OWLOntology to report
+   * @param iohelper IOHelper to work with ontology
+   * @param options map of report options
+   */
+  public static void report(OWLOntology ontology, IOHelper iohelper, Map<String, String> options) {
+    try {
+      report(ontology, null, null, null, null);
+    } catch (Exception e) {
+    }
+  }
+
+  /**
    * Given an ontology, a profile path (or null), an output path (or null), and a report format (or
    * null) report on the ontology using the rules within the profile and write results to the output
    * path. If profile is null, use the default profile in resources. If the output path is null,

--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateOperation.java
@@ -13,6 +13,7 @@ import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLClassExpression;
 import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLDatatype;
 import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
@@ -108,6 +109,133 @@ public class TemplateOperation {
    */
   private static String unknownTypeError =
       NS + "UNKNOWN TYPE ERROR \"%4$s\" for row %2$d (\"%3$s\") in table \"%1$s\".";
+
+  /**
+   * Find an annotation property with the given name or create one.
+   *
+   * @param checker used to search by rdfs:label (for example)
+   * @param name the name to search for
+   * @return an annotation property
+   * @throws Exception if the name cannot be resolved
+   */
+  public static OWLAnnotationProperty getAnnotationProperty(
+      QuotedEntityChecker checker, String name) throws Exception {
+    return TemplateHelper.getAnnotationProperty(checker, name);
+  }
+
+  /**
+   * Find a datatype with the given name or create one.
+   *
+   * @param checker used to search by rdfs:label (for example)
+   * @param name the name to search for
+   * @return a datatype
+   * @throws Exception if the name cannot be resolved
+   */
+  public static OWLDatatype getDatatype(QuotedEntityChecker checker, String name) throws Exception {
+    return TemplateHelper.getDatatype(checker, name);
+  }
+
+  /**
+   * Return a string annotation for the given template string and value.
+   *
+   * @param checker used to resolve the annotation property
+   * @param template the template string
+   * @param value the value for the annotation
+   * @return a new annotation with property and string literal value
+   * @throws Exception if the annotation property cannot be found
+   */
+  public static OWLAnnotation getStringAnnotation(
+      QuotedEntityChecker checker, String template, String value) throws Exception {
+    return TemplateHelper.getStringAnnotation(checker, template, value);
+  }
+
+  /**
+   * Return a typed annotation for the given template string and value. The template string format
+   * is "AT [name]^^[datatype]" and the value is any string.
+   *
+   * @param checker used to resolve the annotation property and datatype
+   * @param template the template string
+   * @param value the value for the annotation
+   * @return a new annotation axiom with property and typed literal value
+   * @throws Exception if the annotation property cannot be found
+   */
+  public static OWLAnnotation getTypedAnnotation(
+      QuotedEntityChecker checker, String template, String value) throws Exception {
+    return TemplateHelper.getTypedAnnotation(checker, template, value);
+  }
+
+  /**
+   * Return a language tagged annotation for the given template and value. The template string
+   * format is "AL [name]@[lang]" and the value is any string.
+   *
+   * @param checker used to resolve the annotation property
+   * @param template the template string
+   * @param value the value for the annotation
+   * @return a new annotation axiom with property and language tagged literal
+   * @throws Exception if the annotation property cannot be found
+   */
+  public static OWLAnnotation getLanguageAnnotation(
+      QuotedEntityChecker checker, String template, String value) throws Exception {
+    return TemplateHelper.getLanguageAnnotation(checker, template, value);
+  }
+
+  /**
+   * Return an IRI annotation for the given template string and value. The template string format is
+   * "AI [name]" and the value is a string that can be interpreted as an IRI.
+   *
+   * @param checker used to resolve the annotation property
+   * @param template the template string
+   * @param value the IRI value for the annotation
+   * @return a new annotation axiom with property and an IRI value
+   * @throws Exception if the annotation property cannot be found
+   */
+  public static OWLAnnotation getIRIAnnotation(
+      QuotedEntityChecker checker, String template, IRI value) throws Exception {
+    return TemplateHelper.getIRIAnnotation(checker, template, value);
+  }
+
+  /**
+   * Use type, id, and label information to get an entity from the data in a row. Requires either:
+   * an id (default type is owl:Class); an id and type; or a label.
+   *
+   * @param checker for looking up labels
+   * @param type the IRI of the type for this entity, or null
+   * @param id the ID for this entity, or null
+   * @param label the label for this entity, or null
+   * @return the entity
+   * @throws Exception if the entity cannot be created
+   */
+  public static OWLEntity getEntity(QuotedEntityChecker checker, IRI type, String id, String label)
+      throws Exception {
+    return TemplateHelper.getEntity(checker, type, id, label);
+  }
+
+  /**
+   * Get a list of the IRIs defined in a set of template tables.
+   *
+   * @param tables a map from table names to tables
+   * @param ioHelper used to find entities by name
+   * @return a list of IRIs
+   * @throws Exception when names or templates cannot be handled
+   */
+  public static List<IRI> getIRIs(Map<String, List<List<String>>> tables, IOHelper ioHelper)
+      throws Exception {
+    return TemplateHelper.getIRIs(tables, ioHelper);
+  }
+
+  /**
+   * Get a list of the IRIs defined in a template table.
+   *
+   * @param tableName the name of the table
+   * @param rows the table of data
+   * @param ioHelper used to find entities by name
+   * @return a list of IRIs
+   * @throws Exception when names or templates cannot be handled
+   */
+  public static List<IRI> getIRIs(String tableName, List<List<String>> rows, IOHelper ioHelper)
+      throws Exception {
+    return TemplateHelper.getIRIs(tableName, rows, ioHelper);
+  }
 
   /**
    * Return true if the template string is valid, false otherwise.


### PR DESCRIPTION
Use the `japicmp` Maven plugin to ensure backwards compatibility of binary and source APIs.

- http://siom79.github.io/japicmp
- http://siom79.github.io/japicmp/MavenPlugin.html

The checks are run on `mvn verify` and results are in `robot-core/target/japicmp/`.

The build currently fails because we've broken compatibility with 1.0.0 in several ways.

I'm not 100% sure this is a good idea, but I want to give it a try.

@rctauber: Please try this out.