### PR TITLE
WIP: new command: analyze - performs analysis of logical axioms

### DIFF
--- a/docs/analyze.md
+++ b/docs/analyze.md
@@ -1,0 +1,82 @@
+# Analyze
+
+Example:
+
+```
+robot analyze  --input logical_axioms.owl --output results/analysis_report.tsv
+```
+
+This performs an analysis of logical axioms in the ontology. Currently
+one type of analysis is performed, a power analysis of each axiom.
+
+Each axiom is tested for its inferential power - i.e. how many
+additional axioms does it entail, and how many existing asserted
+axioms can only be entailed when it is used.
+
+This is useful to know, as a low power rating means that you may be
+under-utilizing axioms and reasoning, or you may be *overstating*
+logical definitions.
+
+## Algorithm
+
+### Step 1: Removed Redundant Axioms
+
+Any asserted axiom that can still be entailed is removed from the
+ontology
+
+For each subClassOf axiom `A = C SubClassOf D`, we remove `A` from
+`O`. We then use the reasoner to test if `D` is an inferred superclass
+(direct or indirect of C).
+
+If this is the case, the `A` is redundant and is removed from the
+ontology.
+
+### Step 2: Perform relaxation step
+
+Additional SubClassOf axioms are added, according to the
+[relax](relax) operation.
+
+```
+C EquivalentTo X1 and X2 and ... and Xn
+==>
+C SubClassOf X1
+C SubClassOf X2
+...
+C SubClassOf Xn
+```
+
+The purpose of this step is to avoid treating the relaxed axioms as
+"new" inferences.
+
+### Step 3: Test individual axioms
+
+For each logical axiom `A` we calculate:
+
+```Power = | E(O) - E(O-A) |```
+
+Where `E` returns all entailed direct axioms (currently just
+subClassOf) from an ontology.
+
+### Step 4: Aggregate statistics and report
+
+The average power is calculated, as well as all axioms that share the maximum power.
+
+## Workflow
+
+By design, this command works on the root ontology in an import
+chain. Use [merge](merge) first if you need to merge an import chain
+into one ontology.
+
+For example, if you wish to evaluate how much CL, CHEBI, and Uberon,
+etc contribute to classification in GO, then you can take either the
+go-edit file, or the release go-plus (both of which include full
+axioms, plus import modules), merge the results, then run `analyze`.
+
+Currently aggregate stats will not be performed per-source, but you
+can easily do this from the output TSV using standard tools.
+
+
+
+
+
+

--- a/docs/examples/analysis_report.tsv
+++ b/docs/examples/analysis_report.tsv
@@ -1,12 +1,13 @@
 # |Removed_redundant_axioms| = 2
-SubClassOf	1	SubClassOf(<http://x.org/A> <http://x.org/B>)
-SubClassOf	1	SubClassOf(<http://x.org/B> <http://x.org/C>)
-EquivalentClasses	0	EquivalentClasses(<http://x.org/YB> ObjectIntersectionOf(<http://x.org/YC> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/B>)) )
-EquivalentClasses	1	EquivalentClasses(<http://x.org/XC> ObjectIntersectionOf(<http://x.org/X> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/C>)) )
-EquivalentClasses	2	EquivalentClasses(<http://x.org/XB> ObjectIntersectionOf(<http://x.org/X> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/B>)) )
-EquivalentClasses	0	EquivalentClasses(<http://x.org/YC> ObjectIntersectionOf(<http://x.org/Y> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/C>)) )
-EquivalentClasses	1	EquivalentClasses(<http://x.org/XA> ObjectIntersectionOf(<http://x.org/X> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/A>)) )
-EquivalentClasses	0	EquivalentClasses(<http://x.org/YA> ObjectIntersectionOf(<http://x.org/YB> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/A>)) )
+AxiomType	Power	About	InRoot	Axiom
+SubClassOf	1	<http://x.org/B>	true	SubClassOf(<http://x.org/B> <http://x.org/C>)
+SubClassOf	1	<http://x.org/A>	true	SubClassOf(<http://x.org/A> <http://x.org/B>)
+EquivalentClasses	0	<http://x.org/YC>	true	EquivalentClasses(<http://x.org/YC> ObjectIntersectionOf(<http://x.org/Y> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/C>)) )
+EquivalentClasses	1	<http://x.org/XC>	true	EquivalentClasses(<http://x.org/XC> ObjectIntersectionOf(<http://x.org/X> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/C>)) )
+EquivalentClasses	2	<http://x.org/XB>	true	EquivalentClasses(<http://x.org/XB> ObjectIntersectionOf(<http://x.org/X> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/B>)) )
+EquivalentClasses	0	<http://x.org/YA>	true	EquivalentClasses(<http://x.org/YA> ObjectIntersectionOf(<http://x.org/YB> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/A>)) )
+EquivalentClasses	1	<http://x.org/XA>	true	EquivalentClasses(<http://x.org/XA> ObjectIntersectionOf(<http://x.org/X> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/A>)) )
+EquivalentClasses	0	<http://x.org/YB>	true	EquivalentClasses(<http://x.org/YB> ObjectIntersectionOf(<http://x.org/YC> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/B>)) )
 # Total_power = 6
 # Average_power = 0.75
 # Most_powerful_axioms = 2 Axioms: [EquivalentClasses(<http://x.org/XB> ObjectIntersectionOf(<http://x.org/X> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/B>)) )]

--- a/docs/examples/analysis_report.tsv
+++ b/docs/examples/analysis_report.tsv
@@ -1,0 +1,12 @@
+# |Removed_redundant_axioms| = 2
+SubClassOf	1	SubClassOf(<http://x.org/A> <http://x.org/B>)
+SubClassOf	1	SubClassOf(<http://x.org/B> <http://x.org/C>)
+EquivalentClasses	0	EquivalentClasses(<http://x.org/YB> ObjectIntersectionOf(<http://x.org/YC> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/B>)) )
+EquivalentClasses	1	EquivalentClasses(<http://x.org/XC> ObjectIntersectionOf(<http://x.org/X> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/C>)) )
+EquivalentClasses	2	EquivalentClasses(<http://x.org/XB> ObjectIntersectionOf(<http://x.org/X> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/B>)) )
+EquivalentClasses	0	EquivalentClasses(<http://x.org/YC> ObjectIntersectionOf(<http://x.org/Y> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/C>)) )
+EquivalentClasses	1	EquivalentClasses(<http://x.org/XA> ObjectIntersectionOf(<http://x.org/X> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/A>)) )
+EquivalentClasses	0	EquivalentClasses(<http://x.org/YA> ObjectIntersectionOf(<http://x.org/YB> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/A>)) )
+# Total_power = 6
+# Average_power = 0.75
+# Most_powerful_axioms = 2 Axioms: [EquivalentClasses(<http://x.org/XB> ObjectIntersectionOf(<http://x.org/X> ObjectSomeValuesFrom(<http://x.org/p> <http://x.org/B>)) )]

--- a/docs/examples/logical_axioms.owl
+++ b/docs/examples/logical_axioms.owl
@@ -1,0 +1,187 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://x.org#"
+     xml:base="http://x.org"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    <owl:Ontology rdf:about="http://x.org"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://x.org/p -->
+
+    <owl:ObjectProperty rdf:about="http://x.org/p"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://x.org/A -->
+
+    <owl:Class rdf:about="http://x.org/A">
+        <rdfs:subClassOf rdf:resource="http://x.org/B"/>
+    </owl:Class>
+    
+
+
+    <!-- http://x.org/B -->
+
+    <owl:Class rdf:about="http://x.org/B">
+        <rdfs:subClassOf rdf:resource="http://x.org/C"/>
+    </owl:Class>
+    
+
+
+    <!-- http://x.org/C -->
+
+    <owl:Class rdf:about="http://x.org/C"/>
+    
+
+
+    <!-- http://x.org/X -->
+
+    <owl:Class rdf:about="http://x.org/X"/>
+    
+
+
+    <!-- http://x.org/XA -->
+
+    <owl:Class rdf:about="http://x.org/XA">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://x.org/X"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://x.org/p"/>
+                        <owl:someValuesFrom rdf:resource="http://x.org/A"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://x.org/XB"/>
+    </owl:Class>
+    
+
+
+    <!-- http://x.org/XB -->
+
+    <owl:Class rdf:about="http://x.org/XB">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://x.org/X"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://x.org/p"/>
+                        <owl:someValuesFrom rdf:resource="http://x.org/B"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://x.org/XC"/>
+    </owl:Class>
+    
+
+
+    <!-- http://x.org/XC -->
+
+    <owl:Class rdf:about="http://x.org/XC">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://x.org/X"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://x.org/p"/>
+                        <owl:someValuesFrom rdf:resource="http://x.org/C"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    
+
+
+    <!-- http://x.org/Y -->
+
+    <owl:Class rdf:about="http://x.org/Y"/>
+    
+
+
+    <!-- http://x.org/YA -->
+
+    <owl:Class rdf:about="http://x.org/YA">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://x.org/YB"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://x.org/p"/>
+                        <owl:someValuesFrom rdf:resource="http://x.org/A"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    
+
+
+    <!-- http://x.org/YB -->
+
+    <owl:Class rdf:about="http://x.org/YB">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://x.org/YC"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://x.org/p"/>
+                        <owl:someValuesFrom rdf:resource="http://x.org/B"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+    
+
+
+    <!-- http://x.org/YC -->
+
+    <owl:Class rdf:about="http://x.org/YC">
+        <owl:equivalentClass>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://x.org/Y"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://x.org/p"/>
+                        <owl:someValuesFrom rdf:resource="http://x.org/C"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </owl:equivalentClass>
+    </owl:Class>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.6) https://github.com/owlcs/owlapi -->
+

--- a/robot-command/src/main/java/org/obolibrary/robot/AnalyzeCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/AnalyzeCommand.java
@@ -1,0 +1,130 @@
+package org.obolibrary.robot;
+
+import java.util.Map;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles inputs and outputs for the {@link AnalyzeOperation}.
+ *
+ * @author cjm
+ */
+public class AnalyzeCommand implements Command {
+  /** Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(AnalyzeCommand.class);
+
+  /** Store the command-line options for the command. */
+  private Options options;
+
+  /** Initialze the command. */
+  public AnalyzeCommand() {
+    Options o = CommandLineHelper.getCommonOptions();
+    o.addOption("r", "reasoner", true, "reasoner to use: ELK, HermiT, JFact");
+    o.addOption("i", "input", true, "load ontology from a file");
+    o.addOption("I", "input-iri", true, "load ontology from an IRI");
+    o.addOption("o", "output", true, "save report to a file");
+    o.addOption("f", "format", true, "save report in a given format (TSV or YAML)");
+    options = o;
+  }
+
+  /**
+   * Name of the command.
+   *
+   * @return name
+   */
+  public String getName() {
+    return "analyze";
+  }
+
+  /**
+   * Brief description of the command.
+   *
+   * @return description
+   */
+  public String getDescription() {
+    return "analyze axioms in an ontology";
+  }
+
+  /**
+   * Command-line usage for the command.
+   *
+   * @return usage
+   */
+  public String getUsage() {
+    return "robot analyze --input <file> " + "--output <file> ";
+  }
+
+  /**
+   * Command-line options for the command.
+   *
+   * @return options
+   */
+  public Options getOptions() {
+    return options;
+  }
+
+  /**
+   * Handle the command-line and file operations for the AnalyzeOperation.
+   *
+   * @param args strings to use as arguments
+   */
+  public void main(String[] args) {
+    try {
+      execute(null, args);
+    } catch (Exception e) {
+      CommandLineHelper.handleException(e);
+    }
+  }
+
+  /**
+   * Given an input state and command line arguments, report a new ontology and return an new state.
+   * The input ontology is not changed.
+   *
+   * @param state the state from the previous command, or null
+   * @param args the command-line arguments
+   * @return a new state with the reported ontology
+   * @throws Exception on any problem
+   */
+  public CommandState execute(CommandState state, String[] args) throws Exception {
+    CommandLine line = CommandLineHelper.getCommandLine(getUsage(), getOptions(), args);
+    if (line == null) {
+      return null;
+    }
+
+    IOHelper ioHelper = CommandLineHelper.getIOHelper(line);
+    state = CommandLineHelper.updateInputOntology(ioHelper, state, line);
+    OWLOntology ontology = state.getOntology();
+
+    OWLReasonerFactory reasonerFactory = CommandLineHelper.getReasonerFactory(line, true);
+
+    // Override default reasoner options with command-line options
+    Map<String, String> reasonerOptions = ReasonOperation.getDefaultOptions();
+    for (String option : reasonerOptions.keySet()) {
+      if (line.hasOption(option)) {
+        reasonerOptions.put(option, line.getOptionValue(option));
+      }
+    }
+
+    // Override default report options with command-line options
+    Map<String, String> reportOptions = AnalyzeOperation.getDefaultOptions();
+    for (String option : reportOptions.keySet()) {
+      if (line.hasOption(option)) {
+        reportOptions.put(option, line.getOptionValue(option));
+      }
+    }
+
+    // output is optional - no output means the file will not be written anywhere
+    String outputPath = CommandLineHelper.getOptionalValue(line, "output");
+
+    // Success is based on failOn
+    // If any violations are found of the fail-on level, this will be false
+    // If fail-on is "none" or if no violations are found, this will be true
+    double score = AnalyzeOperation.analyze(ontology, reasonerFactory, outputPath, reportOptions);
+    logger.info("Score = " + score);
+    return state;
+  }
+}

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineInterface.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineInterface.java
@@ -19,6 +19,7 @@ public class CommandLineInterface {
    */
   private static CommandManager initManager() {
     CommandManager m = new CommandManager();
+    m.addCommand("analyze", new AnalyzeCommand());
     m.addCommand("annotate", new AnnotateCommand());
     m.addCommand("convert", new ConvertCommand());
     m.addCommand("diff", new DiffCommand());

--- a/robot-command/src/main/resources/log4j.properties
+++ b/robot-command/src/main/resources/log4j.properties
@@ -3,5 +3,6 @@ log4j.appender.console.layout=org.apache.log4j.PatternLayout
 #log4j.appender.console.layout.ConversionPattern=%-5p %m%n
 log4j.appender.console.layout.ConversionPattern=%d %-5p %c - %m%n
 log4j.logger.org.obolibrary.obo2owl=off
+log4j.logger.org.semanticweb.elk=off
 log4j.logger.user=DEBUG
 log4j.rootLogger=ERROR, console

--- a/robot-core/src/main/java/org/obolibrary/robot/AnalyzeOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/AnalyzeOperation.java
@@ -1,0 +1,234 @@
+package org.obolibrary.robot;
+
+import com.google.common.collect.Sets;
+import com.google.common.collect.Sets.SetView;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.*;
+import org.obolibrary.robot.exceptions.*;
+import org.semanticweb.elk.owlapi.ElkReasoner;
+import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
+import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
+import org.semanticweb.owlapi.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Analyze logical axioms in an ontology
+ *
+ * @author <a href="mailto:cjmungall@lbl.gov">Chris Mungall</a>
+ */
+public class AnalyzeOperation {
+  /** Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(AnalyzeOperation.class);
+
+  private static final String NS = "analyze#";
+
+  /**
+   * Return a map from option name to default option value, for all the available reasoner options.
+   *
+   * @return a map with default values for all available options
+   */
+  public static Map<String, String> getDefaultOptions() {
+    Map<String, String> options = new HashMap<>();
+    options.put("foo", "false");
+
+    return options;
+  }
+
+  /**
+   * Given an ontology and a reasoner factory, return the ontology with inferred axioms added after
+   * reasoning. Use default options.
+   *
+   * @param ontology the ontology to reason over
+   * @param reasonerFactory the factory to create a reasoner instance from
+   * @throws OntologyLogicException if the ontology contains unsatisfiable classes, properties or
+   *     inconsistencies
+   * @throws OWLOntologyCreationException if ontology cannot be created
+   * @throws InvalidReferenceException if the reference checker fails
+   */
+  public static double analyze(OWLOntology ontology, OWLReasonerFactory reasonerFactory)
+      throws Exception {
+    return analyze(ontology, reasonerFactory, null, getDefaultOptions());
+  }
+
+  /**
+   * Given an ontology, a reasoner factory, and a map of options, return the ontology with inferred
+   * axioms added after reasoning.
+   *
+   * @param ontology the ontology to reason over
+   * @param reasonerFactory the factory to create a reasoner instance from
+   * @param options a map of option strings, or null
+   * @throws OntologyLogicException if the ontology contains unsatisfiable classes, properties or
+   *     inconsistencies
+   * @throws OWLOntologyCreationException if ontology cannot be created
+   * @throws InvalidReferenceException if the reference checker fails
+   * @throws IOException
+   */
+  public static double analyze(
+      OWLOntology ontology,
+      OWLReasonerFactory reasonerFactory,
+      String outputPath,
+      Map<String, String> options)
+      throws Exception {
+    logger.info("Ontology has {} axioms.", ontology.getAxioms().size());
+
+    List<String> reportLines = new ArrayList<>();
+
+    BufferedWriter bw = null;
+    if (outputPath != null) {
+      FileWriter fw = new FileWriter(outputPath);
+      bw = new BufferedWriter(fw);
+    }
+
+    // Check the ontology for reference violations
+    // Maybe fail if prevent-invalid-references
+    ReasonOperation.checkReferenceViolations(ontology, options);
+
+    // Get the reasoner and run initial reasoning
+    // No axioms are asserted in this step
+    OWLReasoner reasoner = reasonerFactory.createReasoner(ontology);
+
+    Set<OWLAxiom> removedAxioms = removeRedundantAxioms(reasoner);
+    report("# |Removed_redundant_axioms| = " + removedAxioms.size(), bw);
+    Set<OWLLogicalAxiom> originalAxioms = ontology.getLogicalAxioms();
+
+    // we are uninterested in trivial inferences, so first relax
+    // so that trivial axioms are asserted alreadt
+    RelaxOperation.relax(ontology, options);
+
+    Set<OWLLogicalAxiom> infAxioms = getInferredAxioms(reasoner);
+
+    for (OWLAxiom a : infAxioms) {
+      logger.info(" I=" + a);
+    }
+
+    int n = 0;
+    int tPower = 0;
+    Set<OWLLogicalAxiom> mostPowerfulAxioms = null;
+    int maxPower = 0;
+    for (OWLLogicalAxiom axiom : originalAxioms) {
+      AxiomType<?> atype = axiom.getAxiomType();
+      int power = getLogicalAxiomPower(axiom, reasoner, infAxioms);
+      tPower += power;
+      report(atype + "\t" + power + "\t" + axiom, bw);
+      if (power > maxPower) {
+        maxPower = power;
+        mostPowerfulAxioms = new HashSet<>();
+      }
+      if (power > 0 && power == maxPower) {
+        mostPowerfulAxioms.add(axiom);
+      }
+      n++;
+    }
+    double avgPower = tPower / (double) n;
+    report("# Total_power = " + tPower, bw);
+    report("# Average_power = " + avgPower, bw);
+    report("# Most_powerful_axioms = " + maxPower + " Axioms: " + mostPowerfulAxioms, bw);
+
+    if (bw != null) bw.close();
+
+    return avgPower;
+  }
+
+  private static void report(String line, BufferedWriter bw) throws IOException {
+    if (bw != null) bw.write(line + "\n");
+    else System.out.println(line);
+  }
+
+  /**
+   * Power = | E(O) - E(O-A) |
+   * 
+   * The power of a logical axiom is the number of entailments it contributes to
+   * 
+   * @param axiom
+   * @param reasoner
+   * @param infAxioms
+   * @return axiom power calculation
+   */
+  public static int getLogicalAxiomPower(
+      OWLLogicalAxiom axiom, OWLReasoner reasoner, Set<OWLLogicalAxiom> infAxioms) {
+    OWLOntology ontology = reasoner.getRootOntology();
+    OWLOntologyManager manager = ontology.getOWLOntologyManager();
+    manager.removeAxiom(ontology, axiom);
+    reasoner.flush();
+    Set<OWLLogicalAxiom> infAxiomsPostRemoval = getInferredAxioms(reasoner);
+    SetView<OWLLogicalAxiom> remaining = Sets.difference(infAxioms, infAxiomsPostRemoval);
+
+    for (OWLAxiom a : remaining) {
+      logger.info(" R=" + a);
+    }
+    // restore
+    manager.addAxiom(ontology, axiom);
+    logger.info("Base=" + infAxioms.size() + " Rem=" + remaining.size());
+    return remaining.size();
+  }
+
+  public static Set<OWLAxiom> removeRedundantAxioms(OWLReasoner reasoner) {
+    OWLOntology ontology = reasoner.getRootOntology();
+    OWLOntologyManager manager = ontology.getOWLOntologyManager();
+    Set<OWLAxiom> redundantAxioms = new HashSet<>();
+    for (OWLLogicalAxiom axiom : ontology.getLogicalAxioms()) {
+      manager.removeAxiom(ontology, axiom);
+      reasoner.flush();
+      if (isEntailed(reasoner, axiom)) {
+        logger.info("Redundant: " + axiom);
+        redundantAxioms.add(axiom);
+      }
+      // restore
+      manager.addAxiom(ontology, axiom);
+    }
+    logger.info("# Removed_redundant_axioms = " + redundantAxioms.size());
+    manager.removeAxioms(ontology, redundantAxioms);
+    return redundantAxioms;
+  }
+
+  public static boolean isEntailed(OWLReasoner reasoner, OWLLogicalAxiom axiom) {
+    logger.info("Testing: " + axiom);
+    if (axiom instanceof OWLSubClassOfAxiom) {
+      OWLSubClassOfAxiom sca = (OWLSubClassOfAxiom) axiom;
+      if (sca.getSuperClass().isOWLThing()) {
+        return true;
+      }
+    }
+
+    if (reasoner instanceof ElkReasoner) {
+      if (axiom instanceof OWLSubClassOfAxiom) {
+        OWLSubClassOfAxiom sca = (OWLSubClassOfAxiom) axiom;
+        if (sca.getSuperClass().isAnonymous()) {
+          return false;
+        } else {
+          return reasoner
+              .getSuperClasses(sca.getSubClass(), false)
+              .containsEntity(sca.getSuperClass().asOWLClass());
+        }
+      } else {
+        return false;
+      }
+    } else {
+      return reasoner.isEntailed(axiom);
+    }
+  }
+
+  public static Set<OWLLogicalAxiom> getInferredAxioms(OWLReasoner reasoner) {
+    // can't seem to get InferredAxiomGenerator to work...
+    OWLOntology ontology = reasoner.getRootOntology();
+    OWLOntologyManager manager = ontology.getOWLOntologyManager();
+    OWLDataFactory df = manager.getOWLDataFactory();
+    Set<OWLLogicalAxiom> currentAxioms = ontology.getLogicalAxioms();
+
+    reasoner.flush();
+    Set<OWLLogicalAxiom> infAxioms = new HashSet<>();
+    for (OWLClass c : ontology.getClassesInSignature()) {
+      for (OWLClass sc : reasoner.getSuperClasses(c, true).getFlattened()) {
+        OWLSubClassOfAxiom a = df.getOWLSubClassOfAxiom(c, sc);
+        if (!currentAxioms.contains(a) && !sc.isOWLThing() && !c.isOWLNothing()) {
+          infAxioms.add(a);
+        }
+      }
+    }
+    return infAxioms;
+  }
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
@@ -494,7 +494,7 @@ public class ReasonOperation {
    * @param options map of reason options
    * @throws InvalidReferenceException on invalid reference, if prevent-invalid-references
    */
-  private static void checkReferenceViolations(OWLOntology ontology, Map<String, String> options)
+  static void checkReferenceViolations(OWLOntology ontology, Map<String, String> options)
       throws InvalidReferenceException {
     Set<InvalidReferenceViolation> referenceViolations =
         InvalidReferenceChecker.getInvalidReferenceViolations(ontology, false);

--- a/robot-core/src/test/java/org/obolibrary/robot/AnalyzeOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/AnalyzeOperationTest.java
@@ -1,0 +1,25 @@
+package org.obolibrary.robot;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
+
+/** Tests for AnalyzeOperation. */
+public class AnalyzeOperationTest extends CoreTest {
+  /**
+   * Test reasoning with StructuralReasoner.
+   *
+   * @throws Exception on any problem
+   */
+  @Test
+  public void testBasic() throws Exception {
+    OWLOntology ontology = loadOntology("/analyze_test.omn");
+    OWLReasonerFactory reasonerFactory = new org.semanticweb.HermiT.ReasonerFactory();
+
+    // OWLReasonerFactory reasonerFactory = new ElkReasonerFactory();
+    double avgPower = AnalyzeOperation.analyze(ontology, reasonerFactory);
+    assertTrue(Math.abs(avgPower - 0.5) < 0.0001);
+  }
+}

--- a/robot-core/src/test/resources/analyze_test.omn
+++ b/robot-core/src/test/resources/analyze_test.omn
@@ -1,0 +1,40 @@
+Prefix: : <http://x.org/>
+
+Ontology: <http://x.org>
+
+##
+
+Class: A
+  SubClassOf: B
+
+Class: B
+  SubClassOf: C
+
+Class: C
+
+ObjectProperty: p        
+
+## These axioms have more power        
+Class: X
+
+Class: XA
+  SubClassOf: XB
+  EquivalentTo: X and p some A
+Class: XB
+  SubClassOf: XC
+  EquivalentTo: X and p some B
+Class: XC
+  EquivalentTo: X and p some C
+
+
+## These axioms have less power        
+Class: Y
+
+Class: YA
+  EquivalentTo: YB and p some A
+Class: YB
+  EquivalentTo: YC and p some B
+Class: YC
+  EquivalentTo: Y and p some C
+
+        

--- a/robot-core/src/test/resources/analyze_test.omn
+++ b/robot-core/src/test/resources/analyze_test.omn
@@ -27,7 +27,8 @@ Class: XC
   EquivalentTo: X and p some C
 
 
-## These axioms have less power        
+## These axioms have less power,
+## Due to the fact they overstate the genus
 Class: Y
 
 Class: YA


### PR DESCRIPTION
This command will analyze all logical axioms in an ontology. So far only a single analysis is performed, testing the power of each axiom. See below for how this is performed.

This is an important metric, many novice ontology develops will add logical axioms without understanding the entailments, this provides a way of knowing which axioms are just added for decoration and do not provide any inferential benefit. There is some analogy to formal static analysis in computer programs and [unreachable code](https://en.wikipedia.org/wiki/Unreachable_code) but this is more nuanced and potentially worse.

This is what the current doc page for this looks like:

# Analyze

Example:

```
robot analyze  --input logical_axioms.owl --output results/analysis_report.tsv
```

This performs an analysis of logical axioms in the ontology. Currently
one type of analysis is performed, a power analysis of each axiom.

Each axiom is tested for its inferential power - i.e. how many
additional axioms does it entail, and how many existing asserted
axioms can only be entailed when it is used.

This is useful to know, as a low power rating means that you may be
under-utilizing axioms and reasoning, or you may be *overstating*
logical definitions.

## Algorithm

### Step 1: Removed Redundant Axioms

Any asserted axiom that can still be entailed is removed from the
ontology

For each subClassOf axiom `A = C SubClassOf D`, we remove `A` from
`O`. We then use the reasoner to test if `D` is an inferred superclass
(direct or indirect of C).

If this is the case, the `A` is redundant and is removed from the
ontology.

### Step 2: Perform relaxation step

Additional SubClassOf axioms are added, according to the
[relax](relax) operation.

```
C EquivalentTo X1 and X2 and ... and Xn
==>
C SubClassOf X1
C SubClassOf X2
...
C SubClassOf Xn
```

The purpose of this step is to avoid treating the relaxed axioms as
"new" inferences.

### Step 3: Test individual axioms

For each logical axiom `A` we calculate:

```Power = | E(O) - E(O-A) |```

Where `E` returns all entailed direct axioms (currently just
subClassOf) from an ontology.

### Step 4: Aggregate statistics and report

The average power is calculated, as well as all axioms that share the maximum power.

## Workflow

By design, this command works on the root ontology in an import
chain. Use [merge](merge) first if you need to merge an import chain
into one ontology.

For example, if you wish to evaluate how much CL, CHEBI, and Uberon,
etc contribute to classification in GO, then you can take either the
go-edit file, or the release go-plus (both of which include full
axioms, plus import modules), merge the results, then run `analyze`.

Currently aggregate stats will not be performed per-source, but you
can easily do this from the output TSV using standard tools.

