### PR TITLE
Use TDB datasets to execute query on disk

### DIFF
--- a/docs/examples/nucleus.ttl
+++ b/docs/examples/nucleus.ttl
@@ -1,0 +1,191 @@
+@prefix : <http://purl.obolibrary.org/obo/go.owl#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@base <http://purl.obolibrary.org/obo/go.owl> .
+
+<http://purl.obolibrary.org/obo/go.owl> rdf:type owl:Ontology .
+
+#################################################################
+#    Annotation properties
+#################################################################
+
+###  http://www.w3.org/2000/01/rdf-schema#label
+rdfs:label rdf:type owl:AnnotationProperty .
+
+
+#################################################################
+#    Datatypes
+#################################################################
+
+###  http://www.w3.org/2001/XMLSchema#string
+xsd:string rdf:type rdfs:Datatype .
+
+
+#################################################################
+#    Object Properties
+#################################################################
+
+###  http://purl.obolibrary.org/obo/BFO_0000050
+<http://purl.obolibrary.org/obo/BFO_0000050> rdf:type owl:ObjectProperty ,
+                                                      owl:TransitiveProperty .
+
+
+#################################################################
+#    Classes
+#################################################################
+
+###  http://purl.obolibrary.org/obo/GO_0005575
+<http://purl.obolibrary.org/obo/GO_0005575> rdf:type owl:Class ;
+                                            rdfs:label "cellular_component" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0005622
+<http://purl.obolibrary.org/obo/GO_0005622> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0044464> ;
+                                            rdfs:label "intracellular" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0005623
+<http://purl.obolibrary.org/obo/GO_0005623> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0005575> ;
+                                            rdfs:label "cell" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0005634
+<http://purl.obolibrary.org/obo/GO_0005634> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0043231> ;
+                                            rdfs:label "nucleus" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0031974
+<http://purl.obolibrary.org/obo/GO_0031974> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0005575> ;
+                                            rdfs:label "membrane-enclosed lumen" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0031981
+<http://purl.obolibrary.org/obo/GO_0031981> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0044428> ,
+                                                            <http://purl.obolibrary.org/obo/GO_0070013> ,
+                                                            [ rdf:type owl:Restriction ;
+                                                              owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                              owl:someValuesFrom <http://purl.obolibrary.org/obo/GO_0005634>
+                                                            ] ;
+                                            rdfs:label "nuclear lumen" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0043226
+<http://purl.obolibrary.org/obo/GO_0043226> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0005575> ;
+                                            rdfs:label "organelle" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0043227
+<http://purl.obolibrary.org/obo/GO_0043227> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0043226> ;
+                                            rdfs:label "membrane-bounded organelle" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0043229
+<http://purl.obolibrary.org/obo/GO_0043229> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0043226> ,
+                                                            <http://purl.obolibrary.org/obo/GO_0044424> ,
+                                                            [ rdf:type owl:Restriction ;
+                                                              owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                              owl:someValuesFrom <http://purl.obolibrary.org/obo/GO_0005622>
+                                                            ] ;
+                                            rdfs:label "intracellular organelle" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0043231
+<http://purl.obolibrary.org/obo/GO_0043231> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0043227> ,
+                                                            <http://purl.obolibrary.org/obo/GO_0043229> ;
+                                            rdfs:label "intracellular membrane-bounded organelle" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0043233
+<http://purl.obolibrary.org/obo/GO_0043233> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0031974> ,
+                                                            <http://purl.obolibrary.org/obo/GO_0044422> ,
+                                                            [ rdf:type owl:Restriction ;
+                                                              owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                              owl:someValuesFrom <http://purl.obolibrary.org/obo/GO_0043226>
+                                                            ] ;
+                                            rdfs:label "organelle lumen" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0044422
+<http://purl.obolibrary.org/obo/GO_0044422> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0005575> ,
+                                                            [ rdf:type owl:Restriction ;
+                                                              owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                              owl:someValuesFrom <http://purl.obolibrary.org/obo/GO_0043226>
+                                                            ] ;
+                                            rdfs:label "organelle part" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0044424
+<http://purl.obolibrary.org/obo/GO_0044424> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0044464> ,
+                                                            [ rdf:type owl:Restriction ;
+                                                              owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                              owl:someValuesFrom <http://purl.obolibrary.org/obo/GO_0005622>
+                                                            ] ;
+                                            rdfs:label "intracellular part" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0044428
+<http://purl.obolibrary.org/obo/GO_0044428> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0044446> ,
+                                                            [ rdf:type owl:Restriction ;
+                                                              owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                              owl:someValuesFrom <http://purl.obolibrary.org/obo/GO_0005634>
+                                                            ] ;
+                                            rdfs:label "nuclear part" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0044446
+<http://purl.obolibrary.org/obo/GO_0044446> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0044422> ,
+                                                            <http://purl.obolibrary.org/obo/GO_0044424> ,
+                                                            [ rdf:type owl:Restriction ;
+                                                              owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                              owl:someValuesFrom <http://purl.obolibrary.org/obo/GO_0005622>
+                                                            ] ,
+                                                            [ rdf:type owl:Restriction ;
+                                                              owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                              owl:someValuesFrom <http://purl.obolibrary.org/obo/GO_0043226>
+                                                            ] ,
+                                                            [ rdf:type owl:Restriction ;
+                                                              owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                              owl:someValuesFrom <http://purl.obolibrary.org/obo/GO_0043229>
+                                                            ] ;
+                                            rdfs:label "intracellular organelle part" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0044464
+<http://purl.obolibrary.org/obo/GO_0044464> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0005575> ,
+                                                            [ rdf:type owl:Restriction ;
+                                                              owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                              owl:someValuesFrom <http://purl.obolibrary.org/obo/GO_0005623>
+                                                            ] ;
+                                            rdfs:label "cell part" .
+
+
+###  http://purl.obolibrary.org/obo/GO_0070013
+<http://purl.obolibrary.org/obo/GO_0070013> rdf:type owl:Class ;
+                                            rdfs:subClassOf <http://purl.obolibrary.org/obo/GO_0043233> ,
+                                                            <http://purl.obolibrary.org/obo/GO_0044446> ,
+                                                            [ rdf:type owl:Restriction ;
+                                                              owl:onProperty <http://purl.obolibrary.org/obo/BFO_0000050> ;
+                                                              owl:someValuesFrom <http://purl.obolibrary.org/obo/GO_0043229>
+                                                            ] ;
+                                            rdfs:label "intracellular organelle lumen" .
+
+
+###  Generated by the OWL API (version 4.5.6) https://github.com/owlcs/owlapi

--- a/docs/query.md
+++ b/docs/query.md
@@ -61,6 +61,19 @@ The `--update` option only updates the ontology itself, not any of the imports.
 
 **Warning:** The output of SPARQL updates will not include `xsd:string` datatypes, because `xsd:string` is considered implicit in RDF version 1.1. This behaviour differs from other ROBOT commands, where `xsd:string` datatypes from the input are maintained in the output.
 
+## Executing on Disk
+
+For very large ontologies, it may be beneficial to load the ontology to a mapping file on disk rather than loading it into memory. This is supported by [Jena TDB Datasets](http://jena.apache.org/documentation/tdb/datasets.html). To execute a query with TDB, use `--tdb true`:
+ 
+    robot query --input nucleus.ttl --tdb true \
+     --query cell_part.sparql results/cell_part.csv
+ 
+Please not that this will only work with ontologies in RDF/XML (`.owl` or `.rdf`) or TTL syntax (`.ttl`). ROBOT will create a directory to store the ontology as a dataset, which defaults to `.tdb`. You can change the location of the TDB directory by using `--tdb-directory <directory>`.
+
+Once the query operation is complete, ROBOT will remove the TDB directory. If you are performing many query commands on one ontology, you can include `--keep-tdb-mappings true` to prevent ROBOT from removing the TDB directory. This will greatly reduce the execution time of subsequent queries.
+
+The ontology is never loaded as an `OWLOntology` object, since doing so loads the whole ontology into memory. Therefore, TDB cannot be used while chaining commands or with the `--update` option.
+
 ---
 
 ## Error Messages
@@ -80,3 +93,11 @@ The query was not able to be parsed. Often, this is as a result of an undefined 
 ### Query Type Error
 
 Each SPARQL query should be a SELECT, ASK, DESCRIBE, or CONSTRUCT.
+
+### Syntax Error
+
+This error occurs when an ontology cannot be loaded from file to a TDB dataset. Review your ontology to ensure it is valid RDF/XML or TTL syntax.
+
+### TDB Format Error
+
+`--tdb true` can only be used with RDF/XML (`.owl` or `.rdf`) or TTL syntax (`.ttl`).

--- a/docs/query.md
+++ b/docs/query.md
@@ -68,7 +68,7 @@ For very large ontologies, it may be beneficial to load the ontology to a mappin
     robot query --input nucleus.ttl --tdb true \
      --query cell_part.sparql results/cell_part.csv
  
-Please not that this will only work with ontologies in RDF/XML (`.owl` or `.rdf`) or TTL syntax (`.ttl`). ROBOT will create a directory to store the ontology as a dataset, which defaults to `.tdb`. You can change the location of the TDB directory by using `--tdb-directory <directory>`.
+Please note that this will only work with ontologies in RDF/XML (`.owl` or `.rdf`) or TTL syntax (`.ttl`). Attempting to load an ontology in a different syntax will result in a [Syntax Error](/query#syntax-error). ROBOT will create a directory to store the ontology as a dataset, which defaults to `.tdb`. You can change the location of the TDB directory by using `--tdb-directory <directory>`.
 
 Once the query operation is complete, ROBOT will remove the TDB directory. If you are performing many query commands on one ontology, you can include `--keep-tdb-mappings true` to prevent ROBOT from removing the TDB directory. This will greatly reduce the execution time of subsequent queries.
 

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
@@ -456,7 +456,8 @@ public class CommandLineHelper {
    * @throws IOException if the ontology cannot be loaded
    */
   public static OWLOntology getInputOntology(
-      IOHelper ioHelper, CommandLine line, String catalogPath) throws IllegalArgumentException, IOException {
+      IOHelper ioHelper, CommandLine line, String catalogPath)
+      throws IllegalArgumentException, IOException {
     List<String> inputOntologyPaths = getOptionalValues(line, "input");
     List<String> inputOntologyIRIs = getOptionalValues(line, "input-iri");
 

--- a/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
@@ -159,6 +159,9 @@ public class QueryOperation {
       FileManager.get().readModel(m, inputPath);
       dataset.commit();
     } catch (JenaException e) {
+      dataset.abort();
+      dataset.end();
+      dataset.close();
       throw new IOException(String.format(syntaxError, inputPath, e.getMessage()));
     } finally {
       dataset.end();


### PR DESCRIPTION
## Executing on Disk
For very large ontologies, it may be beneficial to load the ontology to a mapping file on disk rather than loading it into memory. This is supported by [Jena TDB Datasets](http://jena.apache.org/documentation/tdb/datasets.html). To execute a query with TDB, use `--tdb true`:
 
    robot query --input nucleus.ttl --tdb true \
     --query cell_part.sparql results/cell_part.csv
 
Please note that this will only work with ontologies in RDF/XML (`.owl` or `.rdf`) or TTL syntax (`.ttl`). Attempting to load an ontology in a different syntax will result in a [Syntax Error](/query#syntax-error). ROBOT will create a directory to store the ontology as a dataset, which defaults to `.tdb`. You can change the location of the TDB directory by using `--tdb-directory <directory>`.

Once the query operation is complete, ROBOT will remove the TDB directory. If you are performing many query commands on one ontology, you can include `--keep-tdb-mappings true` to prevent ROBOT from removing the TDB directory. This will greatly reduce the execution time of subsequent queries.

The ontology is never loaded as an `OWLOntology` object, since doing so loads the whole ontology into memory. Therefore, TDB cannot be used while chaining commands or with the `--update` option.
