### PR TITLE
Stop using deprecated methods

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/ExtractOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExtractOperation.java
@@ -7,6 +7,7 @@ import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.parameters.Imports;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.manchester.cs.owlapi.modularity.ModuleType;
@@ -40,7 +41,7 @@ public class ExtractOperation {
 
     Set<OWLEntity> entities = new HashSet<>();
     for (IRI term : terms) {
-      entities.addAll(inputOntology.getEntitiesInSignature(term, true));
+      entities.addAll(inputOntology.getEntitiesInSignature(term, Imports.INCLUDED));
     }
 
     ModuleType type = moduleType;

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -613,6 +613,7 @@ public class IOHelper {
    * @param term the term to convert to an IRI
    * @return the new IRI
    */
+  @SuppressWarnings("unchecked")
   public IRI createIRI(String term) {
     if (term == null) {
       return null;
@@ -729,6 +730,7 @@ public class IOHelper {
    * @return a map from prefix name strings to prefix IRI strings
    * @throws IOException on any problem
    */
+  @SuppressWarnings("unchecked")
   public static Context parseContext(String jsonString) throws IOException {
     try {
       Object jsonObject = JsonUtils.fromString(jsonString);

--- a/robot-core/src/main/java/org/obolibrary/robot/OntologyHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/OntologyHelper.java
@@ -1,5 +1,6 @@
 package org.obolibrary.robot;
 
+import com.google.common.base.Optional;
 import java.util.*;
 import java.util.function.Function;
 import org.obolibrary.robot.checks.InvalidReferenceChecker;
@@ -1231,22 +1232,25 @@ public class OntologyHelper {
   public static void setOntologyIRI(OWLOntology ontology, IRI ontologyIRI, IRI versionIRI) {
     OWLOntologyID currentID = ontology.getOntologyID();
 
+    // Get rid of optionals when changing to OWLAPI 5
+    Optional<IRI> ont;
+    Optional<IRI> version;
+
     if (ontologyIRI == null && versionIRI == null) {
       // don't change anything
       return;
     } else if (ontologyIRI == null) {
-      ontologyIRI = currentID.getOntologyIRI().orNull();
+      ont = currentID.getOntologyIRI();
+      version = Optional.of(versionIRI);
     } else if (versionIRI == null) {
-      versionIRI = currentID.getVersionIRI().orNull();
-    }
-
-    OWLOntologyID newID;
-    if (versionIRI == null) {
-      newID = new OWLOntologyID(ontologyIRI);
+      version = currentID.getVersionIRI();
+      ont = Optional.of(ontologyIRI);
     } else {
-      newID = new OWLOntologyID(ontologyIRI, versionIRI);
+      ont = Optional.of(ontologyIRI);
+      version = Optional.of(versionIRI);
     }
 
+    OWLOntologyID newID = new OWLOntologyID(ont, version);
     SetOntologyID setID = new SetOntologyID(ontology, newID);
     ontology.getOWLOntologyManager().applyChange(setID);
   }

--- a/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
@@ -45,10 +45,12 @@ public class QueryOperation {
   /**
    * Load an ontology into a DatasetGraph. The ontology is not changed.
    *
+   * @deprecated use {@link #loadOntologyAsDataset(OWLOntology)} instead.
    * @param ontology The ontology to load into the graph
    * @return A new DatasetGraph with the ontology loaded into the default graph
    * @throws OWLOntologyStorageException rarely
    */
+  @Deprecated
   public static DatasetGraph loadOntology(OWLOntology ontology) throws OWLOntologyStorageException {
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     ontology.getOWLOntologyManager().saveOntology(ontology, new TurtleDocumentFormat(), os);
@@ -129,18 +131,20 @@ public class QueryOperation {
   }
 
   public static Dataset createEmptyDataset() {
-    return DatasetFactory.create(DatasetGraphFactory.create());
+    return DatasetFactory.create();
   }
 
   /**
    * Execute a SPARQL CONSTRUCT query on a graph and return the model.
    *
+   * @deprecated use {@link #execConstruct(Dataset, String)} instead.
    * @param dsg the graph to construct in
    * @param query the SPARQL construct query string
    * @return the result Model
    */
+  @Deprecated
   public static Model execConstruct(DatasetGraph dsg, String query) {
-    return execConstruct(DatasetFactory.create(dsg), query);
+    return execConstruct(DatasetFactory.wrap(dsg), query);
   }
 
   /**
@@ -158,13 +162,15 @@ public class QueryOperation {
   /**
    * Execute a SPARQL SELECT query on a graph and return a result set.
    *
+   * @deprecated use {@link #execQuery(Dataset, String)} instead.
    * @param dsg the graph to query
    * @param query the SPARQL query string
    * @return the result set
    * @throws IOException on query parse error
    */
+  @Deprecated
   public static ResultSet execQuery(DatasetGraph dsg, String query) throws IOException {
-    return execQuery(DatasetFactory.create(dsg), query);
+    return execQuery(DatasetFactory.wrap(dsg), query);
   }
 
   /**
@@ -216,15 +222,32 @@ public class QueryOperation {
    * Execute a SPARQL query and return true if there are any results, false otherwise. Prints
    * violations to STDERR.
    *
+   * @deprecated use {@link #execVerify(Dataset, String, String)} instead
+   *
    * @param dsg the graph to query over
    * @param ruleName name of rule to verify
    * @param query the SPARQL query string
    * @return true if the are results, false otherwise
    * @throws IOException on query parse error
    */
+  @Deprecated
   public static boolean execVerify(DatasetGraph dsg, String ruleName, String query)
       throws IOException {
-    ResultSetRewindable results = ResultSetFactory.copyResults(execQuery(dsg, query));
+    return execVerify(DatasetFactory.wrap(dsg), ruleName, query);
+  }
+
+  /**
+   * Execute a SPARQL query and return true if there are any results, false otherwise. Prints
+   * violations to STDERR.
+   *
+   * @param dataset the dataset to query
+   * @param ruleName name of rule to verify
+   * @param query the SPARQL query string
+   * @return true if the are results, false otherwise
+   * @throws IOException on query parse error
+   */
+  public static boolean execVerify(Dataset dataset, String ruleName, String query) throws IOException {
+    ResultSetRewindable results = ResultSetFactory.copyResults(execQuery(dataset, query));
     System.out.println("Rule " + ruleName + ": " + results.size() + " violation(s)");
     if (results.size() == 0) {
       System.out.println("PASS Rule " + ruleName + ": 0 violation(s)");
@@ -417,15 +440,17 @@ public class QueryOperation {
   /**
    * Run a SELECT query on a graph and write the results to a file.
    *
+   * @deprecated use {@link #runQuery(Dataset, String, File, Lang)} instead.
    * @param dsg the graph to query
    * @param query The SPARQL query string.
    * @param output The file to write to.
    * @param outputFormat The file format.
    * @throws IOException if output file is not found or query cannot be parsed
    */
+  @Deprecated
   public static void runQuery(DatasetGraph dsg, String query, File output, Lang outputFormat)
       throws IOException {
-    runQuery(DatasetFactory.create(dsg), query, output, outputFormat);
+    runQuery(DatasetFactory.wrap(dsg), query, output, outputFormat);
   }
 
   /**
@@ -448,6 +473,7 @@ public class QueryOperation {
   /**
    * Run a SPARQL query and return true if there were results, false otherwise.
    *
+   * @deprecated use {@link #runSparqlQuery(Dataset, String, String, OutputStream)} instead.
    * @param dsg the graph to query over
    * @param query the SPARQL query string
    * @param formatName the name of the output format
@@ -455,9 +481,10 @@ public class QueryOperation {
    * @return true if results, false if otherwise
    * @throws IOException on issue parsing query
    */
+  @Deprecated
   public static boolean runSparqlQuery(
       DatasetGraph dsg, String query, String formatName, OutputStream output) throws IOException {
-    return runSparqlQuery(DatasetFactory.create(dsg), query, formatName, output);
+    return runSparqlQuery(DatasetFactory.wrap(dsg), query, formatName, output);
   }
 
   /**
@@ -519,6 +546,7 @@ public class QueryOperation {
   /**
    * Run a SELECT query over the graph and write the result to a file. Prints violations to STDERR.
    *
+   * @deprecated use {@link #runVerify(Dataset, String, String, Path, Lang)} instead.
    * @param dsg The graph to query over.
    * @param ruleName name of the rule
    * @param query The SPARQL query string.
@@ -527,10 +555,11 @@ public class QueryOperation {
    * @throws IOException if output file is not found or query cannot be parsed
    * @return true if the are results (so file is written), false otherwise
    */
+  @Deprecated
   public static boolean runVerify(
       DatasetGraph dsg, String ruleName, String query, Path outputPath, Lang outputFormat)
       throws IOException {
-    return runVerify(DatasetFactory.create(dsg), ruleName, query, outputPath, outputFormat);
+    return runVerify(DatasetFactory.wrap(dsg), ruleName, query, outputPath, outputFormat);
   }
 
   /**

--- a/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
@@ -223,7 +223,6 @@ public class QueryOperation {
    * violations to STDERR.
    *
    * @deprecated use {@link #execVerify(Dataset, String, String)} instead
-   *
    * @param dsg the graph to query over
    * @param ruleName name of rule to verify
    * @param query the SPARQL query string
@@ -246,7 +245,8 @@ public class QueryOperation {
    * @return true if the are results, false otherwise
    * @throws IOException on query parse error
    */
-  public static boolean execVerify(Dataset dataset, String ruleName, String query) throws IOException {
+  public static boolean execVerify(Dataset dataset, String ruleName, String query)
+      throws IOException {
     ResultSetRewindable results = ResultSetFactory.copyResults(execQuery(dataset, query));
     System.out.println("Rule " + ruleName + ": " + results.size() + " violation(s)");
     if (results.size() == 0) {

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -447,13 +447,15 @@ public class ReportOperation {
   /**
    * Given an ontology as a DatasetGraph and a query, return the violations found by that query.
    *
+   * @deprecated use {@link #getViolations(Dataset, String)} instead.
    * @param dsg the ontology as a graph
    * @param query the query
    * @return List of Violations
    * @throws IOException on issue parsing query
    */
+  @Deprecated
   private static List<Violation> getViolations(DatasetGraph dsg, String query) throws IOException {
-    return getViolations(DatasetFactory.create(dsg), query);
+    return getViolations(DatasetFactory.wrap(dsg), query);
   }
 
   /**
@@ -477,7 +479,7 @@ public class ReportOperation {
         return null;
       }
       // skip RDFS and OWL terms
-      if (entity != null && (entity.contains("/rdf-schema#") || entity.contains("/owl#"))) {
+      if (entity.contains("/rdf-schema#") || entity.contains("/owl#")) {
         continue;
       }
       Violation violation = new Violation(entity);

--- a/robot-core/src/test/java/org/obolibrary/robot/CoreTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/CoreTest.java
@@ -8,13 +8,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Set;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.AxiomType;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLDataFactory;
-import org.semanticweb.owlapi.model.OWLDeclarationAxiom;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.*;
 import uk.ac.manchester.cs.owl.owlapi.OWLDataFactoryImpl;
 
 /** Helper methods for core tests. */
@@ -68,7 +62,7 @@ public class CoreTest {
     // TODO: move logic here to IOHelper
     // IOHelper ioh = new IOHelper();
     OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
-    manager.addIRIMapper(new CatalogXmlIRIMapper(catalogFile));
+    manager.getIRIMappers().add(new CatalogXmlIRIMapper(catalogFile));
     return manager.loadOntology(ontologyIRI);
   }
 

--- a/robot-core/src/test/java/org/obolibrary/robot/ReasonOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ReasonOperationTest.java
@@ -73,7 +73,7 @@ public class ReasonOperationTest extends CoreTest {
       throws IOException, OWLOntologyCreationException, OntologyLogicException,
           InvalidReferenceException {
     OWLOntology reasoned = loadOntology("/simple.owl");
-    OWLReasonerFactory reasonerFactory = new org.semanticweb.HermiT.Reasoner.ReasonerFactory();
+    OWLReasonerFactory reasonerFactory = new org.semanticweb.HermiT.ReasonerFactory();
     ReasonOperation.reason(reasoned, reasonerFactory);
     assertEquals(6, reasoned.getAxiomCount());
     assertIdentical("/simple_hermit.owl", reasoned);
@@ -111,7 +111,7 @@ public class ReasonOperationTest extends CoreTest {
       throws IOException, OWLOntologyCreationException, OntologyLogicException,
           InvalidReferenceException {
     OWLOntology reasoned = loadOntology("/simple.owl");
-    OWLReasonerFactory reasonerFactory = new org.semanticweb.HermiT.Reasoner.ReasonerFactory();
+    OWLReasonerFactory reasonerFactory = new org.semanticweb.HermiT.ReasonerFactory();
     Map<String, String> opts = new HashMap<>();
     // see https://github.com/ontodev/robot/issues/80
     opts.put("create-new-ontology", "true");
@@ -135,7 +135,7 @@ public class ReasonOperationTest extends CoreTest {
       throws IOException, OWLOntologyCreationException, OntologyLogicException,
           InvalidReferenceException {
     OWLOntology reasoned = loadOntology("/relax_equivalence_axioms_test.obo");
-    OWLReasonerFactory reasonerFactory = new org.semanticweb.HermiT.Reasoner.ReasonerFactory();
+    OWLReasonerFactory reasonerFactory = new org.semanticweb.HermiT.ReasonerFactory();
     Map<String, String> opts = new HashMap<>();
 
     // see https://github.com/ontodev/robot/issues/80
@@ -163,7 +163,7 @@ public class ReasonOperationTest extends CoreTest {
       throws IOException, OWLOntologyCreationException, OntologyLogicException,
           InvalidReferenceException {
     OWLOntology reasoned = loadOntology("/relax_equivalence_axioms_test.obo");
-    OWLReasonerFactory reasonerFactory = new org.semanticweb.HermiT.Reasoner.ReasonerFactory();
+    OWLReasonerFactory reasonerFactory = new org.semanticweb.HermiT.ReasonerFactory();
     Map<String, String> opts = new HashMap<>();
     opts.put("create-new-ontology", "true");
     opts.put("annotate-inferred-axioms", "true");

--- a/robot-core/src/test/java/org/obolibrary/robot/RelatedObjectsHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/RelatedObjectsHelperTest.java
@@ -27,6 +27,7 @@ public class RelatedObjectsHelperTest extends CoreTest {
    * @throws IOException on any problem
    */
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetCompleteAxioms() throws IOException {
     IOHelper ioHelper = new IOHelper();
     String base = "https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl#";
@@ -57,6 +58,7 @@ public class RelatedObjectsHelperTest extends CoreTest {
    * @throws IOException on any problem
    */
   @Test
+  @SuppressWarnings("unchecked")
   public void testGetPartialAxioms() throws IOException {
     IOHelper ioHelper = new IOHelper();
     String base = "https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl#";


### PR DESCRIPTION
See #408 

Also adds `@Deprecated` warnings and Javadoc comments to methods that use Jena's `DatasetGraph` instead of `Dataset`.