### PR TITLE
Fix bug with --force option

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/ExtractOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExtractOperation.java
@@ -53,6 +53,7 @@ public class ExtractOperation {
     options.put("copy-ontology-annotations", "false");
     options.put("annotate-with-source", "false");
     options.put("intermediates", "all");
+    options.put("force", "false");
     return options;
   }
 


### PR DESCRIPTION
See #434 - `--force` was added but the option was not properly picked up because it was not in the default extract options (`ExtractOperation.getDefaultOptions()`)