### PR TITLE
Fix index out of bounds when printing report violations

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -626,6 +626,9 @@ public class ReportOperation {
    * @param n number of lines to print
    */
   private static void printNViolations(String[] lines, int n) {
+    if (lines.length <= n) {
+      n = lines.length - 1;
+    }
     System.out.println(String.format("\nFirst %d violations:", n));
     for (int i = 0; i < n; i++) {
       // i + 1 to skip headers


### PR DESCRIPTION
See #544 - if the `--print` option is greater than the number of violations, ROBOT throws an exception. This fixes that bug.