### PR TITLE
Is lower-case defintion-test correct?

### DIFF
--- a/robot-core/src/main/resources/report_queries/lowercase_definition.rq
+++ b/robot-core/src/main/resources/report_queries/lowercase_definition.rq
@@ -10,6 +10,6 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   VALUES ?property { obo:IAO_0000115
                      obo:IAO_0000600 }
   ?entity ?property ?value .
-  FILTER (!regex(?value, "^[A-Z]"))
+  FILTER (!regex(?value, "^[A-Z0-9]"))
 }
 ORDER BY ?entity


### PR DESCRIPTION
Hi,

for hpo I get the report:

`INFO	lowercase_definition	HP:0030271	IAO:0000115	2,3-diphosphoglycerate (2,3-DPG) controls the movement of ...
`

Is this expected behaviour? This PR could fix this maybe, if this not intended behaviour.