### PR TITLE
Add new Exceptions, optimize codebase, see #349

### DIFF
--- a/docs/query.md
+++ b/docs/query.md
@@ -48,6 +48,10 @@ The names of the graphs correspond to the ontology IRIs of the imports. If the i
 
 You must specify a query to execute with `--query` or `--queries`.
 
+### Query Parse Error
+
+The query was not able to be parsed. Often, this is as a result of an undefined prefix in the query. See the error message for more details.
+
 ### Query Type Error
 
 Each SPARQL query should be a SELECT, ASK, DESCRIBE, or CONSTRUCT.

--- a/docs/report.md
+++ b/docs/report.md
@@ -75,6 +75,14 @@ INFO	file:///absolute/path/to/other_query.rq
 
 ## Error Messages
 
+### Fail On Error
+
+Only `info`, `warn`, and `error` are valid inputs for `--fail-on`.
+
+### Missing Entity Binding
+
+All queries must bind `?entity ?property ?value` for correct formatting. If `?entity` is ever `null`, the query cannot be reported on.
+
 ### Report Level Error
 
 The logging level defined in a profile must be `ERROR`, `WARN`, or `INFO`.

--- a/robot-command/src/main/java/org/obolibrary/robot/AnnotateCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/AnnotateCommand.java
@@ -170,8 +170,8 @@ public class AnnotateCommand implements Command {
       OntologyHelper.removeOntologyAnnotations(ontology);
     }
 
-    String property = null;
-    String value = null;
+    String property;
+    String value;
 
     // Add annotations with PROP VALUE
     List<String> annotationItems = CommandLineHelper.getOptionValues(line, "annotation");
@@ -209,7 +209,7 @@ public class AnnotateCommand implements Command {
     while (langItems.size() > 0) {
       hasAnnotation = true;
       // Check for valid input
-      String lang = null;
+      String lang;
       try {
         property = langItems.remove(0);
         value = langItems.remove(0);
@@ -227,7 +227,7 @@ public class AnnotateCommand implements Command {
     while (typedItems.size() > 0) {
       hasAnnotation = true;
       // Check for valid input
-      String type = null;
+      String type;
       try {
         property = typedItems.remove(0);
         value = typedItems.remove(0);
@@ -255,7 +255,7 @@ public class AnnotateCommand implements Command {
     }
 
     // Load any annotation files as ontologies and merge them in
-    List<OWLOntology> ontologies = new ArrayList<OWLOntology>();
+    List<OWLOntology> ontologies = new ArrayList<>();
     List<String> paths = CommandLineHelper.getOptionValues(line, "annotation-file");
     for (String path : paths) {
       ontologies.add(ioHelper.loadOntology(path));

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
@@ -777,14 +777,11 @@ public class CommandLineHelper {
       // This will be used any time `robot --version` is entered on command line
       String cls = CommandLineHelper.class.getName().replace(".", "/") + ".class";
       resource = CommandLineHelper.class.getClassLoader().getResource(cls);
-      String protocol;
-      try {
-        protocol = resource.getProtocol();
-      } catch (NullPointerException e) {
+      if (resource == null) {
         throw new IOException(
-            "Cannot access version information from JAR. The directory address has no protocol.");
+            "Cannot access version information from JAR. The resource does not exist.");
       }
-      if (protocol.equals("jar")) {
+      if (resource.getProtocol().equals("jar")) {
         // Get the JAR path and open as JAR file
         String jarPath = resource.getPath().substring(5, resource.getPath().indexOf("!"));
         try (JarFile jar = new JarFile(URLDecoder.decode(jarPath, "UTF-8"))) {

--- a/robot-command/src/main/java/org/obolibrary/robot/DiffCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/DiffCommand.java
@@ -1,6 +1,7 @@
 package org.obolibrary.robot;
 
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 import org.apache.commons.cli.CommandLine;
@@ -22,11 +23,8 @@ public class DiffCommand implements Command {
   /** Namespace for error messages. */
   private static final String NS = "diff#";
 
-  private static final String doubleLeftError =
-      NS + "DOUBLE INPUT ERROR only one left ontology allowed";
-
-  private static final String doubleRightError =
-      NS + "DOUBLE INPUT ERROR only one right ontology allowed";
+  private static final String doubleInputError =
+      NS + "DOUBLE INPUT ERROR only one of each side (right/left) allowed";
 
   /** Error message when --left is not provided. */
   private static final String missingLeftError =
@@ -120,36 +118,21 @@ public class DiffCommand implements Command {
     }
 
     OWLOntology leftOntology = null;
-    if (state != null && state.getOntology() != null) {
+    if (state.getOntology() != null) {
       leftOntology = state.getOntology();
     }
     if (leftOntology == null) {
       String leftOntologyPath = CommandLineHelper.getOptionalValue(line, "left");
       String leftOntologyIRI = CommandLineHelper.getOptionalValue(line, "left-iri");
-      if (leftOntologyPath != null && leftOntologyIRI != null) {
-        throw new IllegalArgumentException(doubleLeftError);
-      } else if (leftOntologyPath != null) {
-        leftOntology = ioHelper.loadOntology(leftOntologyPath);
-      } else if (leftOntologyIRI != null) {
-        leftOntology = ioHelper.loadOntology(IRI.create(leftOntologyIRI));
-      }
+      leftOntology = setOntology(ioHelper, leftOntologyPath, leftOntologyIRI);
     }
     if (leftOntology == null) {
       throw new IllegalArgumentException(missingLeftError);
     }
 
-    OWLOntology rightOntology = null;
-    if (rightOntology == null) {
-      String rightOntologyPath = CommandLineHelper.getOptionalValue(line, "right");
-      String rightOntologyIRI = CommandLineHelper.getOptionalValue(line, "right-iri");
-      if (rightOntologyPath != null && rightOntologyIRI != null) {
-        throw new IllegalArgumentException(doubleRightError);
-      } else if (rightOntologyPath != null) {
-        rightOntology = ioHelper.loadOntology(rightOntologyPath);
-      } else if (rightOntologyIRI != null) {
-        rightOntology = ioHelper.loadOntology(IRI.create(rightOntologyIRI));
-      }
-    }
+    String rightOntologyPath = CommandLineHelper.getOptionalValue(line, "right");
+    String rightOntologyIRI = CommandLineHelper.getOptionalValue(line, "right-iri");
+    OWLOntology rightOntology = setOntology(ioHelper, rightOntologyPath, rightOntologyIRI);
     if (rightOntology == null) {
       throw new IllegalArgumentException(missingRightError);
     }
@@ -167,5 +150,27 @@ public class DiffCommand implements Command {
     writer.close();
 
     return state;
+  }
+
+  /**
+   * Given an IOHelper, a path (or null), and an IRI (or null), return the OWLOntology loaded by
+   * either path or IRI. Either path or iri must be included (not null), but both cannot be
+   * included.
+   *
+   * @param ioHelper IOHelper to load ontology
+   * @param path path to local ontology, or null
+   * @param iri IRI to remote ontology, or null
+   * @return loaded OWLOntology
+   * @throws IOException on issue loading ontology
+   */
+  private static OWLOntology setOntology(IOHelper ioHelper, String path, String iri)
+      throws IOException {
+    if (path != null && iri != null) {
+      throw new IllegalArgumentException(doubleInputError);
+    } else if (path != null) {
+      return ioHelper.loadOntology(path);
+    } else if (iri != null) {
+      return ioHelper.loadOntology(IRI.create(iri));
+    } else return null;
   }
 }

--- a/robot-command/src/main/java/org/obolibrary/robot/ExceptionHelper.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ExceptionHelper.java
@@ -27,7 +27,11 @@ public class ExceptionHelper {
       if (exceptionID != null) {
         System.out.println(trimExceptionID(msg));
         System.out.println("For details see: http://robot.obolibrary.org/" + exceptionID);
+      } else {
+        System.out.println(msg);
       }
+    } else {
+      System.out.println(exception.getMessage());
     }
     // Will only print with --very-very-verbose (DEBUG level)
     if (logger.isDebugEnabled()) {

--- a/robot-command/src/main/java/org/obolibrary/robot/MaterializeCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/MaterializeCommand.java
@@ -132,7 +132,7 @@ public class MaterializeCommand implements Command {
     }
 
     Set<IRI> terms = CommandLineHelper.getTerms(ioHelper, line, true);
-    Set<OWLObjectProperty> properties = new HashSet<OWLObjectProperty>();
+    Set<OWLObjectProperty> properties = new HashSet<>();
     for (IRI term : terms) {
       properties.add(
           ontology.getOWLOntologyManager().getOWLDataFactory().getOWLObjectProperty(term));

--- a/robot-command/src/main/java/org/obolibrary/robot/MergeCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/MergeCommand.java
@@ -107,7 +107,7 @@ public class MergeCommand implements Command {
     List<OWLOntology> inputOntologies = new ArrayList<>();
     // inputOntologies should not be empty
     boolean notEmpty = false;
-    if (state != null && state.getOntology() != null) {
+    if (state.getOntology() != null) {
       notEmpty = true;
       inputOntologies.add(state.getOntology());
     }

--- a/robot-command/src/main/java/org/obolibrary/robot/RemoveCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/RemoveCommand.java
@@ -134,19 +134,21 @@ public class RemoveCommand implements Command {
         removeImports = true;
         selectGroup.remove("imports");
       }
-      selectGroups.add(selectGroup);
+      if (!selectGroup.isEmpty()) {
+        selectGroups.add(selectGroup);
+      }
     }
 
-    // If removing imports, and there are no objects, save and return
-    if (removeImports && objects.isEmpty()) {
+    // If removing imports, and there are no other selects, save and return
+    if (removeImports && selectGroups.isEmpty()) {
       if (trim) {
         OntologyHelper.trimOntology(ontology);
       }
       CommandLineHelper.maybeSaveOutput(line, ontology);
       state.setOntology(ontology);
       return state;
-      // Otherwise, proceed, and if objects is empty, add all objects
     } else if (objects.isEmpty()) {
+      // Otherwise, proceed, and if objects is empty, add all objects
       for (OWLAxiom axiom : ontology.getAxioms()) {
         objects.addAll(OntologyHelper.getObjects(axiom));
       }

--- a/robot-command/src/main/java/org/obolibrary/robot/TemplateCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/TemplateCommand.java
@@ -132,7 +132,7 @@ public class TemplateCommand implements Command {
     if (templatePaths.size() == 0) {
       throw new IllegalArgumentException(missingTemplateError);
     }
-    Map<String, List<List<String>>> tables = new LinkedHashMap<String, List<List<String>>>();
+    Map<String, List<List<String>>> tables = new LinkedHashMap<>();
     for (String templatePath : templatePaths) {
       tables.put(templatePath, TemplateHelper.readTable(templatePath));
     }
@@ -157,13 +157,13 @@ public class TemplateCommand implements Command {
       OWLOntology ancestors =
           MireotOperation.getAncestors(
               inputOntology, null, iris, MireotOperation.getDefaultAnnotationProperties());
-      ontologies = new ArrayList<OWLOntology>();
+      ontologies = new ArrayList<>();
       ontologies.add(ancestors);
       MergeOperation.mergeInto(ontologies, outputOntology, includeAnnotations, collapseImports);
     }
 
     // Either merge-then-save, save-then-merge, or don't merge
-    ontologies = new ArrayList<OWLOntology>();
+    ontologies = new ArrayList<>();
     ontologies.add(outputOntology);
     boolean mergeBefore = CommandLineHelper.getBooleanValue(line, "merge-before", false, true);
     boolean mergeAfter = CommandLineHelper.getBooleanValue(line, "merge-after", false, true);

--- a/robot-command/src/main/java/org/obolibrary/robot/UnmergeCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/UnmergeCommand.java
@@ -101,9 +101,9 @@ public class UnmergeCommand implements Command {
       state = new CommandState();
     }
 
-    List<OWLOntology> inputOntologies = new ArrayList<OWLOntology>();
+    List<OWLOntology> inputOntologies = new ArrayList<>();
     boolean notEmpty = false;
-    if (state != null && state.getOntology() != null) {
+    if (state.getOntology() != null) {
       notEmpty = true;
       inputOntologies.add(state.getOntology());
     }

--- a/robot-command/src/main/java/org/obolibrary/robot/ValidateProfileCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ValidateProfileCommand.java
@@ -29,7 +29,7 @@ public class ValidateProfileCommand implements Command {
 
   /** Error message when the ontology validates provided profile. Expects ontology IRI, profile. */
   private static final String profileViolationError =
-      NS + "PROFILE VIOLATION ERROR %1 violates profile %2";
+      NS + "PROFILE VIOLATION ERROR %s violates profile %s";
 
   /** Initialize the command. */
   public ValidateProfileCommand() {

--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -49,8 +49,8 @@
           </newVersion>
           <parameter>
             <!-- see documentation: http://siom79.github.io/japicmp/MavenPlugin.html -->
-            <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
-            <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+            <breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications>
+            <breakBuildOnSourceIncompatibleModifications>false</breakBuildOnSourceIncompatibleModifications>
             <!-- Temporarily exclude QueryOperation for Jena upgrade #314. -->
             <excludes>
               <exclude>org.obolibrary.robot.QueryOperation</exclude>

--- a/robot-core/src/main/java/org/obolibrary/robot/CatalogElementHandler.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/CatalogElementHandler.java
@@ -7,7 +7,6 @@ import org.semanticweb.owlapi.model.IRI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 /** A SAX DefaultHandler for reading OWL Catalog files. */
@@ -41,11 +40,9 @@ public class CatalogElementHandler extends DefaultHandler {
    * @param localName the local name of the start element
    * @param qName the qualified name of the start element
    * @param attributes the attributes object of the start element
-   * @throws SAXException on any problem
    */
   @Override
-  public void startElement(String uri, String localName, String qName, Attributes attributes)
-      throws SAXException {
+  public void startElement(String uri, String localName, String qName, Attributes attributes) {
     if (!"uri".equals(qName)) {
       return;
     }
@@ -55,10 +52,6 @@ public class CatalogElementHandler extends DefaultHandler {
       return;
     }
     IRI fromIRI = IRI.create(fromString);
-    if (fromIRI == null) {
-      return;
-    }
-
     String toString = attributes.getValue("uri");
     if (toString == null) {
       return;
@@ -69,7 +62,7 @@ public class CatalogElementHandler extends DefaultHandler {
     // then treat this as a "file://" IRI.
     // Otherwise treat this as web IRI.
     IRI toIRI = null;
-    if (parentFolder != null && toString.indexOf(":") < 0) {
+    if (parentFolder != null && !toString.contains(":")) {
       File toFile = new File(toString);
       if (!toFile.isAbsolute()) {
         toFile = new File(parentFolder, toString);

--- a/robot-core/src/main/java/org/obolibrary/robot/CatalogXmlIRIMapper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/CatalogXmlIRIMapper.java
@@ -8,6 +8,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -121,7 +122,7 @@ public class CatalogXmlIRIMapper implements OWLOntologyIRIMapper {
    * @return the mapped IRI, usually to a local file
    */
   @Override
-  public IRI getDocumentIRI(IRI ontologyIRI) {
+  public IRI getDocumentIRI(@Nonnull IRI ontologyIRI) {
     return mappings.get(ontologyIRI);
   }
 
@@ -147,7 +148,7 @@ public class CatalogXmlIRIMapper implements OWLOntologyIRIMapper {
     factory.setValidating(false);
 
     try {
-      final Map<IRI, IRI> mappings = new HashMap<IRI, IRI>();
+      final Map<IRI, IRI> mappings = new HashMap<>();
       SAXParser saxParser = factory.newSAXParser();
       saxParser.parse(inputStream, new CatalogElementHandler(parentFolder, mappings));
       return mappings;

--- a/robot-core/src/main/java/org/obolibrary/robot/DiffOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/DiffOperation.java
@@ -59,16 +59,16 @@ public class DiffOperation {
   public static boolean compare(OWLOntology ontology1, OWLOntology ontology2, Writer writer)
       throws IOException {
 
-    Map<IRI, String> labels = OntologyHelper.getLabels(ontology1);
-    labels.putAll(OntologyHelper.getLabels(ontology2));
+    // Map<IRI, String> labels = OntologyHelper.getLabels(ontology1);
+    // labels.putAll(OntologyHelper.getLabels(ontology2));
 
     Set<String> strings1 = getAxiomStrings(ontology1);
     Set<String> strings2 = getAxiomStrings(ontology2);
     Set<String> sorted;
 
-    Set<String> strings1minus2 = new HashSet<String>(strings1);
+    Set<String> strings1minus2 = new HashSet<>(strings1);
     strings1minus2.removeAll(strings2);
-    Set<String> strings2minus1 = new HashSet<String>(strings2);
+    Set<String> strings2minus1 = new HashSet<>(strings2);
     strings2minus1.removeAll(strings1);
 
     if (strings1minus2.size() == 0 && strings2minus1.size() == 0) {
@@ -83,9 +83,9 @@ public class DiffOperation {
     }
 
     writer.write(strings1minus2.size() + " axioms in Ontology 1 but not in Ontology 2:\n");
-    sorted = new TreeSet<String>();
+    sorted = new TreeSet<>();
     for (String axiom : strings1minus2) {
-      sorted.add("- " + addLabels(labels, axiom) + "\n");
+      sorted.add("- " + axiom + "\n");
     }
     for (String axiom : sorted) {
       writer.write(axiom);
@@ -94,9 +94,9 @@ public class DiffOperation {
     writer.write("\n");
 
     writer.write(strings2minus1.size() + " axioms in Ontology 2 but not in Ontology 1:\n");
-    sorted = new TreeSet<String>();
+    sorted = new TreeSet<>();
     for (String axiom : strings2minus1) {
-      sorted.add("+ " + addLabels(labels, axiom) + "\n");
+      sorted.add("+ " + axiom + "\n");
     }
     for (String axiom : sorted) {
       writer.write(axiom);
@@ -117,8 +117,8 @@ public class DiffOperation {
     Matcher matcher = iriPattern.matcher(axiom);
     StringBuffer sb = new StringBuffer();
     while (matcher.find()) {
-      String iri = matcher.group(1);
-      String id = iri;
+      IRI iri = IRI.create(matcher.group(1));
+      String id = iri.toString();
       if (id.startsWith(oboBase)) {
         id = id.substring(oboBase.length());
       }
@@ -139,7 +139,7 @@ public class DiffOperation {
    * @return a set of strings, one for each axiom in the ontology
    */
   public static Set<String> getAxiomStrings(OWLOntology ontology) {
-    Set<String> strings = new HashSet<String>();
+    Set<String> strings = new HashSet<>();
     strings.add(ontology.getOntologyID().toString());
     for (OWLAxiom axiom : ontology.getAxioms()) {
       strings.add(axiom.toString().replaceAll("\\n", "\\n"));

--- a/robot-core/src/main/java/org/obolibrary/robot/ExtractOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExtractOperation.java
@@ -38,7 +38,7 @@ public class ExtractOperation {
       throws OWLOntologyCreationException {
     logger.debug("Extracting...");
 
-    Set<OWLEntity> entities = new HashSet<OWLEntity>();
+    Set<OWLEntity> entities = new HashSet<>();
     for (IRI term : terms) {
       entities.addAll(inputOntology.getEntitiesInSignature(term, true));
     }

--- a/robot-core/src/main/java/org/obolibrary/robot/MaterializeOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/MaterializeOperation.java
@@ -40,7 +40,7 @@ public class MaterializeOperation {
    * @return a map with default values for all available options
    */
   public static Map<String, String> getDefaultOptions() {
-    Map<String, String> options = new HashMap<String, String>();
+    Map<String, String> options = new HashMap<>();
     options.put("create-new-ontology", "false");
     return options;
   }
@@ -109,8 +109,6 @@ public class MaterializeOperation {
         new ExpressionMaterializingReasonerFactory(reasonerFactory);
     ExpressionMaterializingReasoner emr = merf.createReasoner(ontology);
     ReasonerHelper.validate(emr);
-
-    startTime = System.currentTimeMillis();
 
     Set<OWLAxiom> newAxioms = new HashSet<>();
 

--- a/robot-core/src/main/java/org/obolibrary/robot/MergeOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/MergeOperation.java
@@ -185,7 +185,7 @@ public class MergeOperation {
             .addAxioms(targetOntology, ontology.getAxioms(Imports.INCLUDED));
       } else {
         // Merge the ontologies with imports excluded
-        Set<OWLOntology> imports = targetOntology.getDirectImports();
+        Set<OWLImportsDeclaration> imports = targetOntology.getImportsDeclarations();
         try {
           OntologyHelper.removeImports(targetOntology);
         } catch (Exception e) {
@@ -198,14 +198,8 @@ public class MergeOperation {
         OWLOntologyManager manager = targetOntology.getOWLOntologyManager();
         OWLDataFactory dataFactory = manager.getOWLDataFactory();
         // Re-add the imports
-        for (OWLOntology imp : imports) {
-          IRI importIRI = imp.getOntologyID().getOntologyIRI().orNull();
-          if (importIRI != null) {
-            OWLImportsDeclaration dec = dataFactory.getOWLImportsDeclaration(importIRI);
-            manager.applyChange(new AddImport(targetOntology, dec));
-          } else {
-            logger.error("Failed to add import %s - IRI is null.", imp.getOntologyID());
-          }
+        for (OWLImportsDeclaration dec : imports) {
+          manager.applyChange(new AddImport(targetOntology, dec));
         }
       }
       if (includeAnnotations) {

--- a/robot-core/src/main/java/org/obolibrary/robot/MergeOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/MergeOperation.java
@@ -23,7 +23,7 @@ public class MergeOperation {
    * @return the new ontology
    */
   public static OWLOntology merge(OWLOntology ontology) {
-    List<OWLOntology> ontologies = new ArrayList<OWLOntology>();
+    List<OWLOntology> ontologies = new ArrayList<>();
     ontologies.add(ontology);
     // One ontology will always collapse the import closure
     mergeInto(ontologies, ontology, false, true);
@@ -51,7 +51,7 @@ public class MergeOperation {
    * @param ontologies the list of ontologies to merge
    * @param includeAnnotations if true, ontology annotations should be merged; annotations on
    *     imports are not merged
-   * @param collapseImportClosure if true, imports closure from all ontologies included
+   * @param collapseImportsClosure if true, imports closure from all ontologies included
    * @return the first ontology
    */
   public static OWLOntology merge(
@@ -87,7 +87,7 @@ public class MergeOperation {
    * @param targetOntology the ontology to merge axioms into
    */
   public static void mergeInto(OWLOntology ontology, OWLOntology targetOntology) {
-    List<OWLOntology> ontologies = new ArrayList<OWLOntology>();
+    List<OWLOntology> ontologies = new ArrayList<>();
     ontologies.add(ontology);
     // By default, do not include annotations and do not collapse import closure
     mergeInto(ontologies, targetOntology, false, false);
@@ -122,7 +122,7 @@ public class MergeOperation {
    */
   public static void mergeInto(
       OWLOntology ontology, OWLOntology targetOntology, boolean includeAnnotations) {
-    List<OWLOntology> ontologies = new ArrayList<OWLOntology>();
+    List<OWLOntology> ontologies = new ArrayList<>();
     ontologies.add(ontology);
     mergeInto(ontologies, targetOntology, includeAnnotations);
   }
@@ -143,7 +143,7 @@ public class MergeOperation {
       OWLOntology targetOntology,
       boolean includeAnnotations,
       boolean collapseImportsClosure) {
-    List<OWLOntology> ontologies = new ArrayList<OWLOntology>();
+    List<OWLOntology> ontologies = new ArrayList<>();
     ontologies.add(ontology);
     mergeInto(ontologies, targetOntology, includeAnnotations, collapseImportsClosure);
   }
@@ -199,9 +199,13 @@ public class MergeOperation {
         OWLDataFactory dataFactory = manager.getOWLDataFactory();
         // Re-add the imports
         for (OWLOntology imp : imports) {
-          OWLImportsDeclaration dec =
-              dataFactory.getOWLImportsDeclaration(imp.getOntologyID().getOntologyIRI().orNull());
-          manager.applyChange(new AddImport(targetOntology, dec));
+          IRI importIRI = imp.getOntologyID().getOntologyIRI().orNull();
+          if (importIRI != null) {
+            OWLImportsDeclaration dec = dataFactory.getOWLImportsDeclaration(importIRI);
+            manager.applyChange(new AddImport(targetOntology, dec));
+          } else {
+            logger.error("Failed to add import %s - IRI is null.", imp.getOntologyID());
+          }
         }
       }
       if (includeAnnotations) {
@@ -236,7 +240,7 @@ public class MergeOperation {
    * @return a map with default values for all available options
    */
   public static Map<String, String> getDefaultOptions() {
-    Map<String, String> options = new HashMap<String, String>();
+    Map<String, String> options = new HashMap<>();
     options.put("collapse-imports-closure", "false");
 
     return options;

--- a/robot-core/src/main/java/org/obolibrary/robot/MireotOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/MireotOperation.java
@@ -43,7 +43,7 @@ public class MireotOperation {
    * @return a set of annotation properties
    */
   public static Set<OWLAnnotationProperty> getDefaultAnnotationProperties() {
-    Set<OWLAnnotationProperty> annotationProperties = new HashSet<OWLAnnotationProperty>();
+    Set<OWLAnnotationProperty> annotationProperties = new HashSet<>();
     annotationProperties.add(dataFactory.getRDFSLabel());
     return annotationProperties;
   }
@@ -261,9 +261,6 @@ public class MireotOperation {
       Collection<OWLAnnotationProperty> subproperies =
           EntitySearcher.getSubProperties(entity.asOWLAnnotationProperty(), inputOntology, true);
       for (OWLAnnotationProperty subproperty : subproperies) {
-        if (subproperty == dataFactory.getOWLNothing()) {
-          continue;
-        }
         OntologyHelper.copy(inputOntology, outputOntology, subproperty, annotationProperties);
         outputManager.addAxiom(
             outputOntology,
@@ -289,9 +286,6 @@ public class MireotOperation {
       Set<OWLDataProperty> subproperies =
           reasoner.getSubDataProperties(entity.asOWLDataProperty(), true).getFlattened();
       for (OWLDataProperty subproperty : subproperies) {
-        if (subproperty == dataFactory.getOWLNothing()) {
-          continue;
-        }
         OntologyHelper.copy(inputOntology, outputOntology, subproperty, annotationProperties);
         outputManager.addAxiom(
             outputOntology,

--- a/robot-core/src/main/java/org/obolibrary/robot/MirrorOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/MirrorOperation.java
@@ -1,6 +1,5 @@
 package org.obolibrary.robot;
 
-import com.google.common.base.Optional;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -45,21 +44,21 @@ public class MirrorOperation {
       validateImports(ont);
 
       OWLOntologyID ontologyID = ont.getOntologyID();
-      Optional<IRI> ontologyIRI = ontologyID.getOntologyIRI();
+      IRI ontologyIRI = ontologyID.getOntologyIRI().orNull();
 
       // Not really sure why this is here, but apparently we can get
       // an ontology without an IRI, in which case we'll generate one
       // that is 'sort of' unique (only fails if two different machines
       // run this tool at the exact same time).
       //
-      if (!ontologyIRI.isPresent()) {
-        ontologyIRI = Optional.of(IRI.generateDocumentIRI());
+      if (ontologyIRI == null) {
+        ontologyIRI = IRI.generateDocumentIRI();
       }
       // Always write the actualIRI
-      String localFilePath = getMirrorPathOfOntologyIRI(ontologyIRI.get());
+      String localFilePath = getMirrorPathOfOntologyIRI(ontologyIRI);
       IRI outputStream = IRI.create(new File(baseFolder, localFilePath));
       ont.getOWLOntologyManager().saveOntology(ont, outputStream);
-      iriMap.put(ontologyIRI.get(), localFilePath);
+      iriMap.put(ontologyIRI, localFilePath);
 
       //
       // In case there is a difference between the source document IRI
@@ -74,8 +73,8 @@ public class MirrorOperation {
       //
 
       IRI documentIRI = ont.getOWLOntologyManager().getOntologyDocumentIRI(ont);
-      if (!documentIRI.toString().startsWith("file:") && documentIRI != ontologyIRI.get()) {
-        String sourceLocalFile = getMirrorPathOfOntologyIRI(ontologyIRI.get());
+      if (!documentIRI.toString().startsWith("file:") && documentIRI != ontologyIRI) {
+        String sourceLocalFile = getMirrorPathOfOntologyIRI(ontologyIRI);
         logger.info("Mirroring " + documentIRI + " in " + sourceLocalFile);
         iriMap.put(documentIRI, sourceLocalFile);
       }
@@ -91,7 +90,7 @@ public class MirrorOperation {
    * @throws IOException on any problem.
    */
   public static void writeCatalog(File catalogFile, Map<IRI, String> iriMap) throws IOException {
-    List<String> lines = new ArrayList<String>();
+    List<String> lines = new ArrayList<>();
     lines.add("<?xml version=\"1.0\" encoding=\"UTF-8\" " + "standalone=\"no\"?>");
     lines.add(
         "<catalog prefer=\"public\" xmlns=\"urn:oasis:names:tc:entity" + ":xmlns:xml:catalog\">");

--- a/robot-core/src/main/java/org/obolibrary/robot/OntologyHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/OntologyHelper.java
@@ -1,13 +1,6 @@
 package org.obolibrary.robot;
 
-import com.google.common.collect.Sets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import org.obolibrary.robot.checks.InvalidReferenceChecker;
 import org.semanticweb.owlapi.model.*;
@@ -197,7 +190,7 @@ public class OntologyHelper {
     for (OWLAnnotationAssertionAxiom axiom : axioms) {
       if (annotationProperties == null || annotationProperties.contains(axiom.getProperty())) {
         // Copy the annotation property and then the axiom.
-        copy(inputOntology, outputOntology, (OWLEntity) axiom.getProperty(), annotationProperties);
+        copy(inputOntology, outputOntology, axiom.getProperty(), annotationProperties);
         outputManager.addAxiom(outputOntology, axiom);
       }
     }
@@ -236,8 +229,7 @@ public class OntologyHelper {
    * @return The set of objects
    */
   public static Set<OWLObject> getObjects(OWLAxiom axiom) {
-    Set<OWLObject> objects = new HashSet<>();
-    objects.addAll(axiom.getSignature());
+    Set<OWLObject> objects = new HashSet<>(axiom.getSignature());
 
     // The following are special cases
     // where there might be something anonymous that we want to include
@@ -257,12 +249,16 @@ public class OntologyHelper {
     } else if (axiom instanceof OWLNaryClassAxiom) {
       OWLNaryClassAxiom a = (OWLNaryClassAxiom) axiom;
       objects.addAll(a.getClassExpressions());
+    } else if (axiom instanceof OWLSameIndividualAxiom) {
+      OWLSameIndividualAxiom a = (OWLSameIndividualAxiom) axiom;
+      objects.addAll(a.getAnonymousIndividuals());
     } else if (axiom instanceof OWLNaryIndividualAxiom) {
       OWLNaryIndividualAxiom a = (OWLNaryIndividualAxiom) axiom;
       objects.addAll(a.getIndividuals());
     } else if (axiom instanceof OWLNaryPropertyAxiom) {
       OWLNaryPropertyAxiom a = (OWLNaryPropertyAxiom) axiom;
-      objects.addAll(a.getProperties());
+      objects.addAll(a.getDataPropertiesInSignature());
+      objects.addAll(a.getObjectPropertiesInSignature());
     } else if (axiom instanceof OWLNegativeObjectPropertyAssertionAxiom) {
       OWLNegativeObjectPropertyAssertionAxiom a = (OWLNegativeObjectPropertyAssertionAxiom) axiom;
       objects.addAll(a.getAnonymousIndividuals());
@@ -272,9 +268,6 @@ public class OntologyHelper {
     } else if (axiom instanceof OWLObjectPropertyAxiom) {
       OWLObjectPropertyAxiom a = (OWLObjectPropertyAxiom) axiom;
       objects.addAll(a.getNestedClassExpressions());
-    } else if (axiom instanceof OWLSameIndividualAxiom) {
-      OWLSameIndividualAxiom a = (OWLSameIndividualAxiom) axiom;
-      objects.addAll(a.getAnonymousIndividuals());
     } else if (axiom instanceof OWLSubClassOfAxiom) {
       OWLSubClassOfAxiom a = (OWLSubClassOfAxiom) axiom;
       objects.add(a.getSuperClass());
@@ -668,10 +661,9 @@ public class OntologyHelper {
    */
   public static Set<OWLAnnotationAssertionAxiom> getAnnotationAxioms(
       OWLOntology ontology, OWLAnnotationProperty property) {
-    Set<OWLAnnotationProperty> properties = new HashSet<OWLAnnotationProperty>();
+    Set<OWLAnnotationProperty> properties = new HashSet<>();
     properties.add(property);
-    Set<IRI> subjects = null;
-    return getAnnotationAxioms(ontology, properties, subjects);
+    return getAnnotationAxioms(ontology, properties, null);
   }
 
   /**
@@ -685,11 +677,11 @@ public class OntologyHelper {
    */
   public static Set<OWLAnnotationAssertionAxiom> getAnnotationAxioms(
       OWLOntology ontology, OWLAnnotationProperty property, IRI subject) {
-    Set<OWLAnnotationProperty> properties = new HashSet<OWLAnnotationProperty>();
+    Set<OWLAnnotationProperty> properties = new HashSet<>();
     properties.add(property);
     Set<IRI> subjects = null;
     if (subject != null) {
-      subjects = new HashSet<IRI>();
+      subjects = new HashSet<>();
       subjects.add(subject);
     }
     return getAnnotationAxioms(ontology, properties, subjects);
@@ -706,7 +698,7 @@ public class OntologyHelper {
    */
   public static Set<OWLAnnotationAssertionAxiom> getAnnotationAxioms(
       OWLOntology ontology, Set<OWLAnnotationProperty> properties, Set<IRI> subjects) {
-    Set<OWLAnnotationAssertionAxiom> results = new HashSet<OWLAnnotationAssertionAxiom>();
+    Set<OWLAnnotationAssertionAxiom> results = new HashSet<>();
 
     for (OWLAxiom axiom : ontology.getAxioms()) {
       if (!(axiom instanceof OWLAnnotationAssertionAxiom)) {
@@ -719,7 +711,7 @@ public class OntologyHelper {
       OWLAnnotationSubject subject = aaa.getSubject();
       if (subjects == null) {
         results.add(aaa);
-      } else if (subject instanceof IRI && subjects.contains((IRI) subject)) {
+      } else if (subject instanceof IRI && subjects.contains(subject)) {
         results.add(aaa);
       }
     }
@@ -738,9 +730,9 @@ public class OntologyHelper {
    */
   public static String getAnnotationString(
       OWLOntology ontology, OWLAnnotationProperty property, IRI subject) {
-    Set<OWLAnnotationProperty> properties = new HashSet<OWLAnnotationProperty>();
+    Set<OWLAnnotationProperty> properties = new HashSet<>();
     properties.add(property);
-    Set<IRI> subjects = new HashSet<IRI>();
+    Set<IRI> subjects = new HashSet<>();
     subjects.add(subject);
     return getAnnotationString(ontology, properties, subjects);
   }
@@ -758,7 +750,7 @@ public class OntologyHelper {
   public static String getAnnotationString(
       OWLOntology ontology, Set<OWLAnnotationProperty> properties, Set<IRI> subjects) {
     Set<String> valueSet = getAnnotationStrings(ontology, properties, subjects);
-    List<String> valueList = new ArrayList<String>(valueSet);
+    List<String> valueList = new ArrayList<>(valueSet);
     Collections.sort(valueList);
     String value = null;
     if (valueList.size() > 0) {
@@ -778,9 +770,9 @@ public class OntologyHelper {
    */
   public static Set<String> getAnnotationStrings(
       OWLOntology ontology, OWLAnnotationProperty property, IRI subject) {
-    Set<OWLAnnotationProperty> properties = new HashSet<OWLAnnotationProperty>();
+    Set<OWLAnnotationProperty> properties = new HashSet<>();
     properties.add(property);
-    Set<IRI> subjects = new HashSet<IRI>();
+    Set<IRI> subjects = new HashSet<>();
     subjects.add(subject);
     return getAnnotationStrings(ontology, properties, subjects);
   }
@@ -796,7 +788,7 @@ public class OntologyHelper {
    */
   public static Set<String> getAnnotationStrings(
       OWLOntology ontology, Set<OWLAnnotationProperty> properties, Set<IRI> subjects) {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     Set<OWLAnnotationValue> values = getAnnotationValues(ontology, properties, subjects);
     for (OWLAnnotationValue value : values) {
       results.add(getValue(value));
@@ -815,9 +807,9 @@ public class OntologyHelper {
    */
   public static Set<OWLAnnotationValue> getAnnotationValues(
       OWLOntology ontology, OWLAnnotationProperty property, IRI subject) {
-    Set<OWLAnnotationProperty> properties = new HashSet<OWLAnnotationProperty>();
+    Set<OWLAnnotationProperty> properties = new HashSet<>();
     properties.add(property);
-    Set<IRI> subjects = new HashSet<IRI>();
+    Set<IRI> subjects = new HashSet<>();
     subjects.add(subject);
     return getAnnotationValues(ontology, properties, subjects);
   }
@@ -833,7 +825,7 @@ public class OntologyHelper {
    */
   public static Set<OWLAnnotationValue> getAnnotationValues(
       OWLOntology ontology, Set<OWLAnnotationProperty> properties, Set<IRI> subjects) {
-    Set<OWLAnnotationValue> results = new HashSet<OWLAnnotationValue>();
+    Set<OWLAnnotationValue> results = new HashSet<>();
     Set<OWLAnnotationAssertionAxiom> axioms = getAnnotationAxioms(ontology, properties, subjects);
     for (OWLAnnotationAssertionAxiom axiom : axioms) {
       results.add(axiom.getValue());
@@ -896,13 +888,16 @@ public class OntologyHelper {
       return entities;
     }
     for (IRI iri : iris) {
+      OWLEntity entity;
       try {
-        OWLEntity entity = getEntity(ontology, iri, true);
-        if (entity != null) {
-          // Do not add null entries
-          entities.add(entity);
-        }
+        entity = getEntity(ontology, iri, true);
       } catch (Exception e) {
+        // This block shouldn't get hit, but just in case, skip this entity
+        entity = null;
+      }
+      if (entity != null) {
+        // Do not add null entries
+        entities.add(entity);
       }
     }
     return entities;
@@ -928,7 +923,7 @@ public class OntologyHelper {
    * @return a set of IRIs for all entities in the ontology
    */
   public static Set<IRI> getIRIs(OWLOntology ontology) {
-    Set<IRI> iris = new HashSet<IRI>();
+    Set<IRI> iris = new HashSet<>();
     for (OWLEntity entity : getEntities(ontology)) {
       iris.add(entity.getIRI());
     }
@@ -974,7 +969,7 @@ public class OntologyHelper {
    * @return a map from label strings to IRIs
    */
   public static Map<String, IRI> getLabelIRIs(OWLOntology ontology) {
-    Map<String, IRI> results = new HashMap<String, IRI>();
+    Map<String, IRI> results = new HashMap<>();
     OWLOntologyManager manager = ontology.getOWLOntologyManager();
     OWLAnnotationProperty rdfsLabel = manager.getOWLDataFactory().getRDFSLabel();
     Set<OWLAnnotationAssertionAxiom> axioms = getAnnotationAxioms(ontology, rdfsLabel);
@@ -984,7 +979,7 @@ public class OntologyHelper {
         continue;
       }
       OWLAnnotationSubject subject = axiom.getSubject();
-      if (subject == null || !(subject instanceof IRI)) {
+      if (!(subject instanceof IRI)) {
         continue;
       }
       if (results.containsKey(value)) {
@@ -1004,10 +999,10 @@ public class OntologyHelper {
    */
   public static Map<IRI, String> getLabels(OWLOntology ontology) {
     logger.info("Fetching labels for " + ontology.getOntologyID());
-    Map<IRI, String> results = new HashMap<IRI, String>();
+    Map<IRI, String> results = new HashMap<>();
     OWLOntologyManager manager = ontology.getOWLOntologyManager();
     OWLAnnotationProperty rdfsLabel = manager.getOWLDataFactory().getRDFSLabel();
-    Set<OWLOntology> ontologies = new HashSet<OWLOntology>();
+    Set<OWLOntology> ontologies = new HashSet<>();
     ontologies.add(ontology);
     ReferencedEntitySetProvider resp = new ReferencedEntitySetProvider(ontologies);
     logger.info("iterating through entities...");
@@ -1092,7 +1087,7 @@ public class OntologyHelper {
    */
   public static String getValue(Set<OWLAnnotation> annotations) {
     Set<String> valueSet = getValues(annotations);
-    List<String> valueList = new ArrayList<String>(valueSet);
+    List<String> valueList = new ArrayList<>(valueSet);
     Collections.sort(valueList);
     String value = null;
     if (valueList.size() > 0) {
@@ -1108,7 +1103,7 @@ public class OntologyHelper {
    * @return a set of the value strings
    */
   public static Set<String> getValues(Set<OWLAnnotation> annotations) {
-    Set<String> results = new HashSet<String>();
+    Set<String> results = new HashSet<>();
     for (OWLAnnotation annotation : annotations) {
       String value = getValue(annotation);
       if (value != null) {
@@ -1154,15 +1149,15 @@ public class OntologyHelper {
     return false;
   }
 
-  public static void removeImports(OWLOntology ontology) throws Exception {
+  /**
+   * Given an ontology, remove the import declarations.
+   *
+   * @param ontology OWLOntology to remove imports from
+   */
+  public static void removeImports(OWLOntology ontology) {
     OWLOntologyManager manager = ontology.getOWLOntologyManager();
-    for (OWLOntology i : ontology.getImports()) {
-      IRI iri = i.getOntologyID().getOntologyIRI().orNull();
-      if (iri == null) {
-        throw new Exception(nullIRIError);
-      }
-      manager.applyChange(
-          new RemoveImport(ontology, manager.getOWLDataFactory().getOWLImportsDeclaration(iri)));
+    for (OWLImportsDeclaration i : ontology.getImportsDeclarations()) {
+      manager.applyChange(new RemoveImport(ontology, i));
     }
   }
 
@@ -1253,9 +1248,9 @@ public class OntologyHelper {
         }
       }
     }
-    Set<OWLAxiom> axioms =
-        RelatedObjectsHelper.getPartialAxioms(
-            ontology, trimObjects, Sets.newHashSet(OWLAxiom.class));
+    Set<Class<? extends OWLAxiom>> type = new HashSet<>();
+    type.add(OWLAxiom.class);
+    Set<OWLAxiom> axioms = RelatedObjectsHelper.getPartialAxioms(ontology, trimObjects, type);
     manager.removeAxioms(ontology, axioms);
   }
 }

--- a/robot-core/src/main/java/org/obolibrary/robot/OptionsHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/OptionsHelper.java
@@ -50,10 +50,6 @@ public class OptionsHelper {
     }
 
     value = value.trim().toLowerCase();
-    if (value.equals("true") || value.equals("yes")) {
-      return true;
-    }
-
-    return false;
+    return value.equals("true") || value.equals("yes");
   }
 }

--- a/robot-core/src/main/java/org/obolibrary/robot/QuotedEntityChecker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/QuotedEntityChecker.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.semanticweb.owlapi.expression.OWLEntityChecker;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotation;
@@ -43,28 +44,28 @@ public class QuotedEntityChecker implements OWLEntityChecker {
   private IOHelper ioHelper = null;
 
   /** Optional short form providers for additional names. */
-  private List<ShortFormProvider> providers = new ArrayList<ShortFormProvider>();
+  private List<ShortFormProvider> providers = new ArrayList<>();
 
   /** List of annotation properties to use for finding entities. */
-  private List<OWLAnnotationProperty> properties = new ArrayList<OWLAnnotationProperty>();
+  private List<OWLAnnotationProperty> properties = new ArrayList<>();
 
   /** Map from names to IRIs of annotation properties. */
-  private Map<String, IRI> annotationProperties = new HashMap<String, IRI>();
+  private Map<String, IRI> annotationProperties = new HashMap<>();
 
   /** Map from names to IRIs of classes. */
-  private Map<String, IRI> classes = new HashMap<String, IRI>();
+  private Map<String, IRI> classes = new HashMap<>();
 
   /** Map from names to IRIs of data properties. */
-  private Map<String, IRI> dataProperties = new HashMap<String, IRI>();
+  private Map<String, IRI> dataProperties = new HashMap<>();
 
   /** Map from names to IRIs of datatypes. */
-  private Map<String, IRI> datatypes = new HashMap<String, IRI>();
+  private Map<String, IRI> datatypes = new HashMap<>();
 
   /** Map from names to IRIs of named individuals. */
-  private Map<String, IRI> namedIndividuals = new HashMap<String, IRI>();
+  private Map<String, IRI> namedIndividuals = new HashMap<>();
 
   /** Map from names to IRIs of object properties. */
-  private Map<String, IRI> objectProperties = new HashMap<String, IRI>();
+  private Map<String, IRI> objectProperties = new HashMap<>();
 
   /**
    * Add an IOHelper for resolving names to IRIs.
@@ -275,7 +276,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
    * @param name the name of the entity to find
    * @return an annotation property, or null
    */
-  public OWLAnnotationProperty getOWLAnnotationProperty(String name) {
+  public OWLAnnotationProperty getOWLAnnotationProperty(@Nonnull String name) {
     return getOWLAnnotationProperty(name, false);
   }
 
@@ -306,7 +307,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
    * @param name the name of the entity to find
    * @return a class, or null
    */
-  public OWLClass getOWLClass(String name) {
+  public OWLClass getOWLClass(@Nonnull String name) {
     IRI iri = getIRI(classes, name);
     if (iri != null) {
       return dataFactory.getOWLClass(iri);
@@ -326,7 +327,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
    * @param name the name of the entity to find
    * @return a data property, or null
    */
-  public OWLDataProperty getOWLDataProperty(String name) {
+  public OWLDataProperty getOWLDataProperty(@Nonnull String name) {
     IRI iri = getIRI(dataProperties, name);
     if (iri != null) {
       return dataFactory.getOWLDataProperty(iri);
@@ -340,7 +341,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
    * @param name the name of the entity to find
    * @return a datatype, or null
    */
-  public OWLDatatype getOWLDatatype(String name) {
+  public OWLDatatype getOWLDatatype(@Nonnull String name) {
     return getOWLDatatype(name, false);
   }
 
@@ -352,7 +353,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
    * @param create when true and an IOHelper is defined, create the type
    * @return a datatype, or null
    */
-  public OWLDatatype getOWLDatatype(String name, boolean create) {
+  public OWLDatatype getOWLDatatype(@Nonnull String name, boolean create) {
     IRI iri = getIRI(datatypes, name);
     if (iri != null) {
       return dataFactory.getOWLDatatype(iri);
@@ -372,7 +373,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
    * @param name the name of the entity to find
    * @return a named individual, or null
    */
-  public OWLNamedIndividual getOWLIndividual(String name) {
+  public OWLNamedIndividual getOWLIndividual(@Nonnull String name) {
     IRI iri = getIRI(namedIndividuals, name);
     if (iri != null) {
       return dataFactory.getOWLNamedIndividual(iri);
@@ -386,7 +387,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
    * @param name the name of the entity to find
    * @return an object property, or null
    */
-  public OWLObjectProperty getOWLObjectProperty(String name) {
+  public OWLObjectProperty getOWLObjectProperty(@Nonnull String name) {
     IRI iri = getIRI(objectProperties, name);
     if (iri != null) {
       return dataFactory.getOWLObjectProperty(iri);
@@ -402,17 +403,17 @@ public class QuotedEntityChecker implements OWLEntityChecker {
    */
   public OWLEntity getOWLEntity(String name) {
     if (annotationProperties.containsKey(name)) {
-      return (OWLEntity) getOWLAnnotationProperty(name);
+      return getOWLAnnotationProperty(name);
     } else if (objectProperties.containsKey(name)) {
-      return (OWLEntity) getOWLObjectProperty(name);
+      return getOWLObjectProperty(name);
     } else if (dataProperties.containsKey(name)) {
-      return (OWLEntity) getOWLDataProperty(name);
+      return getOWLDataProperty(name);
     } else if (datatypes.containsKey(name)) {
-      return (OWLEntity) getOWLDatatype(name);
+      return getOWLDatatype(name);
     } else if (namedIndividuals.containsKey(name)) {
-      return (OWLEntity) getOWLIndividual(name);
+      return getOWLIndividual(name);
     } else if (classes.containsKey(name)) {
-      return (OWLEntity) getOWLClass(name);
+      return getOWLClass(name);
     }
     return null;
   }

--- a/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
@@ -18,23 +18,7 @@ import org.obolibrary.robot.exceptions.OntologyLogicException;
 import org.obolibrary.robot.reason.EquivalentClassReasoning;
 import org.obolibrary.robot.reason.EquivalentClassReasoningMode;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.AxiomType;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLAnnotationValue;
-import org.semanticweb.owlapi.model.OWLAxiom;
-import org.semanticweb.owlapi.model.OWLClass;
-import org.semanticweb.owlapi.model.OWLClassAxiom;
-import org.semanticweb.owlapi.model.OWLClassExpression;
-import org.semanticweb.owlapi.model.OWLDataFactory;
-import org.semanticweb.owlapi.model.OWLEntity;
-import org.semanticweb.owlapi.model.OWLImportsDeclaration;
-import org.semanticweb.owlapi.model.OWLNamedObject;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.model.OWLOntologyManager;
-import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
-import org.semanticweb.owlapi.model.RemoveImport;
+import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.model.parameters.Imports;
 import org.semanticweb.owlapi.reasoner.InferenceType;
 import org.semanticweb.owlapi.reasoner.Node;
@@ -61,7 +45,7 @@ public class ReasonOperation {
    * @return a map with default values for all available options
    */
   public static Map<String, String> getDefaultOptions() {
-    Map<String, String> options = new HashMap<String, String>();
+    Map<String, String> options = new HashMap<>();
     options.put("remove-redundant-subclass-axioms", "true");
     options.put("create-new-ontology", "false");
     options.put("create-new-ontology-with-annotations", "false");
@@ -171,8 +155,7 @@ public class ReasonOperation {
     Set<OWLAxiom> existingAxioms = ontology.getAxioms(Imports.INCLUDED);
 
     // Make sure to add the axiom generators in this way!!!
-    List<InferredAxiomGenerator<? extends OWLAxiom>> gens =
-        new ArrayList<InferredAxiomGenerator<? extends OWLAxiom>>();
+    List<InferredAxiomGenerator<? extends OWLAxiom>> gens = new ArrayList<>();
     gens.add(new InferredSubClassAxiomGenerator());
     InferredOntologyGenerator generator = new InferredOntologyGenerator(reasoner, gens);
     logger.info("Using these axiom generators:");
@@ -253,7 +236,7 @@ public class ReasonOperation {
         ontology
             .getAxioms(AxiomType.DECLARATION)
             .stream()
-            .map(a -> a.getEntity())
+            .map(OWLDeclarationAxiom::getEntity)
             .collect(Collectors.toSet());
     for (OWLAxiom a : newAxiomOntology.getAxioms()) {
       if (OptionsHelper.optionIsTrue(options, "exclude-external-entities")) {
@@ -350,7 +333,7 @@ public class ReasonOperation {
 
       // Use the reasoner to get all
       // the direct superclasses of this class.
-      Set<OWLClass> inferredSuperClasses = new HashSet<OWLClass>();
+      Set<OWLClass> inferredSuperClasses = new HashSet<>();
       for (Node<OWLClass> node : reasoner.getSuperClasses(thisClass, true)) {
         for (OWLClass inferredSuperClass : node) {
           inferredSuperClasses.add(inferredSuperClass);

--- a/robot-core/src/main/java/org/obolibrary/robot/ReasonerHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReasonerHelper.java
@@ -10,17 +10,7 @@ import java.util.stream.Collectors;
 import org.obolibrary.robot.exceptions.IncoherentRBoxException;
 import org.obolibrary.robot.exceptions.IncoherentTBoxException;
 import org.obolibrary.robot.exceptions.InconsistentOntologyException;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLAnnotation;
-import org.semanticweb.owlapi.model.OWLAnnotationProperty;
-import org.semanticweb.owlapi.model.OWLAxiom;
-import org.semanticweb.owlapi.model.OWLClass;
-import org.semanticweb.owlapi.model.OWLDataFactory;
-import org.semanticweb.owlapi.model.OWLObjectProperty;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.model.OWLOntologyID;
-import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.model.parameters.Imports;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.slf4j.Logger;
@@ -112,9 +102,7 @@ public class ReasonerHelper {
         // we want to ensure this is thrown
         try {
           saveIncoherentModule(ont, unsatisfiableClasses, unsatisfiableModulePath, ioHelper);
-        } catch (OWLOntologyCreationException e) {
-          e.printStackTrace();
-        } catch (IOException e) {
+        } catch (OWLOntologyCreationException | IOException e) {
           e.printStackTrace();
         }
       }
@@ -190,7 +178,8 @@ public class ReasonerHelper {
     if (outputIRI == null) {
       outputIRI = IRI.generateDocumentIRI();
     }
-    Set<IRI> terms = unsatisfiableClasses.stream().map(x -> x.getIRI()).collect(Collectors.toSet());
+    Set<IRI> terms =
+        unsatisfiableClasses.stream().map(OWLNamedObject::getIRI).collect(Collectors.toSet());
     OWLOntology module = ExtractOperation.extract(ontology, terms, outputIRI, ModuleType.BOT);
 
     if (ontology.getImportsClosure().size() > 1) {

--- a/robot-core/src/main/java/org/obolibrary/robot/ReduceOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReduceOperation.java
@@ -66,7 +66,7 @@ public class ReduceOperation {
    * @return a map with default values for all available options
    */
   public static Map<String, String> getDefaultOptions() {
-    Map<String, String> options = new HashMap<String, String>();
+    Map<String, String> options = new HashMap<>();
     options.put("preserve-annotated-axioms", "false");
     return options;
   }
@@ -109,6 +109,7 @@ public class ReduceOperation {
 
     Map<OWLClass, Set<OWLClass>> assertedSubClassMap = new HashMap<>();
     Set<OWLSubClassOfAxiom> assertedSubClassAxioms = ontology.getAxioms(AxiomType.SUBCLASS_OF);
+    // TODO - exprs is updated but never used
     Set<OWLClassExpression> exprs = new HashSet<>();
     Map<OWLClassExpression, OWLClass> exprToNamedClassMap = new HashMap<>();
 
@@ -117,7 +118,7 @@ public class ReduceOperation {
       OWLClass superClass = mapClass(dataFactory, exprToNamedClassMap, ax.getSuperClass());
 
       if (!assertedSubClassMap.containsKey(subClass)) {
-        assertedSubClassMap.put(subClass, new HashSet<OWLClass>());
+        assertedSubClassMap.put(subClass, new HashSet<>());
       }
 
       assertedSubClassMap.get(subClass).add(superClass);

--- a/robot-core/src/main/java/org/obolibrary/robot/RelatedObjectsHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/RelatedObjectsHelper.java
@@ -479,7 +479,7 @@ public class RelatedObjectsHelper {
    * @param objects Set of OWLObjects to filter
    * @param annotationPattern annotation to filter OWLObjects on
    * @return subset of OWLObjects matching the annotation pattern
-   * @throws Exception
+   * @throws Exception on issue getting literal annotations
    */
   public static Set<OWLObject> selectPattern(
       OWLOntology ontology, Set<OWLObject> objects, String annotationPattern) throws Exception {
@@ -528,6 +528,7 @@ public class RelatedObjectsHelper {
    * @param ioHelper IOHelper to get IRI
    * @param annotation String input
    * @return set of OWLAnnotations
+   * @throws Exception on issue getting literal annotation
    */
   protected static Set<OWLAnnotation> getAnnotations(
       OWLOntology ontology, IOHelper ioHelper, String annotation) throws Exception {
@@ -593,14 +594,12 @@ public class RelatedObjectsHelper {
           try {
             OWLLiteralImplPlain plain = (OWLLiteralImplPlain) av;
             annotationValue = plain.getLiteral();
-          } catch (Exception e1) {
+          } catch (ClassCastException ex) {
             try {
               OWLLiteralImplString str = (OWLLiteralImplString) av;
               annotationValue = str.getLiteral();
-            } catch (Exception e2) {
-              throw e2;
-              // TODO: does this block actually get hit?
-              // The pattern should only match a string anyway
+            } catch (ClassCastException ex2) {
+              continue;
             }
           }
           Matcher matcher = pattern.matcher(annotationValue);

--- a/robot-core/src/main/java/org/obolibrary/robot/RelationType.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/RelationType.java
@@ -54,7 +54,7 @@ public enum RelationType {
    *
    * @param name command line name option
    */
-  private RelationType(String name) {
+  RelationType(String name) {
     this.name = name;
   }
 
@@ -68,7 +68,7 @@ public enum RelationType {
     return name;
   }
 
-  public static final RelationType getRelationType(String name) {
+  public static RelationType getRelationType(String name) {
     RelationType rt = NAME_RELATION_MAP.get(name);
     if (rt == null) {
       // TODO
@@ -78,10 +78,6 @@ public enum RelationType {
   }
 
   public static boolean isRelationType(String name) {
-    if (NAME_RELATION_MAP.get(name) == null) {
-      return false;
-    } else {
-      return true;
-    }
+    return NAME_RELATION_MAP.get(name) != null;
   }
 }

--- a/robot-core/src/main/java/org/obolibrary/robot/RelaxOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/RelaxOperation.java
@@ -78,9 +78,8 @@ public class RelaxOperation {
    * @return a map with default values for all available options
    */
   public static Map<String, String> getDefaultOptions() {
-    Map<String, String> options = new HashMap<String, String>();
     // options.put("remove-redundant-subclass-axioms", "true");
-    return options;
+    return new HashMap<>();
   }
 
   /**

--- a/robot-core/src/main/java/org/obolibrary/robot/RepairOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/RepairOperation.java
@@ -1,6 +1,5 @@
 package org.obolibrary.robot;
 
-import com.google.common.base.Optional;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -27,10 +26,8 @@ public class RepairOperation {
    * @return a map with default values for all available options
    */
   public static Map<String, String> getDefaultOptions() {
-    Map<String, String> options = new HashMap<>();
     // options.put("remove-redundant-subclass-axioms", "true");
-
-    return options;
+    return new HashMap<>();
   }
 
   /**
@@ -162,15 +159,15 @@ public class RepairOperation {
                 .getIRI()
                 .equals(IRI.create("http://purl.obolibrary.org/obo/IAO_0100001"))) {
               OWLAnnotationValue val = aaa.getValue();
-              Optional<IRI> valIRI = val.asIRI();
-              if (valIRI.isPresent()) {
+              IRI valIRI = val.asIRI().orNull();
+              if (valIRI != null) {
                 logger.info("Using URI replacement: " + valIRI);
-                replacedBy = valIRI.get();
+                replacedBy = valIRI;
               } else {
-                Optional<OWLLiteral> valLit = val.asLiteral();
-                if (valLit.isPresent()) {
+                OWLLiteral valLit = val.asLiteral().orNull();
+                if (valLit != null) {
                   logger.info("Using CURIE replacement: " + valLit);
-                  replacedBy = iohelper.createIRI(valLit.get().getLiteral());
+                  replacedBy = iohelper.createIRI(valLit.getLiteral());
                 }
               }
             }

--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
@@ -47,6 +47,10 @@ public class TemplateHelper {
   private static final String annotationPropertyError =
       NS + "ANNOTATION PROPERTY ERROR could not handle annotation property: %s";
 
+  /** Error message when the CLASS_TYPE is not subclass or equivalent. */
+  private static final String classTypeError =
+      NS + "CLASS TYPE ERROR '%s' is not a valid CLASS_TYPE";
+
   /** Error message when datatype cannot be resolved. Expects: datatype name. */
   private static final String datatypeError = NS + "DATATYPE ERROR could not find datatype: %s";
 
@@ -120,13 +124,13 @@ public class TemplateHelper {
     if (template.startsWith("A ")) {
       return getStringAnnotation(checker, template, value);
     } else if (template.startsWith("AT ")) {
-      if (template.indexOf("^^") > -1) {
+      if (template.contains("^^")) {
         return getTypedAnnotation(checker, template, value);
       } else {
         throw new Exception(String.format(typedFormatError, template));
       }
     } else if (template.startsWith("AL ")) {
-      if (template.indexOf("@") > -1) {
+      if (template.contains("@")) {
         return getLanguageAnnotation(checker, template, value);
       } else {
         throw new Exception(String.format(languageFormatError, template));
@@ -234,7 +238,7 @@ public class TemplateHelper {
       }
       return Sets.newHashSet(axiom);
     } else {
-      return null;
+      throw new Exception(String.format(classTypeError, classType));
     }
   }
 
@@ -351,11 +355,10 @@ public class TemplateHelper {
    * @param type the IRI of the type for this entity, or null
    * @param id the ID for this entity, or null
    * @param label the label for this entity, or null
-   * @return the entity
-   * @throws Exception if the entity cannot be created
+   * @return the entity or null
    */
-  public static OWLEntity getEntity(QuotedEntityChecker checker, IRI type, String id, String label)
-      throws Exception {
+  public static OWLEntity getEntity(
+      QuotedEntityChecker checker, IRI type, String id, String label) {
 
     IOHelper ioHelper = checker.getIOHelper();
 
@@ -414,7 +417,7 @@ public class TemplateHelper {
    */
   public static List<IRI> getIRIs(Map<String, List<List<String>>> tables, IOHelper ioHelper)
       throws Exception {
-    List<IRI> iris = new ArrayList<IRI>();
+    List<IRI> iris = new ArrayList<>();
     for (Map.Entry<String, List<List<String>>> table : tables.entrySet()) {
       String tableName = table.getKey();
       List<List<String>> rows = table.getValue();
@@ -451,9 +454,9 @@ public class TemplateHelper {
       throw new Exception(String.format(idError, tableName));
     }
 
-    List<IRI> iris = new ArrayList<IRI>();
+    List<IRI> iris = new ArrayList<>();
     for (int row = 2; row < rows.size(); row++) {
-      String id = null;
+      String id;
       try {
         id = rows.get(row).get(idColumn);
       } catch (IndexOutOfBoundsException e) {
@@ -503,10 +506,10 @@ public class TemplateHelper {
    */
   public static List<List<String>> readCSV(Reader reader) throws IOException {
     CSVReader csv = new CSVReader(reader);
-    List<List<String>> rows = new ArrayList<List<String>>();
+    List<List<String>> rows = new ArrayList<>();
     String[] nextLine;
     while ((nextLine = csv.readNext()) != null) {
-      rows.add(new ArrayList<String>(Arrays.asList(nextLine)));
+      rows.add(new ArrayList<>(Arrays.asList(nextLine)));
     }
     csv.close();
     return rows;
@@ -566,10 +569,10 @@ public class TemplateHelper {
    */
   public static List<List<String>> readTSV(Reader reader) throws IOException {
     CSVReader csv = new CSVReader(reader, '\t');
-    List<List<String>> rows = new ArrayList<List<String>>();
+    List<List<String>> rows = new ArrayList<>();
     String[] nextLine;
     while ((nextLine = csv.readNext()) != null) {
-      rows.add(new ArrayList<String>(Arrays.asList(nextLine)));
+      rows.add(new ArrayList<>(Arrays.asList(nextLine)));
     }
     csv.close();
     return rows;

--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateOperation.java
@@ -202,11 +202,10 @@ public class TemplateOperation {
    * @param type the IRI of the type for this entity, or null
    * @param id the ID for this entity, or null
    * @param label the label for this entity, or null
-   * @return the entity
-   * @throws Exception if the entity cannot be created
+   * @return the entity or null
    */
-  public static OWLEntity getEntity(QuotedEntityChecker checker, IRI type, String id, String label)
-      throws Exception {
+  public static OWLEntity getEntity(
+      QuotedEntityChecker checker, IRI type, String id, String label) {
     return TemplateHelper.getEntity(checker, type, id, label);
   }
 
@@ -257,13 +256,10 @@ public class TemplateOperation {
     if (template.equals("CLASS_TYPE")) {
       return true;
     }
-    if (template.matches("^(>?C|>{0,2}A[L,T,I]?) .*")) {
+    if (template.matches("^(>?C|>{0,2}A[LTI]?) .*")) {
       return true;
     }
-    if (template.equals("CI")) {
-      return true;
-    }
-    return false;
+    return template.equals("CI");
   }
 
   /**
@@ -345,8 +341,8 @@ public class TemplateOperation {
     logger.debug("Templating...");
 
     // Check templates and find the ID and LABEL columns.
-    Map<String, Integer> idColumns = new HashMap<String, Integer>();
-    Map<String, Integer> labelColumns = new HashMap<String, Integer>();
+    Map<String, Integer> idColumns = new HashMap<>();
+    Map<String, Integer> labelColumns = new HashMap<>();
     for (Map.Entry<String, List<List<String>>> table : tables.entrySet()) {
       String tableName = table.getKey();
       List<List<String>> rows = table.getValue();
@@ -496,7 +492,7 @@ public class TemplateOperation {
         continue;
       }
 
-      String cell = null;
+      String cell;
       try {
         cell = rows.get(row).get(column);
       } catch (IndexOutOfBoundsException e) {
@@ -561,9 +557,7 @@ public class TemplateOperation {
           axiomAnnotations.put(lastAxiomAnnotation, Sets.newHashSet());
           nested.put(lastAnnotation, axiomAnnotations);
           // Remove from annotation set to prevent duplication
-          if (annotations.contains(lastAnnotation)) {
-            annotations.remove(lastAnnotation);
-          }
+          annotations.remove(lastAnnotation);
           // Handle axiom annotation annotations ?
         } else if (template.startsWith(">>A")) {
           if (lastAxiomAnnotation == null) {
@@ -678,7 +672,7 @@ public class TemplateOperation {
       }
 
       String header = headers.get(column);
-      String cell = null;
+      String cell;
       try {
         cell = rows.get(row).get(column);
       } catch (IndexOutOfBoundsException e) {
@@ -736,9 +730,7 @@ public class TemplateOperation {
               TemplateHelper.getStringAnnotation(checker, template.substring(1).trim(), cell));
           annotatedExpressions.put(lastExpression, annotations);
           // Remove to prevent duplication
-          if (classExpressions.contains(lastExpression)) {
-            classExpressions.remove(lastExpression);
-          }
+          classExpressions.remove(lastExpression);
         }
       }
     }

--- a/robot-core/src/main/java/org/obolibrary/robot/Tuple.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/Tuple.java
@@ -3,6 +3,7 @@ package org.obolibrary.robot;
 import com.google.common.collect.Lists;
 import java.util.Collection;
 import java.util.Iterator;
+import javax.annotation.Nonnull;
 
 /**
  * Created by edouglass on 8/14/17.
@@ -43,11 +44,13 @@ public class Tuple<A, B> implements Collection {
     return o.equals(left) || o.equals(right);
   }
 
+  @Nonnull
   @Override
   public Iterator iterator() {
     return Lists.newArrayList(left, right).iterator();
   }
 
+  @Nonnull
   @Override
   public Object[] toArray() {
     return new Object[] {left, right};
@@ -64,7 +67,7 @@ public class Tuple<A, B> implements Collection {
   }
 
   @Override
-  public boolean addAll(Collection c) {
+  public boolean addAll(@Nonnull Collection c) {
     return false;
   }
 
@@ -75,22 +78,22 @@ public class Tuple<A, B> implements Collection {
   }
 
   @Override
-  public boolean retainAll(Collection c) {
+  public boolean retainAll(@Nonnull Collection c) {
     return Lists.newArrayList(left, right).retainAll(c);
   }
 
   @Override
-  public boolean removeAll(Collection c) {
+  public boolean removeAll(@Nonnull Collection c) {
     return Lists.newArrayList(left, right).removeAll(c);
   }
 
   @Override
-  public boolean containsAll(Collection c) {
+  public boolean containsAll(@Nonnull Collection c) {
     return Lists.newArrayList(left, right).containsAll(c);
   }
 
   @Override
-  public Object[] toArray(Object[] a) {
+  public Object[] toArray(@Nonnull Object[] a) {
     if (a.length < 2) {
       return new Object[] {left, right};
     } else {

--- a/robot-core/src/main/java/org/obolibrary/robot/UnmergeOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/UnmergeOperation.java
@@ -41,7 +41,7 @@ public class UnmergeOperation {
    * @param targetOntology the ontology to remove axioms from
    */
   public static void unmergeFrom(OWLOntology ontology, OWLOntology targetOntology) {
-    List<OWLOntology> ontologies = new ArrayList<OWLOntology>();
+    List<OWLOntology> ontologies = new ArrayList<>();
     ontologies.add(ontology);
     unmergeFrom(ontologies, targetOntology, false);
   }
@@ -68,7 +68,7 @@ public class UnmergeOperation {
    */
   public static void unmergeFrom(
       OWLOntology ontology, OWLOntology targetOntology, boolean includeAnnotations) {
-    List<OWLOntology> ontologies = new ArrayList<OWLOntology>();
+    List<OWLOntology> ontologies = new ArrayList<>();
     ontologies.add(ontology);
     unmergeFrom(ontologies, targetOntology, includeAnnotations);
   }

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidReferenceChecker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidReferenceChecker.java
@@ -3,13 +3,7 @@ package org.obolibrary.robot.checks;
 import java.util.HashSet;
 import java.util.Set;
 import org.obolibrary.robot.checks.InvalidReferenceViolation.Category;
-import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLAxiom;
-import org.semanticweb.owlapi.model.OWLClass;
-import org.semanticweb.owlapi.model.OWLDeclarationAxiom;
-import org.semanticweb.owlapi.model.OWLEntity;
-import org.semanticweb.owlapi.model.OWLObjectProperty;
-import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.model.parameters.Imports;
 
 /**
@@ -36,14 +30,12 @@ public class InvalidReferenceChecker {
     if (entity instanceof OWLClass) {
       OWLClass owlClass = (OWLClass) entity;
       if (ontology.getAxioms(owlClass, Imports.INCLUDED).size() > 0) return false;
-      if (ontology.getAnnotationAssertionAxioms(owlClass.getIRI()).size() > 0) return false;
-      return true;
+      return ontology.getAnnotationAssertionAxioms(owlClass.getIRI()).size() <= 0;
     }
     if (entity instanceof OWLObjectProperty) {
       OWLObjectProperty owlProperty = (OWLObjectProperty) entity;
       if (ontology.getAxioms(owlProperty, Imports.INCLUDED).size() > 0) return false;
-      if (ontology.getAnnotationAssertionAxioms(owlProperty.getIRI()).size() > 0) return false;
-      return true;
+      return ontology.getAnnotationAssertionAxioms(owlProperty.getIRI()).size() <= 0;
     }
     return false;
   }
@@ -59,7 +51,8 @@ public class InvalidReferenceChecker {
     for (OWLOntology o : ontology.getImportsClosure()) {
       for (OWLAnnotationAssertionAxiom a : o.getAnnotationAssertionAxioms(entity.getIRI())) {
         if (a.isDeprecatedIRIAssertion()) {
-          if (a.getValue().asLiteral().get().parseBoolean()) {
+          OWLLiteral value = a.getValue().asLiteral().orNull();
+          if (value != null && value.parseBoolean()) {
             return true;
           }
         }

--- a/robot-core/src/main/java/org/obolibrary/robot/reason/EquivalentClassReasoning.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/reason/EquivalentClassReasoning.java
@@ -145,14 +145,14 @@ public class EquivalentClassReasoning {
   }
 
   private static String equivAxiomToString(OWLEquivalentClassesAxiom axiom) {
-    String equivalentClassesString = "Equivalence: ";
+    StringBuilder equivalentClassesString = new StringBuilder("Equivalence: ");
     Iterator<OWLClass> classIterator = axiom.getNamedClasses().iterator();
     while (classIterator.hasNext()) {
-      equivalentClassesString += classIterator.next().toString();
+      equivalentClassesString.append(classIterator.next().toString());
       if (classIterator.hasNext()) {
-        equivalentClassesString += " == ";
+        equivalentClassesString.append(" == ");
       }
     }
-    return equivalentClassesString;
+    return equivalentClassesString.toString();
   }
 }

--- a/robot-core/src/test/java/org/obolibrary/robot/CoreTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/CoreTest.java
@@ -1,6 +1,7 @@
 package org.obolibrary.robot;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,7 +50,7 @@ public class CoreTest {
    */
   public OWLOntology loadOntologyWithCatalog(String path) throws IOException {
     IOHelper ioh = new IOHelper();
-    String fullpath = this.getClass().getResource(path).getFile().toString();
+    String fullpath = this.getClass().getResource(path).getFile();
     return ioh.loadOntology(fullpath);
   }
 
@@ -95,7 +96,7 @@ public class CoreTest {
     StringWriter writer = new StringWriter();
     boolean actual = DiffOperation.compare(left, right, writer);
     System.out.println(writer.toString());
-    assertEquals(true, actual);
+    assertTrue(actual);
     assertEquals("Ontologies are identical\n", writer.toString());
   }
 

--- a/robot-core/src/test/java/org/obolibrary/robot/DiffOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/DiffOperationTest.java
@@ -1,6 +1,7 @@
 package org.obolibrary.robot;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -36,7 +37,7 @@ public class DiffOperationTest extends CoreTest {
   @Test
   public void testCompareModified() throws IOException, OWLOntologyCreationException {
     OWLOntology simple = loadOntology("/simple.owl");
-    Set<OWLOntology> onts = new HashSet<OWLOntology>();
+    Set<OWLOntology> onts = new HashSet<>();
     onts.add(simple);
     OWLOntologyManager manager = simple.getOWLOntologyManager();
     OWLDataFactory df = manager.getOWLDataFactory();
@@ -49,7 +50,7 @@ public class DiffOperationTest extends CoreTest {
     StringWriter writer = new StringWriter();
     boolean actual = DiffOperation.compare(simple, simple1, writer);
     System.out.println(writer.toString());
-    assertEquals(false, actual);
+    assertFalse(actual);
     String expected = IOUtils.toString(this.getClass().getResourceAsStream("/simple1.diff"));
     assertEquals(expected, writer.toString());
   }

--- a/robot-core/src/test/java/org/obolibrary/robot/FilterOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/FilterOperationTest.java
@@ -20,7 +20,7 @@ public class FilterOperationTest extends CoreTest {
    */
   @Test
   public void testFilterNothing() throws IOException {
-    Set<OWLObjectProperty> properties = new HashSet<OWLObjectProperty>();
+    Set<OWLObjectProperty> properties = new HashSet<>();
     OWLOntology filtered = loadOntology("/simple.owl");
     FilterOperation.filter(filtered, properties);
     assertIdentical("/simple.owl", filtered);
@@ -34,7 +34,7 @@ public class FilterOperationTest extends CoreTest {
    */
   @Test
   public void testRemoveParts() throws IOException {
-    Set<OWLObjectProperty> properties = new HashSet<OWLObjectProperty>();
+    Set<OWLObjectProperty> properties = new HashSet<>();
     OWLOntology filtered = loadOntology("/simple_parts.owl");
     FilterOperation.filter(filtered, properties);
     assertIdentical("/simple.owl", filtered);
@@ -52,7 +52,7 @@ public class FilterOperationTest extends CoreTest {
 
     OWLOntologyManager manager = simpleParts.getOWLOntologyManager();
     OWLDataFactory df = manager.getOWLDataFactory();
-    Set<OWLObjectProperty> properties = new HashSet<OWLObjectProperty>();
+    Set<OWLObjectProperty> properties = new HashSet<>();
     properties.add(df.getOWLObjectProperty(IRI.create(base + "simple.owl#part_of")));
 
     OWLOntology filtered = loadOntology("/simple_parts.owl");

--- a/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
@@ -80,10 +80,10 @@ public class IOHelperTest extends CoreTest {
             + "}";
 
     IOHelper ioh = new IOHelper();
-    Context context = ioh.parseContext(json);
+    Context context = IOHelper.parseContext(json);
     ioh.setContext(context);
 
-    Map<String, String> expected = new HashMap<String, String>();
+    Map<String, String> expected = new HashMap<>();
     expected.put("foo", "http://example.com#");
     expected.put("bar", "http://example.com#");
     assertEquals("Check JSON prefixes", expected, ioh.getPrefixes());
@@ -97,7 +97,7 @@ public class IOHelperTest extends CoreTest {
   @Test
   public void testPrefixHandling() throws IOException {
     IOHelper ioh = new IOHelper(false);
-    Map<String, String> expected = new HashMap<String, String>();
+    Map<String, String> expected = new HashMap<>();
     assertEquals("Check no prefixes", expected, ioh.getPrefixes());
 
     ioh.addPrefix("foo", "http://example.com#");
@@ -149,7 +149,7 @@ public class IOHelperTest extends CoreTest {
             + "foo:4\n"
             + "definition\n";
 
-    Set<String> terms = new HashSet<String>();
+    Set<String> terms = new HashSet<>();
     terms.add("http://purl.obolibrary.org/obo/GO_1");
     terms.add("obo:GO_2");
     terms.add("GO:3");
@@ -159,7 +159,7 @@ public class IOHelperTest extends CoreTest {
     Set<String> actualTerms = ioh.extractTerms(input);
     assertEquals("Check terms", terms, actualTerms);
 
-    Set<IRI> iris = new HashSet<IRI>();
+    Set<IRI> iris = new HashSet<>();
     iris.add(IRI.create("http://purl.obolibrary.org/obo/GO_1"));
     iris.add(IRI.create("http://purl.obolibrary.org/obo/GO_2"));
     iris.add(IRI.create("http://purl.obolibrary.org/obo/GO_3"));
@@ -182,14 +182,14 @@ public class IOHelperTest extends CoreTest {
 
     assertEquals(IRI.create(base), ioh.createIRI(base));
 
-    literal = ioh.createLiteral("FOO");
+    literal = IOHelper.createLiteral("FOO");
     assertEquals("FOO", OntologyHelper.getValue(literal));
 
     literal = ioh.createTypedLiteral("100", "xsd:integer");
     assertEquals("100", literal.getLiteral());
     assertEquals(ioh.createIRI("xsd:integer"), literal.getDatatype().getIRI());
 
-    literal = ioh.createTaggedLiteral("100", "en");
+    literal = IOHelper.createTaggedLiteral("100", "en");
     assertEquals("100", literal.getLiteral());
     assertEquals("en", literal.getLang());
   }

--- a/robot-core/src/test/java/org/obolibrary/robot/MergeOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/MergeOperationTest.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
 import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
 /** Tests for MergeOperation. */
 public class MergeOperationTest extends CoreTest {
@@ -13,10 +12,9 @@ public class MergeOperationTest extends CoreTest {
    * Test merging a single ontology without imports.
    *
    * @throws IOException on file problem
-   * @throws OWLOntologyCreationException on ontology problem
    */
   @Test
-  public void testMergeOne() throws IOException, OWLOntologyCreationException {
+  public void testMergeOne() throws IOException {
     OWLOntology simple = loadOntology("/simple.owl");
     OWLOntology merged = MergeOperation.merge(simple);
     assertIdentical("/simple.owl", merged);
@@ -26,13 +24,12 @@ public class MergeOperationTest extends CoreTest {
    * Test merging two ontologies without imports. Result should equal simpleParts.
    *
    * @throws IOException on file problem
-   * @throws OWLOntologyCreationException on ontology problem
    */
   @Test
-  public void testMergeTwo() throws IOException, OWLOntologyCreationException {
+  public void testMergeTwo() throws IOException {
     OWLOntology simple = loadOntology("/simple.owl");
     OWLOntology simpleParts = loadOntology("/simple_parts.owl");
-    List<OWLOntology> ontologies = new ArrayList<OWLOntology>();
+    List<OWLOntology> ontologies = new ArrayList<>();
     ontologies.add(simple);
     ontologies.add(simpleParts);
     OWLOntology merged = MergeOperation.merge(ontologies);

--- a/robot-core/src/test/java/org/obolibrary/robot/MireotOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/MireotOperationTest.java
@@ -20,7 +20,7 @@ public class MireotOperationTest extends CoreTest {
   /**
    * Test MIREOT.
    *
-   * @throws Exception
+   * @throws Exception on any problem
    */
   @Test
   public void testMireot() throws Exception {
@@ -31,7 +31,7 @@ public class MireotOperationTest extends CoreTest {
    * Test MIREOT.
    *
    * @param expectedPath the path to a known-good file for comparison
-   * @throws Exception
+   * @throws Exception on any problem
    */
   public void testMireot(String expectedPath) throws Exception {
     OWLOntology inputOntology = loadOntology("/filtered.owl");
@@ -40,12 +40,11 @@ public class MireotOperationTest extends CoreTest {
 
     Set<IRI> upperIRIs =
         Collections.singleton(IRI.create("http://purl.obolibrary.org/obo/UBERON_0001235"));
-    Set<IRI> lowerIRIs = upperIRIs;
     // Set<IRI> branchIRIs = upperIRIs;
 
-    List<OWLOntology> outputOntologies = new ArrayList<OWLOntology>();
+    List<OWLOntology> outputOntologies = new ArrayList<>();
 
-    outputOntologies.add(MireotOperation.getAncestors(inputOntology, upperIRIs, lowerIRIs, null));
+    outputOntologies.add(MireotOperation.getAncestors(inputOntology, upperIRIs, upperIRIs, null));
 
     /*
     outputOntologies.add(

--- a/robot-core/src/test/java/org/obolibrary/robot/MirrorOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/MirrorOperationTest.java
@@ -4,11 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import org.junit.Test;
+import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.model.OWLOntologyStorageException;
 
 /**
  * Tests creating local cache.
@@ -18,15 +16,12 @@ import org.semanticweb.owlapi.model.OWLOntologyStorageException;
 public class MirrorOperationTest extends CoreTest {
 
   /**
-   * Test MIREOT.
+   * Test mirroring.
    *
-   * @throws IOException on IO problems
-   * @throws OWLOntologyCreationException on ontology problems
-   * @throws OWLOntologyStorageException if error in saving ontology
+   * @throws Exception on any problem
    */
   @Test
-  public void testMirror()
-      throws IOException, OWLOntologyCreationException, OWLOntologyStorageException {
+  public void testMirror() throws Exception {
     testMirror("/import_test.owl");
   }
 
@@ -35,19 +30,21 @@ public class MirrorOperationTest extends CoreTest {
    * loaded.
    *
    * @param expectedPath resource path for the ontology.
-   * @throws IOException for reading/writing errors.
-   * @throws OWLOntologyCreationException if ontology cannot be loaded.
-   * @throws OWLOntologyStorageException if ontology cannot be saved.
+   * @throws Exception on any problem
    */
-  public void testMirror(String expectedPath)
-      throws IOException, OWLOntologyCreationException, OWLOntologyStorageException {
+  public void testMirror(String expectedPath) throws Exception {
     OWLOntology inputOntology = loadOntologyWithCatalog(expectedPath);
 
     File catalogFile = new File("target/mirror-catalog.xml");
     MirrorOperation.mirror(inputOntology, new File("target"), catalogFile);
 
-    OWLOntology loadedOntology =
-        loadOntologyWithCatalog(inputOntology.getOntologyID().getOntologyIRI().get(), catalogFile);
+    IRI iri = inputOntology.getOntologyID().getOntologyIRI().orNull();
+    OWLOntology loadedOntology;
+    if (iri != null) {
+      loadedOntology = loadOntologyWithCatalog(iri, catalogFile);
+    } else {
+      throw new Exception(String.format("Test ontology %s does not have an IRI", expectedPath));
+    }
     assertIdentical(loadedOntology, inputOntology);
     int n = 0;
     for (OWLOntology importedOntology : inputOntology.getImportsClosure()) {

--- a/robot-core/src/test/java/org/obolibrary/robot/OntologyHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/OntologyHelperTest.java
@@ -18,16 +18,25 @@ public class OntologyHelperTest extends CoreTest {
   /**
    * Test changing an ontology IRI.
    *
-   * @throws IOException on file problem
+   * @throws Exception on any problem
    */
   @Test
-  public void testSetOntologyIRI() throws IOException {
+  public void testSetOntologyIRI() throws Exception {
     OWLOntology simple = loadOntology("/simple.owl");
     OntologyHelper.setOntologyIRI(simple, "http://ontology.iri", "http://version.iri");
 
-    assertEquals(
-        "http://ontology.iri", simple.getOntologyID().getOntologyIRI().orNull().toString());
-    assertEquals("http://version.iri", simple.getOntologyID().getVersionIRI().orNull().toString());
+    IRI ontologyIRI = simple.getOntologyID().getOntologyIRI().orNull();
+    IRI versionIRI = simple.getOntologyID().getVersionIRI().orNull();
+    if (ontologyIRI != null) {
+      assertEquals("http://ontology.iri", ontologyIRI.toString());
+    } else {
+      throw new Exception(String.format("Ontology IRI for %s does not exist.", "/simple.owl"));
+    }
+    if (versionIRI != null) {
+      assertEquals("http://version.iri", versionIRI.toString());
+    } else {
+      throw new Exception(String.format("Version IRI for %s does not exist.", "/simple.owl"));
+    }
   }
 
   /**
@@ -42,7 +51,7 @@ public class OntologyHelperTest extends CoreTest {
     OWLDataFactory df = simple.getOWLOntologyManager().getOWLDataFactory();
     Set<String> actual = OntologyHelper.getAnnotationStrings(simple, df.getRDFSLabel(), iri);
 
-    Set<String> expected = new HashSet<String>();
+    Set<String> expected = new HashSet<>();
     expected.add("Test 1");
     expected.add("test one");
     assertEquals(expected, actual);
@@ -56,7 +65,7 @@ public class OntologyHelperTest extends CoreTest {
   @Test
   public void testGetLabels() throws IOException {
     OWLOntology simple = loadOntology("/simple.owl");
-    Map<IRI, String> expected = new HashMap<IRI, String>();
+    Map<IRI, String> expected = new HashMap<>();
     expected.put(IRI.create(base + "simple.owl#test1"), "Test 1");
     Map<IRI, String> actual = OntologyHelper.getLabels(simple);
     assertEquals(expected, actual);
@@ -70,7 +79,7 @@ public class OntologyHelperTest extends CoreTest {
   @Test
   public void testGetLabelIRIs() throws IOException {
     OWLOntology simple = loadOntology("/simple.owl");
-    Map<String, IRI> expected = new HashMap<String, IRI>();
+    Map<String, IRI> expected = new HashMap<>();
     expected.put("Test 1", IRI.create(base + "simple.owl#test1"));
     expected.put("test one", IRI.create(base + "simple.owl#test1"));
     Map<String, IRI> actual = OntologyHelper.getLabelIRIs(simple);
@@ -91,7 +100,7 @@ public class OntologyHelperTest extends CoreTest {
 
     // Add plain literal
     OntologyHelper.addOntologyAnnotation(
-        simple, ioHelper.createIRI(base + "foo"), ioHelper.createLiteral("FOO"));
+        simple, ioHelper.createIRI(base + "foo"), IOHelper.createLiteral("FOO"));
     assertEquals(1, simple.getAnnotations().size());
 
     OWLAnnotation annotation = simple.getAnnotations().iterator().next();

--- a/robot-core/src/test/java/org/obolibrary/robot/QuotedEntityCheckerTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/QuotedEntityCheckerTest.java
@@ -1,6 +1,6 @@
 package org.obolibrary.robot;
 
-import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.assertEquals;
 
 import org.junit.Test;
 import org.semanticweb.owlapi.model.*;
@@ -28,8 +28,12 @@ public class QuotedEntityCheckerTest extends CoreTest {
     checker.addAll(ontology);
 
     OWLEntity cls = checker.getOWLClass("test one");
-    assertTrue(
-        "https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl#test1"
-            .equals(cls.getIRI().toString()));
+    if (cls != null) {
+      assertEquals(
+          "https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl#test1",
+          cls.getIRI().toString());
+    } else {
+      throw new Exception("Class 'test one' does not exist.");
+    }
   }
 }

--- a/robot-core/src/test/java/org/obolibrary/robot/ReasonOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ReasonOperationTest.java
@@ -190,7 +190,7 @@ public class ReasonOperationTest extends CoreTest {
     ReasonOperation.reason(reasoned, reasonerFactory, Collections.emptyMap());
     assertIdentical("/redundant_subclasses.owl", reasoned);
 
-    Map<String, String> options = new HashMap<String, String>();
+    Map<String, String> options = new HashMap<>();
     options.put("remove-redundant-subclass-axioms", "true");
 
     reasoned = loadOntology("/redundant_subclasses.owl");
@@ -274,11 +274,12 @@ public class ReasonOperationTest extends CoreTest {
    * @throws InvalidReferenceException if a reference is invalid
    */
   @Test
-  public void testExternal()
-      throws IOException, OWLOntologyCreationException, OntologyLogicException,
-          InvalidReferenceException {
+  public void testExternal() throws Exception {
     OWLOntology importOnt1 = loadOntology("/intersection.omn");
-    IRI oiri = importOnt1.getOntologyID().getOntologyIRI().get();
+    IRI oiri = importOnt1.getOntologyID().getOntologyIRI().orNull();
+    if (oiri == null) {
+      throw new Exception("Ontology 'intersection.omn' does not have an IRI");
+    }
     OWLOntology mainOnt = loadOntology("/simple.owl");
     OWLOntologyManager mgr = mainOnt.getOWLOntologyManager();
     OWLOntology importOnt = mgr.createOntology(oiri);


### PR DESCRIPTION
**Exceptions**:
- QueryParseException no longer fails silently
- If an exception does not have a pre-configured exception message, the Exception message is printed, instead of failing with "use -vvv to see stack trace"
- If a report query does not include `?entity`, it cannot be properly parsed - fail with message
- If an invalid `--catalog-file` is passed in, fail instead of logging a warning
- Check if something is `null` instead of waiting for a `NullPointerException`

With all these changes, I changes the `breakOn` statements for japicmp to false. We still get the reports, but the build won't fail because of these. I can change this to just ignore changed classes, if you'd prefer.

```
<breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications
<breakBuildOnSourceIncompatibleModifications>false</breakBuildOnSourceIncompatibleModifications>
```

**Optimization**:
- Collection types are inferred (`Map<String, String> myNewMap = new HashMap<>();`)
- Removed use of Guava `Optional`
- Removed redundant class casts
- Removed `if` statements that were always true (e.g. `if (state != null)` when it has already been checked to be not-null previously)
- Changed lambda expressions to `forEach` with Consumer
- Simplified boolean return statements
- Replaced instances of `x.indexOf(y) < 0` with `!x.contains(y)`
- Handle imports as sets of `ImportDeclaration` objects instead of sets of `OWLOntology` objects

I'm sorry if I missed something in this list, but this should pretty much cover the changes. This is just a proposal, so I'm happy to revert any of these changes if they don't make sense.

In `ReduceOperation`, I also found the variable `exprs` (a set of OWLClassExpressions) that is updated but it's never used. I left a `TODO` comment to look into this, but this could potentially just be removed before we merge these changes in.

Finally, as we've changed how many of the operations work, we include a lot of methods that are no longer used. I know we maintain these for backwards compatibility, but it may be nice to mark them as `@Deprecated` at some point as a warning to people who are still using them (this might be a `v2.0.0` release milestone)... I'd love to get thoughts on this.