### PR TITLE
Some refactoring of ReasonOperation. 

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/ReasonerHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReasonerHelper.java
@@ -236,7 +236,8 @@ public class ReasonerHelper {
    * Given a list of axiom generator strings, return a list of InferredAxiomGenerator objects.
    *
    * @param axGenerators list of strings to get InferredAxiomGenerators
-   * @param direct return axiom generators which include only direct superclass/superproperties/types
+   * @param direct return axiom generators which include only direct
+   *     superclass/superproperties/types
    * @return list of InferredAxiomGenerators
    */
   public static List<InferredAxiomGenerator<? extends OWLAxiom>> getInferredAxiomGenerators(
@@ -282,7 +283,8 @@ public class ReasonerHelper {
    * Given an axiom generator as a string, return the InferredAxiomGenerator object.
    *
    * @param axGenerator name of InferredAxiomGenerator
-   * @param direct return axiom generators which include only direct superclass/superproperties/types
+   * @param direct return axiom generators which include only direct
+   *     superclass/superproperties/types
    * @return InferredAxiomGenerator
    */
   public static InferredAxiomGenerator<? extends OWLAxiom> getInferredAxiomGenerator(

--- a/robot-core/src/main/java/org/obolibrary/robot/ReasonerHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReasonerHelper.java
@@ -6,6 +6,9 @@ import java.util.stream.Collectors;
 import org.obolibrary.robot.exceptions.IncoherentRBoxException;
 import org.obolibrary.robot.exceptions.IncoherentTBoxException;
 import org.obolibrary.robot.exceptions.InconsistentOntologyException;
+import org.obolibrary.robot.reason.InferredClassAssertionAxiomGeneratorDirectOnly;
+import org.obolibrary.robot.reason.InferredSubClassAxiomGeneratorIncludingIndirect;
+import org.obolibrary.robot.reason.InferredSubObjectPropertyAxiomGeneratorIncludingIndirect;
 import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.model.parameters.Imports;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
@@ -233,19 +236,35 @@ public class ReasonerHelper {
    * Given a list of axiom generator strings, return a list of InferredAxiomGenerator objects.
    *
    * @param axGenerators list of strings to get InferredAxiomGenerators
+   * @param direct return axiom generators which include only direct superclass/superproperties/types
+   * @return list of InferredAxiomGenerators
+   */
+  public static List<InferredAxiomGenerator<? extends OWLAxiom>> getInferredAxiomGenerators(
+      List<String> axGenerators, boolean direct) {
+    List<InferredAxiomGenerator<? extends OWLAxiom>> gens = new ArrayList<>();
+    if (axGenerators == null || axGenerators.isEmpty()) {
+      if (direct) {
+        gens.add(new InferredSubClassAxiomGenerator());
+      } else {
+        gens.add(new InferredSubClassAxiomGeneratorIncludingIndirect());
+      }
+      return gens;
+    }
+    for (String ax : axGenerators) {
+      gens.add(getInferredAxiomGenerator(ax, direct));
+    }
+    return gens;
+  }
+
+  /**
+   * Given a list of axiom generator strings, return a list of InferredAxiomGenerator objects.
+   *
+   * @param axGenerators list of strings to get InferredAxiomGenerators
    * @return list of InferredAxiomGenerators
    */
   public static List<InferredAxiomGenerator<? extends OWLAxiom>> getInferredAxiomGenerators(
       List<String> axGenerators) {
-    List<InferredAxiomGenerator<? extends OWLAxiom>> gens = new ArrayList<>();
-    if (axGenerators == null || axGenerators.isEmpty()) {
-      gens.add(new InferredSubClassAxiomGenerator());
-      return gens;
-    }
-    for (String ax : axGenerators) {
-      gens.add(getInferredAxiomGenerator(ax));
-    }
-    return gens;
+    return getInferredAxiomGenerators(axGenerators, true);
   }
 
   /**
@@ -256,10 +275,26 @@ public class ReasonerHelper {
    */
   public static InferredAxiomGenerator<? extends OWLAxiom> getInferredAxiomGenerator(
       String axGenerator) {
+    return getInferredAxiomGenerator(axGenerator, true);
+  }
+
+  /**
+   * Given an axiom generator as a string, return the InferredAxiomGenerator object.
+   *
+   * @param axGenerator name of InferredAxiomGenerator
+   * @param direct return axiom generators which include only direct superclass/superproperties/types
+   * @return InferredAxiomGenerator
+   */
+  public static InferredAxiomGenerator<? extends OWLAxiom> getInferredAxiomGenerator(
+      String axGenerator, boolean direct) {
     switch (axGenerator.toLowerCase()) {
       case "subclass":
       case "":
-        return new InferredSubClassAxiomGenerator();
+        if (direct) {
+          return new InferredSubClassAxiomGenerator();
+        } else {
+          return new InferredSubClassAxiomGeneratorIncludingIndirect();
+        }
       case "disjointclasses":
         return new InferredDisjointClassesAxiomGenerator();
       case "equivalentclass":
@@ -271,7 +306,11 @@ public class ReasonerHelper {
       case "subdataproperty":
         return new InferredSubDataPropertyAxiomGenerator();
       case "classassertion":
-        return new InferredClassAssertionAxiomGenerator();
+        if (direct) {
+          return new InferredClassAssertionAxiomGeneratorDirectOnly();
+        } else {
+          return new InferredClassAssertionAxiomGenerator();
+        }
       case "propertyassertion":
         return new InferredPropertyAssertionGenerator();
       case "equivalentobjectproperty":
@@ -281,7 +320,11 @@ public class ReasonerHelper {
       case "objectpropertycharacteristic":
         return new InferredObjectPropertyCharacteristicAxiomGenerator();
       case "subobjectproperty":
-        return new InferredSubObjectPropertyAxiomGenerator();
+        if (direct) {
+          return new InferredSubObjectPropertyAxiomGenerator();
+        } else {
+          return new InferredSubObjectPropertyAxiomGeneratorIncludingIndirect();
+        }
       default:
         throw new IllegalArgumentException(String.format(axiomGeneratorError, axGenerator));
     }

--- a/robot-core/src/main/java/org/obolibrary/robot/reason/InferredClassAssertionAxiomGeneratorDirectOnly.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/reason/InferredClassAssertionAxiomGeneratorDirectOnly.java
@@ -9,9 +9,7 @@ import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.util.InferredIndividualAxiomGenerator;
 
-/**
- * An InferredAxiomGenerator which returns only direct class assettion axioms.
- */
+/** An InferredAxiomGenerator which returns only direct class assettion axioms. */
 public class InferredClassAssertionAxiomGeneratorDirectOnly
     extends InferredIndividualAxiomGenerator<OWLClassAssertionAxiom> {
 

--- a/robot-core/src/main/java/org/obolibrary/robot/reason/InferredClassAssertionAxiomGeneratorDirectOnly.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/reason/InferredClassAssertionAxiomGeneratorDirectOnly.java
@@ -1,0 +1,33 @@
+package org.obolibrary.robot.reason;
+
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLClassAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLNamedIndividual;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
+import org.semanticweb.owlapi.util.InferredIndividualAxiomGenerator;
+
+/**
+ * An InferredAxiomGenerator which returns only direct class assettion axioms.
+ */
+public class InferredClassAssertionAxiomGeneratorDirectOnly
+    extends InferredIndividualAxiomGenerator<OWLClassAssertionAxiom> {
+
+  @Override
+  protected void addAxioms(
+      @Nonnull OWLNamedIndividual entity,
+      @Nonnull OWLReasoner reasoner,
+      @Nonnull OWLDataFactory dataFactory,
+      @Nonnull Set<OWLClassAssertionAxiom> result) {
+    for (OWLClass type : reasoner.getTypes(entity, true).getFlattened()) {
+      result.add(dataFactory.getOWLClassAssertionAxiom(type, entity));
+    }
+  }
+
+  @Override
+  public String getLabel() {
+    return "Class assertions (individual direct types)";
+  }
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/reason/InferredSubClassAxiomGeneratorIncludingIndirect.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/reason/InferredSubClassAxiomGeneratorIncludingIndirect.java
@@ -8,9 +8,7 @@ import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.util.InferredClassAxiomGenerator;
 
-/**
- * An InferredAxiomGenerator which returns both direct and indirect inferred subclass axioms.
- */
+/** An InferredAxiomGenerator which returns both direct and indirect inferred subclass axioms. */
 public class InferredSubClassAxiomGeneratorIncludingIndirect
     extends InferredClassAxiomGenerator<OWLSubClassOfAxiom> {
 

--- a/robot-core/src/main/java/org/obolibrary/robot/reason/InferredSubClassAxiomGeneratorIncludingIndirect.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/reason/InferredSubClassAxiomGeneratorIncludingIndirect.java
@@ -1,0 +1,36 @@
+package org.obolibrary.robot.reason;
+
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
+import org.semanticweb.owlapi.util.InferredClassAxiomGenerator;
+
+/**
+ * An InferredAxiomGenerator which returns both direct and indirect inferred subclass axioms.
+ */
+public class InferredSubClassAxiomGeneratorIncludingIndirect
+    extends InferredClassAxiomGenerator<OWLSubClassOfAxiom> {
+
+  @Override
+  protected void addAxioms(
+      @Nonnull OWLClass entity,
+      @Nonnull OWLReasoner reasoner,
+      @Nonnull OWLDataFactory dataFactory,
+      @Nonnull Set<OWLSubClassOfAxiom> result) {
+    if (reasoner.isSatisfiable(entity)) {
+      for (OWLClass superclass : reasoner.getSuperClasses(entity, false).getFlattened()) {
+        result.add(dataFactory.getOWLSubClassOfAxiom(entity, superclass));
+      }
+    } else {
+      result.add(dataFactory.getOWLSubClassOfAxiom(entity, dataFactory.getOWLNothing()));
+    }
+  }
+
+  @Override
+  public String getLabel() {
+    return "Subclasses including indirect";
+  }
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/reason/InferredSubObjectPropertyAxiomGeneratorIncludingIndirect.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/reason/InferredSubObjectPropertyAxiomGeneratorIncludingIndirect.java
@@ -2,7 +2,6 @@ package org.obolibrary.robot.reason;
 
 import java.util.Set;
 import javax.annotation.Nonnull;
-
 import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLObjectProperty;
 import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
@@ -11,20 +10,21 @@ import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.util.InferredObjectPropertyAxiomGenerator;
 
 /**
- * An InferredAxiomGenerator which returns both direct and indirect inferred subobjectproperty axioms.
+ * An InferredAxiomGenerator which returns both direct and indirect inferred subobjectproperty
+ * axioms.
  */
 public class InferredSubObjectPropertyAxiomGeneratorIncludingIndirect
-  extends InferredObjectPropertyAxiomGenerator<OWLSubObjectPropertyOfAxiom> {
+    extends InferredObjectPropertyAxiomGenerator<OWLSubObjectPropertyOfAxiom> {
 
   @Override
   protected void addAxioms(
-    @Nonnull OWLObjectProperty entity,
-    @Nonnull OWLReasoner reasoner,
-    @Nonnull OWLDataFactory dataFactory,
-    @Nonnull Set<OWLSubObjectPropertyOfAxiom> result,
-    @Nonnull Set<OWLObjectPropertyExpression> nonSimpleProperties) {
+      @Nonnull OWLObjectProperty entity,
+      @Nonnull OWLReasoner reasoner,
+      @Nonnull OWLDataFactory dataFactory,
+      @Nonnull Set<OWLSubObjectPropertyOfAxiom> result,
+      @Nonnull Set<OWLObjectPropertyExpression> nonSimpleProperties) {
     for (OWLObjectPropertyExpression prop :
-      reasoner.getSuperObjectProperties(entity, false).getFlattened()) {
+        reasoner.getSuperObjectProperties(entity, false).getFlattened()) {
       result.add(dataFactory.getOWLSubObjectPropertyOfAxiom(entity, prop));
     }
   }

--- a/robot-core/src/main/java/org/obolibrary/robot/reason/InferredSubObjectPropertyAxiomGeneratorIncludingIndirect.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/reason/InferredSubObjectPropertyAxiomGeneratorIncludingIndirect.java
@@ -1,0 +1,36 @@
+package org.obolibrary.robot.reason;
+
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLObjectProperty;
+import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
+import org.semanticweb.owlapi.model.OWLSubObjectPropertyOfAxiom;
+import org.semanticweb.owlapi.reasoner.OWLReasoner;
+import org.semanticweb.owlapi.util.InferredObjectPropertyAxiomGenerator;
+
+/**
+ * An InferredAxiomGenerator which returns both direct and indirect inferred subobjectproperty axioms.
+ */
+public class InferredSubObjectPropertyAxiomGeneratorIncludingIndirect
+  extends InferredObjectPropertyAxiomGenerator<OWLSubObjectPropertyOfAxiom> {
+
+  @Override
+  protected void addAxioms(
+    @Nonnull OWLObjectProperty entity,
+    @Nonnull OWLReasoner reasoner,
+    @Nonnull OWLDataFactory dataFactory,
+    @Nonnull Set<OWLSubObjectPropertyOfAxiom> result,
+    @Nonnull Set<OWLObjectPropertyExpression> nonSimpleProperties) {
+    for (OWLObjectPropertyExpression prop :
+      reasoner.getSuperObjectProperties(entity, false).getFlattened()) {
+      result.add(dataFactory.getOWLSubObjectPropertyOfAxiom(entity, prop));
+    }
+  }
+
+  @Override
+  public String getLabel() {
+    return "Sub object properties including indirect";
+  }
+}

--- a/robot-core/src/test/java/org/obolibrary/robot/ReasonOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ReasonOperationTest.java
@@ -2,14 +2,11 @@ package org.obolibrary.robot;
 
 import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.geneontology.reasoner.ExpressionMaterializingReasonerFactory;
 import org.junit.Test;
-import org.obolibrary.robot.exceptions.InvalidReferenceException;
-import org.obolibrary.robot.exceptions.OntologyLogicException;
 import org.semanticweb.HermiT.ReasonerFactory;
 import org.semanticweb.elk.owlapi.ElkReasonerFactory;
 import org.semanticweb.owlapi.model.*;
@@ -367,37 +364,23 @@ public class ReasonOperationTest extends CoreTest {
     OWLReasonerFactory reasonerFactory = new ReasonerFactory();
     ReasonOperation.reason(ontology, reasonerFactory, options);
     assertTrue(
-      checkContains(
-        ontology,
-        "ClassAssertion(<http://example.org/C> <http://example.org/c>)"));
+        checkContains(ontology, "ClassAssertion(<http://example.org/C> <http://example.org/c>)"));
     assertFalse(
-      checkContains(
-        ontology,
-        "ClassAssertion(<http://example.org/B> <http://example.org/c>)"));
+        checkContains(ontology, "ClassAssertion(<http://example.org/B> <http://example.org/c>)"));
     assertFalse(
-      checkContains(
-        ontology,
-        "ClassAssertion(<http://example.org/A> <http://example.org/c>)"));
+        checkContains(ontology, "ClassAssertion(<http://example.org/A> <http://example.org/c>)"));
     assertTrue(
-      checkContains(
-        ontology,
-        "SubClassOf(<http://example.org/C> <http://example.org/B>)"));
+        checkContains(ontology, "SubClassOf(<http://example.org/C> <http://example.org/B>)"));
     assertFalse(
-      checkContains(
-        ontology,
-        "SubClassOf(<http://example.org/C> <http://example.org/A>)"));
+        checkContains(ontology, "SubClassOf(<http://example.org/C> <http://example.org/A>)"));
     assertFalse(
-      checkContains(
-        ontology,
-        "SubClassOf(<http://example.org/C> <http://example.org/D>)"));
+        checkContains(ontology, "SubClassOf(<http://example.org/C> <http://example.org/D>)"));
     assertTrue(
-      checkContains(
-        ontology,
-        "SubObjectPropertyOf(<http://example.org/t> <http://example.org/s>)"));
+        checkContains(
+            ontology, "SubObjectPropertyOf(<http://example.org/t> <http://example.org/s>)"));
     assertFalse(
-      checkContains(
-        ontology,
-        "SubObjectPropertyOf(<http://example.org/t> <http://example.org/r>)"));
+        checkContains(
+            ontology, "SubObjectPropertyOf(<http://example.org/t> <http://example.org/r>)"));
   }
 
   /**
@@ -415,37 +398,23 @@ public class ReasonOperationTest extends CoreTest {
     OWLReasonerFactory reasonerFactory = new ReasonerFactory();
     ReasonOperation.reason(ontology, reasonerFactory, options);
     assertTrue(
-      checkContains(
-        ontology,
-        "ClassAssertion(<http://example.org/C> <http://example.org/c>)"));
+        checkContains(ontology, "ClassAssertion(<http://example.org/C> <http://example.org/c>)"));
     assertTrue(
-      checkContains(
-        ontology,
-        "ClassAssertion(<http://example.org/B> <http://example.org/c>)"));
+        checkContains(ontology, "ClassAssertion(<http://example.org/B> <http://example.org/c>)"));
     assertTrue(
-      checkContains(
-        ontology,
-        "ClassAssertion(<http://example.org/A> <http://example.org/c>)"));
+        checkContains(ontology, "ClassAssertion(<http://example.org/A> <http://example.org/c>)"));
     assertTrue(
-      checkContains(
-        ontology,
-        "SubClassOf(<http://example.org/C> <http://example.org/B>)"));
+        checkContains(ontology, "SubClassOf(<http://example.org/C> <http://example.org/B>)"));
     assertTrue(
-      checkContains(
-        ontology,
-        "SubClassOf(<http://example.org/C> <http://example.org/A>)"));
+        checkContains(ontology, "SubClassOf(<http://example.org/C> <http://example.org/A>)"));
     assertTrue(
-      checkContains(
-        ontology,
-        "SubClassOf(<http://example.org/C> <http://example.org/D>)"));
+        checkContains(ontology, "SubClassOf(<http://example.org/C> <http://example.org/D>)"));
     assertTrue(
-      checkContains(
-        ontology,
-        "SubObjectPropertyOf(<http://example.org/t> <http://example.org/s>)"));
+        checkContains(
+            ontology, "SubObjectPropertyOf(<http://example.org/t> <http://example.org/s>)"));
     assertTrue(
-      checkContains(
-        ontology,
-        "SubObjectPropertyOf(<http://example.org/t> <http://example.org/r>)"));
+        checkContains(
+            ontology, "SubObjectPropertyOf(<http://example.org/t> <http://example.org/r>)"));
   }
 
   private boolean checkContains(OWLOntology reasoned, String axStr) {

--- a/robot-core/src/test/resources/reason-direct-indirect.ofn
+++ b/robot-core/src/test/resources/reason-direct-indirect.ofn
@@ -1,0 +1,54 @@
+Prefix(:=<http://example.org/>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://example.org/>
+
+Declaration(Class(:A))
+Declaration(Class(:B))
+Declaration(Class(:C))
+Declaration(Class(:D))
+Declaration(ObjectProperty(:r))
+Declaration(ObjectProperty(:s))
+Declaration(ObjectProperty(:t))
+Declaration(NamedIndividual(:c))
+############################
+#   Object Properties
+############################
+
+# Object Property: :s (:s)
+
+SubObjectPropertyOf(:s :r)
+
+# Object Property: :t (:t)
+
+SubObjectPropertyOf(:t :s)
+
+
+############################
+#   Classes
+############################
+
+# Class: :B (:B)
+
+EquivalentClasses(:B ObjectIntersectionOf(:A :D))
+
+# Class: :C (:C)
+
+SubClassOf(:C ObjectIntersectionOf(:B :D))
+
+
+############################
+#   Named Individuals
+############################
+
+# Individual: :c (:c)
+
+ClassAssertion(:C :c)
+
+
+)


### PR DESCRIPTION
Create specialized axiom generators to handle direct vs. indirect. This will eliminate some cases of materializing axioms twice.