### PR TITLE
Support relative paths for user rules in `report`

### DIFF
--- a/docs/report.md
+++ b/docs/report.md
@@ -67,12 +67,13 @@ robot report --input edit.owl \
   --output my-report.tsv
 ```
 
-For all default queries, include the query name shown above. If you do not wish to include a default query in your report, simply omit it from your profile. Any queries not named in the profile will not be run. Furthermore, your own queries can be included by providing the desired logging level followed by the path.
+For all default queries, include the query name shown above. If you do not wish to include a default query in your report, simply omit it from your profile. Any queries not named in the profile will not be run. Furthermore, your own queries can be included by providing the desired logging level followed by the absolute or relative path.
 
 This example would create a report with references to deprecated classes as ERROR and the user query violations as INFO:
 ```
-ERROR	deprecated_class
-INFO	file:///absolute/path/to/other_query.rq
+ERROR   deprecated_class
+INFO    file:///absolute/path/to/other_query.rq
+INFO    file:./relative/path/to/other_query.rq
 ```
 
 ---

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
@@ -361,6 +361,14 @@ public class Report {
     // Map of rule names and their violations
     for (Entry<String, List<Violation>> vs : violationSets.entrySet()) {
       String ruleName = vs.getKey();
+      // Strip user rule file paths
+      if (ruleName.contains("file:")) {
+        try {
+          ruleName = ruleName.substring(ruleName.lastIndexOf("/") + 1, ruleName.lastIndexOf("."));
+        } catch (Exception e) {
+          // Do nothing
+        }
+      }
       for (Violation v : vs.getValue()) {
         String subject = getDisplayName(pm, v.subject);
         for (Entry<String, List<String>> statement : v.statements.entrySet()) {
@@ -425,6 +433,14 @@ public class Report {
     sb.append(NEW_LINE);
     for (Entry<String, List<Violation>> vs : violationSets.entrySet()) {
       String ruleName = vs.getKey();
+      // Strip user rule file paths
+      if (ruleName.contains("file:")) {
+        try {
+          ruleName = ruleName.substring(ruleName.lastIndexOf("/") + 1, ruleName.lastIndexOf("."));
+        } catch (Exception e) {
+          // Do nothing
+        }
+      }
       if (vs.getValue().isEmpty()) {
         continue;
       }


### PR DESCRIPTION
Currently, adding a new rule to a report profile requires an absolute path. This makes it hard to maintain report profiles on github repos. I added a fix for this to support either relative paths or absolute paths, with doc updates.

Absolute: `file:///path/to/absolute.rq`

Relative: `file:./path/to/relative.rq`