### PR TITLE
`remove` and `filter` with no IRIs in the ontology

### DIFF
--- a/robot-command/src/main/java/org/obolibrary/robot/FilterCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/FilterCommand.java
@@ -111,9 +111,14 @@ public class FilterCommand implements Command {
 
     // Get a set of entities to start with
     Set<OWLObject> objects = new HashSet<>();
+    // track if a set of input IRIs were provided
+    boolean hasInputIRIs = false;
     if (line.hasOption("term") || line.hasOption("term-file")) {
       Set<IRI> entityIRIs = CommandLineHelper.getTerms(ioHelper, line, "term", "term-file");
-      objects.addAll(OntologyHelper.getEntities(inputOntology, entityIRIs));
+      if (!entityIRIs.isEmpty()) {
+        objects.addAll(OntologyHelper.getEntities(inputOntology, entityIRIs));
+        hasInputIRIs = true;
+      }
     }
 
     // Get a set of axiom types
@@ -188,8 +193,16 @@ public class FilterCommand implements Command {
       CommandLineHelper.maybeSaveOutput(line, outputOntology);
       state.setOntology(outputOntology);
       return state;
+    } else if (objects.isEmpty() && hasInputIRIs) {
+      // if objects is empty AND there WERE input IRIs
+      // there is nothing to filter because the IRIs do not exist in the ontology
+      // save and exit with empty ontology
+      CommandLineHelper.maybeSaveOutput(line, outputOntology);
+      state.setOntology(outputOntology);
+      return state;
     } else if (objects.isEmpty()) {
-      // If there are no objects, add all the objects from the ontology
+      // if objects is empty AND there were NO input IRIs add all
+      // this means that we are adding everything to the set to start
       objects.addAll(OntologyHelper.getObjects(inputOntology));
     }
 

--- a/robot-command/src/main/java/org/obolibrary/robot/RemoveCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/RemoveCommand.java
@@ -109,9 +109,14 @@ public class RemoveCommand implements Command {
 
     // Get a set of entities to start with
     Set<OWLObject> objects = new HashSet<>();
+    // track if a set of input IRIs were provided
+    boolean hasInputIRIs = false;
     if (line.hasOption("term") || line.hasOption("term-file")) {
       Set<IRI> entityIRIs = CommandLineHelper.getTerms(ioHelper, line, "term", "term-file");
-      objects.addAll(OntologyHelper.getEntities(ontology, entityIRIs));
+      if (!entityIRIs.isEmpty()) {
+        objects.addAll(OntologyHelper.getEntities(ontology, entityIRIs));
+        hasInputIRIs = true;
+      }
     }
 
     // Get a set of axiom types
@@ -151,16 +156,22 @@ public class RemoveCommand implements Command {
       }
     }
 
-    // If removing imports, and there are no other selects, save and return
     if (hadSelection && selectGroups.isEmpty() && objects.isEmpty()) {
-      if (trim) {
-        OntologyHelper.trimOntology(ontology);
-      }
+      // If removing imports or ontology annotations
+      // and there are no other selects, save and return
+      CommandLineHelper.maybeSaveOutput(line, ontology);
+      state.setOntology(ontology);
+      return state;
+    } else if (objects.isEmpty() && hasInputIRIs) {
+      // if objects is empty AND there WERE input IRIs
+      // there is nothing to remove because the IRIs do not exist in the ontology
+      // save and exit
       CommandLineHelper.maybeSaveOutput(line, ontology);
       state.setOntology(ontology);
       return state;
     } else if (objects.isEmpty()) {
-      // Otherwise, proceed, and if objects is empty, add all objects
+      // if objects is empty AND there were NO input IRIs add all
+      // this means that we are adding everything to the set to start
       objects.addAll(OntologyHelper.getObjects(ontology));
     }
 


### PR DESCRIPTION
If a `--term` or `--term-file` is provided, but the IRIs do not exist in the ontology, `remove` removes everything (returning an empty ontology) and `filter` filters for everything (returning the same input ontology).

This should be opposite. If `remove` has a term or term file provided, but the terms do not exist in the ontology, nothing should be removed. If `filter` has a term or term file provided, but the terms do not exist, nothing should be filtered for.

See #506