### PR TITLE
Doc updates for #252

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -22,7 +22,7 @@
         <p align="right">
           - - - - - - - - - -<br>
           <a href="{{ site.github.repository_url }}">view on github</a><br>
-          <a href="/">usage</a><br>
+          <a href="/">getting started</a><br>
           <a href="/errors">common errors</a><br>
           <a href="/chaining">chaining commands</a><br>
           <a href="/global">global options</a><br>
@@ -40,7 +40,7 @@
           <a href="/reason">reason</a><br>
           <a href="/reduce">reduce</a><br>
           <a href="/relax">relax</a><br>
-          <!--<a href="/remove/remove">remove</a><br>-->
+          <a href="/remove">remove</a><br>
           <a href="/repair">repair</a><br>
           <a href="/report">report</a><br>
           <a href="/template">template</a><br>

--- a/docs/filter.md
+++ b/docs/filter.md
@@ -20,14 +20,14 @@ robot filter --input obi.owl --term OBI:0000070 --select annotations
 
 ## Examples
 
-1. Copy a class ('organ') and all its descendants, with all annotations:
+Copy a class ('organ') and all its descendants, with all annotations:
 
     robot filter --input uberon_module.owl\
      --term UBERON:0000062\
      --select "annotations self descendants"\
      --output results/filter_class.owl
 
-2. Copy all of OBI except descendants of 'assay' (`remove` is preferred):
+Copy all of OBI except descendants of 'assay' (`remove` is preferred):
 
     robot filter --input uberon_module.owl\
      --term UBERON:0000062\
@@ -36,7 +36,7 @@ robot filter --input obi.owl --term OBI:0000070 --select annotations
      --select complement\
      --output results/remove_class.owl
 
-4. Copy a subset of classes based on an annotation property:
+Copy a subset of classes based on an annotation property:
 
 ```
 robot filter --input foo.owl --select classes --select "oboInOwl:inSubset='bar'"

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,27 +10,37 @@ ROBOT is a tool for working with [Open Biomedical Ontologies](http://obofoundry.
 See our homepage <http://robot.obolibrary.org> for documentation and examples of commands, and our JavaDocs for [`robot-core`](http://www.javadoc.io/doc/org.obolibrary.robot/robot-core/) and [`robot-command`](http://www.javadoc.io/doc/org.obolibrary.robot/robot-command/).
 
 
-## 1. Command Line Tool
+## 1. Getting Started
 
-The command-line tool is packaged a Java JAR file and can be run via the `robot` shell script.
+The command-line tool is packaged a Java JAR file and can be run via the `robot` shell script. Before getting started, make sure you have [Java 8 or later](https://www.java.com/en/download/) installed. Check by entering `java -version` on the command line.
 
-1. Make sure that you have [Java 8 or later installed](https://www.java.com/en/download/installed.jsp)
-2. Download **two** files: the `robot.jar` file from the [latest release](https://github.com/ontodev/robot/releases/latest), and the right script for your platform:
-    - [`robot`](https://github.com/ontodev/robot/raw/master/bin/robot) shell script for Unix, Linux, and Mac OS X
-    - [`robot.bat`](https://github.com/ontodev/robot/raw/master/bin/robot.bat) batch script for Windows
-3. Put both files on your [system PATH](https://en.wikipedia.org/wiki/PATH_(variable)):
-    - on Unix, Linux, and Mac OS X this could be `/usr/local/bin/`
-    - on Windows this could be `C:\Windows\`
-    - or [update your PATH](https://docs.oracle.com/javase/tutorial/essential/environment/paths.html) to include your chosen directory
-    - NOTE: both files must be in the same directory
-4. Make sure `robot` is executable:
-    - Mac: run the command `chmod u+x robot` (may require `sudo`)
-    - Windows: run the command `icacls robot /grant Users:RX /T`
+### Mac & Linux
+
+1. Download the `robot.jar` file from the [latest release](https://github.com/ontodev/robot/releases/latest).
+2. Save the [ROBOT shell script](https://github.com/ontodev/robot/raw/master/bin/robot).
+    - OR enter `curl https://raw.githubusercontent.com/ontodev/robot/master/bin/robot > robot` in the same directory as `robot.jar` to download it from the terminal.
+3. Put both files on your [system PATH](https://en.wikipedia.org/wiki/PATH_(variable)) in the same directory.
+    - this could be `/usr/local/bin/`
+    - OR [update your PATH](https://docs.oracle.com/javase/tutorial/essential/environment/paths.html) to include the new directory. Follow the Solaris/Linux directions for Mac OS, except instead of updating `.bashrc`, you will need to update your `.bash_profile`.
+4. Make sure `robot` is executable by running `sudo chmod u+x robot` from the terminal in the same directory. This will require you to enter you password.
 5. Now you should be able to run ROBOT from a command line:
 
         robot help
 
-## 2. Library
+### Windows
+
+1. Download the `robot.jar` file from the [latest release](https://github.com/ontodev/robot/releases/latest).
+2. Save the [ROBOT batch script](https://github.com/ontodev/robot/raw/master/bin/robot.bat).
+    - OR enter `echo java -jar %~dp0robot.jar %* > robot.bat` in the same directory as `robot.jar` to create the batch script.
+3. Put both files on your [system PATH](https://en.wikipedia.org/wiki/PATH_(variable)) in the same directory.
+    - this could be `C:\Windows\`
+    - OR [update your PATH](https://docs.oracle.com/javase/tutorial/essential/environment/paths.html) to include the new directory.
+4. Make sure `robot.bat` is executable by running `icacls robot.bat /grant Users:RX /T` from the command prompt in the same directory.
+5. Now you should be able to run ROBOT from a command line:
+
+        robot help
+
+## 2. Using the Library
 
 ROBOT is written in Java, and can be used from any language that runs on the Java Virtual Machine. It's available on Maven Central. The code is divided into two parts:
 

--- a/docs/materialize.md
+++ b/docs/materialize.md
@@ -1,15 +1,15 @@
 # Materialize
 
-Robot can materialize all parent superclass and superclass expressions using the expression materializing reasoner, which wraps an existing OWL Reasoner
+Robot can materialize inferred superclasses and superclass expressions using the expression materializing reasoner, which wraps an existing OWL Reasoner
 
     robot materialize --reasoner ELK \
       --input emr_example.obo \
       --term BFO:0000050  \
       --output results/emr_output.obo
 
-This operation is similar to the reason command, but will also assert parents of the form `P some D`, for all P in the set passed in via `--term`
+This operation is similar to the reason command, but will also assert parents of the form `P some D`, for all P (properties) in the set passed in via `--term` or `--term-file`.
 
-This can be [chained](/chaining) with [remove](/remove) (by specifying a set of properties to *keep*, then selecing the complement properties of that set) and [reduce](/reduce) to create a complete ontology subset:
+This can be [chained](/chaining) with [remove](/remove) and [reduce](/reduce) to create a complete ontology subset. First, `materialize` asserts the inferred superclass expressions. Then, `remove` takes out any object properties (and the axioms that they are used in) that we do not need in the subset. Finally, `reduce` removes any duplicated axioms created by `materialize`.
 
     robot materialize --reasoner ELK \
       --input emr_example.obo \
@@ -17,4 +17,4 @@ This can be [chained](/chaining) with [remove](/remove) (by specifying a set of 
       --select complement --select object-properties \
       reduce --output results/emr_reduced.obo
 
-See [reason](/reason) for details on supported reasoners (EMR is not supported in `materialize`).
+See [reason](/reason) for details on supported reasoners (EMR is not supported in `materialize`, as it is used to wrap another reasoner here).

--- a/docs/reason.md
+++ b/docs/reason.md
@@ -1,6 +1,8 @@
 # Reason
 
-One of the main benefits of working with OWL is the availability of powerful automated reasoners. There are several reasoners available, and each has different capabilities and characteristics. For this example we'll be using <a href="https://code.google.com/p/elk-reasoner/" target="_blank">ELK</a>, a very fast reasoner that supports the EL subset of OWL 2.
+One of the main benefits of working with OWL is the availability of powerful automated reasoners. Reasoning involves two steps: logical validation (described in detail below) and automatic classification. Automatic classification involves asserting all inferred superclasses.
+
+There are several reasoners available, and each has different capabilities and characteristics. For this example we'll be using <a href="https://code.google.com/p/elk-reasoner/" target="_blank">ELK</a>, a very fast reasoner that supports the EL subset of OWL 2.
 
     robot reason --reasoner ELK \
       --input ribosome.owl \
@@ -37,7 +39,7 @@ If no `--reasoner` is provided, ROBOT will default to ELK. The following other r
 
 ## Logical Validation
 
-ROBOT will always perform a logical validation check prior to reasoning. Formally, this is known as testing for *incoherency*, i.e. the presence of either a logical inconsistency or unsatisfiable classes. If either of these hold true, the reason operation will fail and robot will exit with a non-zero code, after reporting the problematic classes.
+ROBOT will always perform a logical validation check prior to automatic classification. Formally, this is known as testing for *incoherency*, i.e. the presence of either a logical inconsistency or unsatisfiable classes. If either of these hold true, the reason operation will fail and robot will exit with a non-zero code, after reporting the problematic classes.
 
 You can perform detailed debugging using an environment like Protege - load the ontology, switch on the reasoner and use the explain feature. For example, if you have unsatisfiable classes, find one of them (they should show up red) and click on the `?` where it says `EquivalentTo Nothing`.
 

--- a/docs/remove.md
+++ b/docs/remove.md
@@ -71,7 +71,7 @@ Terms can also be selected from the set based on axioms. This can be helpful if 
 
 ## Examples
 
-1. Remove a class ('organ') and and all its descendants:
+Remove a class ('organ') and and all its descendants:
 
     robot remove --input uberon_module.owl \
       --term UBERON:0000062 \
@@ -79,27 +79,26 @@ Terms can also be selected from the set based on axioms. This can be helpful if 
       --trim true \
       --output results/remove_class.owl
 
-
-2. Remove all individuals from OBI:
+Remove all individuals from OBI:
 
 ```
 robot remove --input obi.owl --select individuals --trim true
 ```
 
-3. Remove all anonymous entities from the UBERON module:
+Remove all anonymous entities from the UBERON module:
 
     robot remove --input uberon_module.owl \
       --select anonymous --trim true \
       --output results/remove_anonymous.owl
 
-4. Remove all deprecated classes from OBI:
+Remove all deprecated classes from OBI:
 
 ```
 robot remove --input obi.owl \
   --select "owl:deprecated='true'^^xsd:boolean" --trim true
 ```
 
-5. *Filter* for only desired annotation properties (in this case, label and ID). This works by actually *removing* the opposite set of annotation properties (complement annotation-properties) from the ontology:
+*Filter* for only desired annotation properties (in this case, label and ID). This works by actually *removing* the opposite set of annotation properties (complement annotation-properties) from the ontology:
 
     robot remove --input uberon_module.owl \
       --term rdfs:label --term oboInOwl:id --trim true \


### PR DESCRIPTION
* "usage" changed to "getting started"
* improvements in instructions for CLI installation
* more detail for `materialize` and `reason`
* `remove` was missing from the links
* fixed `filter` and `remove` example formatting

Does not include `extract` improvements, which are covered by #345