### PR TITLE
Allow multiple labels with different lang tags

### DIFF
--- a/robot-core/src/main/resources/report_queries/multiple_labels.rq
+++ b/robot-core/src/main/resources/report_queries/multiple_labels.rq
@@ -1,6 +1,6 @@
 # # Multiple Labels
 #
-# Problem: An entity has more than one label. This may cause confusion or misuse, and will prevent translation to OBO format. Excludes deprecated entities.
+# Problem: An entity has more than one label. This may cause confusion or misuse, and will prevent translation to OBO format. Excludes deprecated entities. Allows for multiple labels with different language tags, assuming that if there is no language tag, it is an English label.
 #
 # Solution: Remove extra labels.
 
@@ -12,6 +12,9 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   ?entity ?property ?value .
   ?entity ?property ?value2 .
   FILTER (?value != ?value2) .
+  FILTER (lang(?value) = lang(?value2) ||
+  	((lang(?value) = "") && (lang(?value2) = "en")) ||
+  	((lang(?value) = "en") && (lang(?value2) = "")))
   FILTER NOT EXISTS { ?entity owl:deprecated true }
   FILTER (!isBlank(?entity))
 }


### PR DESCRIPTION
As discussed on the OFOC call yesterday, we should allow labels in different languages. This changes the report "multiple label" query to allow more than one label as long as they have different language tags. If there is no language tag, it assumes the language is English. If one label has no tag and the other has an `@en` tag, it will be reported as a violation.

See also https://github.com/information-artifact-ontology/ontology-metadata/issues/27