### PR TITLE
Ignore obo2owl logging in robot-command

### DIFF
--- a/robot-command/src/main/resources/log4j.properties
+++ b/robot-command/src/main/resources/log4j.properties
@@ -2,5 +2,6 @@ log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 #log4j.appender.console.layout.ConversionPattern=%-5p %m%n
 log4j.appender.console.layout.ConversionPattern=%d %-5p %c - %m%n
+log4j.logger.org.obolibrary.obo2owl=off
 log4j.logger.user=DEBUG
 log4j.rootLogger=ERROR, console


### PR DESCRIPTION
The logging is currently only ignored in `robot-core`, so the logging still appears in some of the commands. This will fully resolve #303.