### PR TITLE
Handle same equivalent & superclass when `--preserve-structure true`

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/RelatedObjectsHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/RelatedObjectsHelper.java
@@ -534,7 +534,7 @@ public class RelatedObjectsHelper {
    *
    * @param objects Set of OWLObjects to look through
    * @param selector IRI pattern to match (enclosed in angle brackets, using ? or * wildcards)
-   * @return
+   * @return set of IRIs that match the selector pattern
    */
   public static Set<OWLObject> selectIRI(Set<OWLObject> objects, String selector) {
     Set<OWLObject> relatedObjects = new HashSet<>();
@@ -725,8 +725,7 @@ public class RelatedObjectsHelper {
             ontology, objects, aPropPairs, p, EntitySearcher.getSuperProperties(p, ontology));
       } else if (object instanceof OWLClass) {
         OWLClass cls = (OWLClass) object;
-        spanGapsHelper(
-            ontology, objects, classPairs, cls, EntitySearcher.getSuperClasses(cls, ontology));
+        spanGapsHelper(ontology, objects, classPairs, cls, getSuperClasses(ontology, cls));
       } else if (object instanceof OWLDataProperty) {
         OWLDataProperty p = (OWLDataProperty) object;
         spanGapsHelper(
@@ -947,16 +946,27 @@ public class RelatedObjectsHelper {
    */
   private static Set<OWLClassExpression> getSuperClasses(OWLOntology ontology, OWLClass cls) {
     Set<OWLClassExpression> superclasses = new HashSet<>();
+
+    // We might get stuck if a class is both subclass and equivalent
+    // So compare the eqs to the superclasses and don't add a super if it's also an eq
+    Collection<OWLClassExpression> eqs = EntitySearcher.getEquivalentClasses(cls, ontology);
+
     for (OWLClassExpression expr : EntitySearcher.getSuperClasses(cls, ontology)) {
       if (expr.isAnonymous()) {
         superclasses.add(expr);
         continue;
       }
-      if (expr.asOWLClass().getIRI() != cls.getIRI()) {
-        superclasses.add(expr);
-      } else {
-        logger.warn("Circular subclass definition: " + cls.getIRI());
+      if (eqs.contains(expr)) {
+        logger.warn(
+            String.format(
+                "Class '%s' has equivalent class and superclass '%s'", cls.getIRI(), expr));
+        continue;
       }
+      if (expr.asOWLClass().getIRI() == cls.getIRI()) {
+        logger.warn("Circular subclass definition: " + cls.getIRI());
+        continue;
+      }
+      superclasses.add(expr);
     }
     return superclasses;
   }


### PR DESCRIPTION
We already fixed cases where a class is a subclass of itself, which caused a stack overflow when `--preserve-structure true`. This fix didn't handle cases where a class is a subclass of a class that it is also equivalent to:
```
cell [CL:0000000] equivalentTo cell [GO:0005623]
cell [CL:0000000] subClassOf cell [GO:0005623]
```

`spanGapsHelper(...)` now checks for equivalent classes to make sure there is no overlap, which results in a stack overflow.