### PR TITLE
Fix query when chaining with input IRI

### DIFF
--- a/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
@@ -270,9 +270,15 @@ public class QueryCommand implements Command {
     String catalogPath = state.getCatalogPath();
     if (catalogPath == null) {
       String ontologyPath = state.getOntologyPath();
-      File catalogFile = ioHelper.guessCatalogFile(new File(ontologyPath));
-      if (catalogFile != null) {
-        catalogPath = catalogFile.getPath();
+      // If loading from IRI, ontologyPath might be null
+      // In which case, we cannot get a catalog
+      if (ontologyPath == null) {
+        catalogPath = null;
+      } else {
+        File catalogFile = ioHelper.guessCatalogFile(new File(ontologyPath));
+        if (catalogFile != null) {
+          catalogPath = catalogFile.getPath();
+        }
       }
     }
     // Make sure the file exists


### PR DESCRIPTION
When chaining with an `--input-iri`, the `ontologyPath` variable in the state will be null. We currently try and guess the catalog path from this variable, but if the `ontologyPath` is null, creating a File object throws a null pointer exception. This PR adds a check to make sure the `ontologyPath` is not null before attempting to guess the catalog.