### PR TITLE
Update `repair` command to allow migration of annotation values

### DIFF
--- a/docs/examples/xref-need-of-repair.obo
+++ b/docs/examples/xref-need-of-repair.obo
@@ -1,0 +1,24 @@
+ontology: xref-need-of-repair
+
+[Term]
+id: GO:1
+name: leaf node
+is_a: GO:2
+
+[Term]
+id: GO:2
+name: original parent
+is_obsolete: true
+replaced_by: GO:3
+xref: FOO:1
+
+[Term]
+id: GO:3
+name: replacement parent
+
+[Term]
+id: GO:4
+name: other term
+is_obsolete: true
+replaced_by: GO:3
+xref: FOO:2

--- a/docs/examples/xref-repaired.obo
+++ b/docs/examples/xref-repaired.obo
@@ -1,0 +1,24 @@
+ontology: xref-need-of-repair
+
+[Term]
+id: GO:1
+name: leaf node
+is_a: GO:3
+
+[Term]
+id: GO:2
+name: original parent
+is_obsolete: true
+replaced_by: GO:3
+
+[Term]
+id: GO:3
+name: replacement parent
+xref: FOO:1
+xref: FOO:2
+
+[Term]
+id: GO:4
+name: other term
+is_obsolete: true
+replaced_by: GO:3

--- a/docs/repair.md
+++ b/docs/repair.md
@@ -6,3 +6,10 @@ ROBOT can repair certain problems encountered in ontologies. So far, this is lim
       --input need-of-repair.owl \
       --output results/repaired.owl
       
+
+By default, annotation axioms are not migrated to replacement classes. However, this can be enabled for a list of annotation properties passed either as arguments to `--annotation-property` or in a term file `--annotation-properties-file`:
+
+    robot repair \
+      --input xref-need-of-repair.obo \
+      --annotation-property oboInOwl:hasDbXref \
+      --output results/xref-repaired.obo

--- a/robot-command/src/main/java/org/obolibrary/robot/RepairCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/RepairCommand.java
@@ -130,7 +130,7 @@ public class RepairCommand implements Command {
             .map(factory::getOWLAnnotationProperty)
             .collect(Collectors.toSet());
 
-    RepairOperation.repair(inputOntology, ioHelper, mergeAxiomAnnotations);
+    RepairOperation.repair(inputOntology, ioHelper, mergeAxiomAnnotations, properties);
     outputOntology = inputOntology;
     if (outputIRI != null) {
       outputOntology.getOWLOntologyManager().setOntologyDocumentIRI(outputOntology, outputIRI);

--- a/robot-command/src/main/java/org/obolibrary/robot/RepairCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/RepairCommand.java
@@ -1,8 +1,12 @@
 package org.obolibrary.robot;
 
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +36,12 @@ public class RepairCommand implements Command {
         true,
         "if true, merge axiom annotations on duplicate axioms");
     options = o;
+    o.addOption("a", "annotation-property", true, "an annotation property to migrate");
+    o.addOption(
+        "A",
+        "annotation-properties-file",
+        true,
+        "load annotation properties to migrate from a file");
   }
 
   /**
@@ -111,6 +121,14 @@ public class RepairCommand implements Command {
 
     boolean mergeAxiomAnnotations =
         CommandLineHelper.getBooleanValue(line, "merge-axiom-annotations", false);
+
+    OWLDataFactory factory = inputOntology.getOWLOntologyManager().getOWLDataFactory();
+    Set<OWLAnnotationProperty> properties =
+        CommandLineHelper.getTerms(
+                ioHelper, line, "annotation-property", "annotation-properties-file")
+            .stream()
+            .map(factory::getOWLAnnotationProperty)
+            .collect(Collectors.toSet());
 
     RepairOperation.repair(inputOntology, ioHelper, mergeAxiomAnnotations);
     outputOntology = inputOntology;

--- a/robot-core/src/main/java/org/obolibrary/robot/RepairOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/RepairOperation.java
@@ -109,7 +109,9 @@ public class RepairOperation {
     Set<InvalidReferenceViolation> violations =
         InvalidReferenceChecker.getInvalidReferenceViolations(ontology, true);
     repairInvalidReferences(ioHelper, ontology, violations, migrateAnnotations);
-    mergeAxiomAnnotations(ontology);
+    if (mergeAxiomAnnotations) {
+      mergeAxiomAnnotations(ontology);
+    }
   }
 
   /**

--- a/robot-core/src/main/java/org/obolibrary/robot/RepairOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/RepairOperation.java
@@ -88,7 +88,7 @@ public class RepairOperation {
       IOHelper ioHelper,
       Map<String, String> options,
       boolean mergeAxiomAnnotations) {
-    repair(ontology, ioHelper, options, false, Collections.emptySet());
+    repair(ontology, ioHelper, options, mergeAxiomAnnotations, Collections.emptySet());
   }
 
   /**

--- a/robot-core/src/main/java/org/obolibrary/robot/RepairOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/RepairOperation.java
@@ -51,7 +51,7 @@ public class RepairOperation {
   /**
    * Repairs ontology
    *
-   * @param ontology the OWLOntology to reapir
+   * @param ontology the OWLOntology to repair
    * @param ioHelper IOHelper to work with the ontology
    * @param mergeAxiomAnnotations if true, merge annotations on duplicate axioms
    * @param migrateAnnotations set of annotation properties for which to migrate values
@@ -78,7 +78,7 @@ public class RepairOperation {
   /**
    * Repairs ontology
    *
-   * @param ontology the OWLOntology to reapir
+   * @param ontology the OWLOntology to repair
    * @param ioHelper IOHelper to work with the ontology
    * @param options map of repair options
    * @param mergeAxiomAnnotations if true, merge annotations on duplicate axioms
@@ -94,7 +94,7 @@ public class RepairOperation {
   /**
    * Repairs ontology
    *
-   * @param ontology the OWLOntology to reapir
+   * @param ontology the OWLOntology to repair
    * @param ioHelper IOHelper to work with the ontology
    * @param options map of repair options
    * @param mergeAxiomAnnotations if true, merge annotations on duplicate axioms

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidReferenceChecker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/InvalidReferenceChecker.java
@@ -88,7 +88,7 @@ public class InvalidReferenceChecker {
       OWLOntology ontology, Set<OWLAxiom> axioms, boolean ignoreDangling) {
     Set<InvalidReferenceViolation> violations = new HashSet<>();
     for (OWLAxiom axiom : axioms) {
-      for (OWLEntity e : axiom.getSignature()) {
+      for (OWLEntity e : expandedSignature(axiom, ontology)) {
         if (!ignoreDangling && isDangling(ontology, e)) {
           violations.add(InvalidReferenceViolation.create(axiom, e, Category.DANGLING));
         }
@@ -125,5 +125,28 @@ public class InvalidReferenceChecker {
       OWLOntology importModule, OWLOntology baseOntology) {
     return getInvalidReferenceViolations(
         importModule, baseOntology.getAxioms(Imports.INCLUDED), true);
+  }
+
+  /**
+   * Get the entity signature for an axiom. This expands the standard axiom signature to include
+   * entities found in the ontology which have IRIs used as the subject for an annotation assertion
+   * axiom.
+   *
+   * @param axiom the axiom for which to get the entity signature
+   * @param ontology ontology to search for entities with IRIs used in annotation assertions
+   * @return set of entities representing the signature of the axiom
+   */
+  private static Set<OWLEntity> expandedSignature(OWLAxiom axiom, OWLOntology ontology) {
+    if (axiom instanceof OWLAnnotationAssertionAxiom) {
+      Set<OWLEntity> signature = axiom.getSignature();
+      OWLAnnotationAssertionAxiom annotationAxiom = (OWLAnnotationAssertionAxiom) axiom;
+      if (annotationAxiom.getSubject().isIRI()) {
+        IRI subjectIRI = (IRI) annotationAxiom.getSubject();
+        signature.addAll(ontology.getEntitiesInSignature(subjectIRI));
+      }
+      return signature;
+    } else {
+      return axiom.getSignature();
+    }
   }
 }

--- a/robot-core/src/test/java/org/obolibrary/robot/RepairOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/RepairOperationTest.java
@@ -1,7 +1,11 @@
 package org.obolibrary.robot;
 
 import java.io.IOException;
+import java.util.Collections;
 import org.junit.Test;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 
@@ -21,5 +25,17 @@ public class RepairOperationTest extends CoreTest {
     RepairOperation.repair(ontology, iohelper, true);
     iohelper.saveOntology(ontology, "target/foo.owl");
     assertIdentical("/repaired.owl", ontology);
+  }
+
+  @Test
+  public void testXrefRepair() throws IOException {
+    OWLAnnotationProperty hasDbXref =
+        OWLManager.getOWLDataFactory()
+            .getOWLAnnotationProperty(
+                IRI.create("http://www.geneontology.org/formats/oboInOwl#hasDbXref"));
+    OWLOntology ontology = loadOntology("/xref-need-of-repair.obo");
+    IOHelper iohelper = new IOHelper();
+    RepairOperation.repair(ontology, iohelper, true, Collections.singleton(hasDbXref));
+    assertIdentical("/xref-repaired.obo", ontology);
   }
 }

--- a/robot-core/src/test/resources/xref-need-of-repair.obo
+++ b/robot-core/src/test/resources/xref-need-of-repair.obo
@@ -1,0 +1,24 @@
+ontology: xref-need-of-repair
+
+[Term]
+id: GO:1
+name: leaf node
+is_a: GO:2
+
+[Term]
+id: GO:2
+name: original parent
+is_obsolete: true
+replaced_by: GO:3
+xref: FOO:1
+
+[Term]
+id: GO:3
+name: replacement parent
+
+[Term]
+id: GO:4
+name: other term
+is_obsolete: true
+replaced_by: GO:3
+xref: FOO:2

--- a/robot-core/src/test/resources/xref-repaired.obo
+++ b/robot-core/src/test/resources/xref-repaired.obo
@@ -1,0 +1,24 @@
+ontology: xref-need-of-repair
+
+[Term]
+id: GO:1
+name: leaf node
+is_a: GO:3
+
+[Term]
+id: GO:2
+name: original parent
+is_obsolete: true
+replaced_by: GO:3
+
+[Term]
+id: GO:3
+name: replacement parent
+xref: FOO:1
+xref: FOO:2
+
+[Term]
+id: GO:4
+name: other term
+is_obsolete: true
+replaced_by: GO:3


### PR DESCRIPTION
See #492.

Syntax: `robot repair --input xref-need-of-repair.obo --annotation-property oboInOwl:hasDbXref --output results/xref-repaired.obo`