### PR TITLE
Fix invalid reference violations for built-ins

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidReferenceChecker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidReferenceChecker.java
@@ -29,12 +29,22 @@ public class InvalidReferenceChecker {
   public static boolean isDangling(OWLOntology ontology, OWLEntity entity) {
     if (entity instanceof OWLClass) {
       OWLClass owlClass = (OWLClass) entity;
-      if (ontology.getAxioms(owlClass, Imports.INCLUDED).size() > 0) return false;
+      // Ignore OWLThing and OWLNothing
+      // Not dangling if there are axioms about the class
+      if (owlClass.isOWLThing()
+          || owlClass.isOWLNothing()
+          || ontology.getAxioms(owlClass, Imports.INCLUDED).size() > 0) return false;
       return ontology.getAnnotationAssertionAxioms(owlClass.getIRI()).size() <= 0;
     }
     if (entity instanceof OWLObjectProperty) {
       OWLObjectProperty owlProperty = (OWLObjectProperty) entity;
-      if (ontology.getAxioms(owlProperty, Imports.INCLUDED).size() > 0) return false;
+      // Ignore top and bottom properties
+      // Not dangling if there are axioms about the property
+      if (owlProperty.isOWLBottomDataProperty()
+          || owlProperty.isOWLTopDataProperty()
+          || owlProperty.isOWLBottomObjectProperty()
+          || owlProperty.isOWLTopObjectProperty()
+          || ontology.getAxioms(owlProperty, Imports.INCLUDED).size() > 0) return false;
       return ontology.getAnnotationAssertionAxioms(owlProperty.getIRI()).size() <= 0;
     }
     return false;


### PR DESCRIPTION
For #374. Ignore `owl:Thing`, `owl:Nothing`, and the top and bottom properties when checking if an entity is dangling.

Previously, when running `reason` over BFO, this error was logged:
```
2019-03-18 14:24:12,787 ERROR org.obolibrary.robot.ReasonOperation - Reference violation: InvalidReferenceViolation [axiom=SubClassOf(<http://purl.obolibrary.org/obo/BFO_0000001> owl:Thing), referencedObject=owl:Thing, category=DANGLING]
```

After this change, no errors are logged when reasoning over BFO.