### PR TITLE
Report Query Bug Fixes

### DIFF
--- a/robot-core/src/main/resources/report_profile.txt
+++ b/robot-core/src/main/resources/report_profile.txt
@@ -1,5 +1,6 @@
 WARN	annotation_whitespace
 ERROR	deprecated_class_reference
+ERROR	deprecated_property_reference
 ERROR	duplicate_definition
 WARN	duplicate_exact_synonym
 WARN	duplicate_label_synonym

--- a/robot-core/src/main/resources/report_queries/deprecated_class_reference.rq
+++ b/robot-core/src/main/resources/report_queries/deprecated_class_reference.rq
@@ -26,13 +26,9 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
    ?entity a owl:Class ;
            owl:deprecated true ;
            ?property ?value .
-   FILTER NOT EXISTS { ?property a owl:AnnotationProperty }
-   FILTER (?property != obo:IAO_0000231)
-   FILTER (?property != rdf:type)
-   FILTER (?property != owl:deprecated)
-   FILTER (?value != oboInOwl:ObsoleteClass)
-   OPTIONAL { ?entity rdfs:subClassOf ?value
-              FILTER (isBlank(?value)) }
+   FILTER EXISTS { ?property a owl:ObjectProperty }
+   FILTER EXISTS { ?property a owl:DatatypeProperty }
+   FILTER ( ?value != oboInOwl:ObsoleteClass )
   }
   UNION
   {

--- a/robot-core/src/main/resources/report_queries/deprecated_class_reference.rq
+++ b/robot-core/src/main/resources/report_queries/deprecated_class_reference.rq
@@ -15,27 +15,36 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
    VALUES ?property {
      owl:equivalentClass
      rdfs:subClassOf
+     owl:disjointWith
    }
-   ?entity owl:deprecated true .
+   ?entity a owl:Class;
+           owl:deprecated true .
    ?value ?property ?entity .
-   FILTER NOT EXISTS { ?entity rdfs:subClassOf oboInOwl:ObsoleteClass }
   }
   UNION
   {
-   ?entity owl:deprecated true .
-   ?entity ?property ?value .
+   ?entity a owl:Class ;
+           owl:deprecated true ;
+           ?property ?value .
+   FILTER NOT EXISTS { ?property a owl:AnnotationProperty }
    FILTER (?property != obo:IAO_0000231)
    FILTER (?property != rdf:type)
-   FILTER NOT EXISTS { ?property a owl:AnnotationProperty }
-   FILTER NOT EXISTS {
-     ?entity rdfs:subClassOf ?value .
-     FILTER (!isBlank(?value))
+   FILTER (?property != owl:deprecated)
+   FILTER (?value != oboInOwl:ObsoleteClass)
+   OPTIONAL { ?entity rdfs:subClassOf ?value
+              FILTER (isBlank(?value)) }
+  }
+  UNION
+  {
+   VALUES ?property {
+     owl:someValuesFrom
+     owl:allValuesFrom
    }
-   FILTER NOT EXISTS {
-     ?entity rdfs:subPropertyOf ?value .
-     FILTER (!isBlank(?value))
-   }
-   FILTER NOT EXISTS { ?entity rdfs:subClassOf oboInOwl:ObsoleteClass }
+   ?value a owl:Class ;
+          owl:deprecated true .
+   ?entity ?x ?rest .
+   ?rest a owl:Restriction ;
+         ?property ?value .
   }
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/deprecated_property_reference.rq
+++ b/robot-core/src/main/resources/report_queries/deprecated_property_reference.rq
@@ -1,0 +1,47 @@
+# # Deprecated Property Reference
+#
+# **Problem:** A deprecated property is used in a logical axiom. A deprecated property can be the child of another property (e.g., ObsoleteProperty), but it cannot have children or be used in blank nodes or equivalence statements. Additionally, a deprecated property should not have any equivalent properties.
+#
+# **Solution:** Replace deprecated property.
+
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+  {
+   VALUES ?property {
+     owl:equivalentProperty
+     rdfs:subPropertyOf
+     owl:inverseOf
+   }
+   ?entity a owl:ObjectProperty ;
+           owl:deprecated true .
+   ?value ?property ?entity .
+  }
+  UNION
+  {
+   VALUES ?property {
+     owl:equivalentProperty
+     rdfs:subPropertyOf
+   }
+   ?entity a owl:DatatypeProperty ;
+           owl:deprecated true .
+   ?value ?property ?entity .
+  }
+  UNION
+  {
+   ?property owl:deprecated true .
+   ?entity ?property ?value .
+  }
+  UNION
+  {
+   ?property owl:deprecated true .
+   ?entity ?x ?value .
+   ?value a owl:Restriction ;
+          owl:onProperty ?property .
+  }
+}
+ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/duplicate_label.rq
+++ b/robot-core/src/main/resources/report_queries/duplicate_label.rq
@@ -14,5 +14,6 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   ?entity2 ?property ?value .
   FILTER (?entity != ?entity2)
   FILTER (!isBlank(?entity))
+  FILTER (!isBlank(?entity2))
 }
 ORDER BY DESC(UCASE(str(?value)))

--- a/robot-core/src/main/resources/report_queries/missing_definition.rq
+++ b/robot-core/src/main/resources/report_queries/missing_definition.rq
@@ -13,26 +13,10 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
-  { VALUES ?property { obo:IAO_0000115 }
-    ?entity ?any ?o
-      FILTER NOT EXISTS { ?entity ?property ?value }
-      FILTER NOT EXISTS { ?entity obo:IAO_0000600 ?elucidation }
-      FILTER NOT EXISTS { ?entity a owl:Ontology }
-      FILTER NOT EXISTS { ?entity a owl:NamedIndividual }
-      FILTER NOT EXISTS { ?entity owl:deprecated true }
-      FILTER NOT EXISTS {
-        ?entity rdfs:subPropertyOf oboInOwl:SubsetProperty .
-      }
-      FILTER EXISTS {
-        ?entity ?prop2 ?object .
-        FILTER (?prop2 != rdf:type)
-      }
-      FILTER (!isBlank(?entity))
-  } UNION {
-  VALUES ?property { obo:IAO_0000600 }
+  VALUES ?property { obo:IAO_0000115 }
   ?entity ?any ?o
   FILTER NOT EXISTS { ?entity ?property ?value }
-  FILTER NOT EXISTS { ?entity obo:IAO_0000115 ?definition }
+  FILTER NOT EXISTS { ?entity obo:IAO_0000600 ?elucidation }
   FILTER NOT EXISTS { ?entity a owl:Ontology }
   FILTER NOT EXISTS { ?entity a owl:NamedIndividual }
   FILTER NOT EXISTS { ?entity owl:deprecated true }
@@ -43,6 +27,5 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
     ?entity ?prop2 ?object .
     FILTER (?prop2 != rdf:type)
   }
-  FILTER (!isBlank(?entity))
-} }
+  FILTER (!isBlank(?entity)) }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/missing_definition.rq
+++ b/robot-core/src/main/resources/report_queries/missing_definition.rq
@@ -13,10 +13,26 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
-  VALUES ?property { obo:IAO_0000115
-                     obo:IAO_0000600 }
+  { VALUES ?property { obo:IAO_0000115 }
+    ?entity ?any ?o
+      FILTER NOT EXISTS { ?entity ?property ?value }
+      FILTER NOT EXISTS { ?entity obo:IAO_0000600 ?elucidation }
+      FILTER NOT EXISTS { ?entity a owl:Ontology }
+      FILTER NOT EXISTS { ?entity a owl:NamedIndividual }
+      FILTER NOT EXISTS { ?entity owl:deprecated true }
+      FILTER NOT EXISTS {
+        ?entity rdfs:subPropertyOf oboInOwl:SubsetProperty .
+      }
+      FILTER EXISTS {
+        ?entity ?prop2 ?object .
+        FILTER (?prop2 != rdf:type)
+      }
+      FILTER (!isBlank(?entity))
+  } UNION {
+  VALUES ?property { obo:IAO_0000600 }
   ?entity ?any ?o
   FILTER NOT EXISTS { ?entity ?property ?value }
+  FILTER NOT EXISTS { ?entity obo:IAO_0000115 ?definition }
   FILTER NOT EXISTS { ?entity a owl:Ontology }
   FILTER NOT EXISTS { ?entity a owl:NamedIndividual }
   FILTER NOT EXISTS { ?entity owl:deprecated true }
@@ -28,5 +44,5 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
     FILTER (?prop2 != rdf:type)
   }
   FILTER (!isBlank(?entity))
-}
+} }
 ORDER BY ?entity


### PR DESCRIPTION
The `deprecated_class_reference` report query was not restricted to classes, even though the name implies that it would be.

This PR adds a `deprecated_property_reference` check and changes `deprecated_class_reference` to *only* check for `owl:Class` types.

Additionally, deprecated classes and properties used in blank nodes were not caught. This adds checks for `owl:onProperty` and `owl:someValuesFrom`/`owl:allValuesFrom` so that those references are properly reported on.

A deprecated property reference in a blank node will look like:
```
ERROR	deprecated_property_reference	continuant [BFO:0000002]	obsolete property [CURIE]	blank node <0145c707bfd631ae3708d939e50fa691>
```

And a deprecated class reference in a blank node will look like:
```
ERROR	deprecated_class_reference	occurrent [BFO:0000003]	owl:someValuesFrom	obsolete class [CURIE]
```

These aren't technically subject, property, object format, but the subject is the entity that the axiom is attached to, so it's easier to find the axiom.

----

**Other Fixes**

* Deprecated class references found if things like `rdfs:label` were not asserted to be annotation properties
* Missing definition errors were duplicated for the elucidation property
* `rdfs:label` used on blank nodes (e.g. as an axiom annotation on an xref) were showing up as duplicate labels