### PR TITLE
Display the help when no argument is given on the command line.

### DIFF
--- a/robot-command/src/main/java/org/obolibrary/robot/CommandManager.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandManager.java
@@ -154,11 +154,15 @@ public class CommandManager implements Command {
    */
   public CommandState execute(CommandState state, String[] args) throws Exception {
     // Maybe print general help or version info
-    String commandName = args[0];
-    if ("help".equals(commandName) && (args.length == 1)) {
+
+    if ((args.length == 0) || "help".equals(args[0]) && (args.length == 1)) {
       printHelp();
       return state;
-    } else if ("help".equals(commandName)) {
+    }
+
+    String commandName = args[0];
+
+    if ("help".equals(commandName)) {
       commandName = args[1];
       Command cmd = commands.get(commandName);
       CommandLineHelper.printHelp(cmd.getUsage(), cmd.getOptions());

--- a/robot-command/src/main/java/org/obolibrary/robot/ExceptionHelper.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ExceptionHelper.java
@@ -24,8 +24,10 @@ public class ExceptionHelper {
     String msg = trimExceptionClass(exception);
     if (msg != null) {
       String exceptionID = getExceptionID(msg);
-      System.out.println(trimExceptionID(msg));
-      System.out.println("For details see: http://robot.obolibrary.org/" + exceptionID);
+      if (exceptionID != null) {
+        System.out.println(trimExceptionID(msg));
+        System.out.println("For details see: http://robot.obolibrary.org/" + exceptionID);
+      }
     }
     // Will only print with --very-very-verbose (DEBUG level)
     if (logger.isDebugEnabled()) {
@@ -44,16 +46,17 @@ public class ExceptionHelper {
    * @return exception ID or empty string
    */
   private static String getExceptionID(String msg) {
-    String exceptionID = "";
+    String exceptionID;
     try {
       exceptionID =
           msg.substring(0, msg.indexOf("ERROR") + 5).trim().toLowerCase().replace(" ", "-");
-    } catch (NullPointerException e) {
+    } catch (Exception e) {
       logger.debug("Malformed exception message: {}", msg);
+      return null;
     }
     if (!exceptionID.contains("#")) {
       logger.debug("Missing exception ID: {}", msg);
-      exceptionID = "";
+      return null;
     }
     return exceptionID;
   }


### PR DESCRIPTION
It is still a bit redundant to make if/else if with return statements, but it solves the issue. We could make it cleaner by first checking arg length and then doing the case by case.