### PR TITLE
Add more detailed OBO errors

### DIFF
--- a/docs/convert.md
+++ b/docs/convert.md
@@ -44,12 +44,6 @@ grep -v ^owl-axioms
 
 `--check` only accepts `true` or `false` (not case sensitive) as arguments. By default, `--check` is true and the OBO document structure checks are performed.
 
-### OBO Structure Error
-
-If `--check` is true (which, by default, it is), the [document structure rules](http://owlcollab.github.io/oboformat/doc/obo-syntax.html#4) are strictly enforced. You may choose to review the exception message by running the command again with `--very-very-verbose`, or run `convert` with the `--check false` option to ignore the errors.
-
-Please note that `--check false` may result in some unintended output. For example, for terms with more than one definition annotation, a defintion will be chosen at random.
-
 ### Output Error
 
 `convert` requires exactly one `--output`. If you do not specify the `--output`, or specify more than one, ROBOT cannot proceed. If chaining commands, place `convert` last.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -80,9 +80,9 @@ For all commands other than [merge](/merge) and [unmerge](/unmerge), only one `-
 
 ### OBO Structure Error
 
-When running the [convert](/convert) command, if `--check` is true (which, by default, it is), the [document structure rules](http://owlcollab.github.io/oboformat/doc/obo-syntax.html#4) are strictly enforced. If you are saving an ontology in OBO format from another command, `--check` is always `true`. 
+When running the [convert](/convert) command, if `--check` is true (default behavior), the [document structure rules](http://owlcollab.github.io/oboformat/doc/obo-syntax.html#4) are strictly enforced. If you are saving an ontology in OBO format from another command, `--check` is always `true`. 
 
-You may choose to review the full exception message by running the command again with `-vvv`, or run convert (or chain to convert) with the `--check false` option to ignore the errors, e.g.:
+You may run convert (or chain to convert) with the `--check false` option to ignore the errors, e.g.:
 ```
 robot reason --input ont.owl \
   convert --check false --output ont.obo

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -78,6 +78,18 @@ Some commands ([extract](/extract) and [filter](/filter)) require terms as input
 
 For all commands other than [merge](/merge) and [unmerge](/unmerge), only one `--input` may be specified.
 
+### OBO Structure Error
+
+When running the [convert](/convert) command, if `--check` is true (which, by default, it is), the [document structure rules](http://owlcollab.github.io/oboformat/doc/obo-syntax.html#4) are strictly enforced. If you are saving an ontology in OBO format from another command, `--check` is always `true`. 
+
+You may choose to review the full exception message by running the command again with `-vvv`, or run convert (or chain to convert) with the `--check false` option to ignore the errors, e.g.:
+```
+robot reason --input ont.owl \
+  convert --check false --output ont.obo
+```
+
+Please note that `--check false` may result in some unintended output. For example, for terms with more than one definition annotation, a definition will be chosen at random.
+
 ### Ontology Storage Error
 
 The ontology could not be saved to the specified IRI. The most common reasons are: the IRI is not a valid file path; ROBOT does not have write permissions; there is not enough space on the storage device.

--- a/robot-command/src/main/java/org/obolibrary/robot/ConvertCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ConvertCommand.java
@@ -1,7 +1,6 @@
 package org.obolibrary.robot;
 
 import java.io.File;
-import java.io.IOException;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.commons.io.FilenameUtils;
@@ -34,10 +33,6 @@ public class ConvertCommand implements Command {
 
   /** Error message when a --format is not specified and the --output does not have an extension. */
   private static final String missingFormatError = NS + "FORMAT ERROR an output format is required";
-
-  /** Error message when --check is true and the document is not in valid OBO structure */
-  private static final String oboStructureError =
-      NS + "OBO STRUCTURE ERROR the ontology does not conform to OBO structure rules";
 
   /** Store the command-line options for the command. */
   private Options options;
@@ -163,18 +158,7 @@ public class ConvertCommand implements Command {
       throw new IllegalArgumentException(checkArgError);
     }
 
-    try {
-      ioHelper.saveOntology(ontology, IOHelper.getFormat(formatName), outputFile, checkOBO);
-    } catch (IOException e) {
-      // specific feedback for writing to OBO
-      if (e.getMessage().contains("FrameStructureException")) {
-        logger.debug(e.getMessage());
-        throw new Exception(oboStructureError, e);
-      } else {
-        throw e;
-      }
-    }
-
+    ioHelper.saveOntology(ontology, IOHelper.getFormat(formatName), outputFile, checkOBO);
     return state;
   }
 }

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -90,7 +90,7 @@ public class IOHelper {
 
   /** Error message when OBO cannot be saved. */
   private static final String oboStructureError =
-      NS + "OBO STRUCTURE ERROR Ontology does not conform to OBO structure rules:\n\t%s";
+      NS + "OBO STRUCTURE ERROR Ontology does not conform to OBO structure rules:\n%s";
 
   /** Error message when the ontology cannot be saved. Expects the IRI string. */
   private static final String ontologyStorageError =
@@ -1176,9 +1176,8 @@ public class IOHelper {
         // Determine if its caused by an OBO Format error
         if (format instanceof OBODocumentFormat
             && e.getCause() instanceof FrameStructureException) {
-          // Trim the message (the user can run -vvv to see full message)
-          String trim = e.getCause().getLocalizedMessage().substring(0, 100) + "...";
-          throw new IOException(String.format(oboStructureError, trim), e);
+          throw new IOException(
+              String.format(oboStructureError, e.getCause().getMessage()), e.getCause());
         }
         throw new IOException(String.format(ontologyStorageError, ontologyIRI.toString()), e);
       }


### PR DESCRIPTION
Currently, if you try to save an ontology in OBO format that breaks some of the format rules, it gives a very uninformative error message.

This PR adds the full details of the `FrameStructureException` to the error message, e.g.:

![image](https://user-images.githubusercontent.com/16750150/54467477-8b2e6d00-4742-11e9-9f33-29d98b5d1196.png)

See #284 