### PR TITLE
Optimize report for large ontologies

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -117,6 +117,10 @@ If a prefix is incorrectly formatted, or if the prefix target does not point to 
 robot -p "robot: http://purl.obolibrary.org/robot/"
 ```
 
+### TDB Format Error
+
+`--tdb true` can only be used with RDF/XML (`.owl` or `.rdf`) or TTL syntax (`.ttl`).
+
 ### Unknown Arg Error
 
 This error message may appear for one of two common reasons:
@@ -154,3 +158,7 @@ If at least one term exists in the ontology, the task can still proceed, but the
 ### Null IRI Error
 
 Occurs when an import ontology does not have a valid IRI.
+
+### Syntax Error
+
+This error occurs when an ontology cannot be loaded from file to a TDB dataset (using `--tdb true`). Review your ontology to ensure it is valid RDF/XML or TTL syntax.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -117,10 +117,6 @@ If a prefix is incorrectly formatted, or if the prefix target does not point to 
 robot -p "robot: http://purl.obolibrary.org/robot/"
 ```
 
-### TDB Format Error
-
-`--tdb true` can only be used with RDF/XML (`.owl` or `.rdf`) or TTL syntax (`.ttl`).
-
 ### Unknown Arg Error
 
 This error message may appear for one of two common reasons:
@@ -161,4 +157,4 @@ Occurs when an import ontology does not have a valid IRI.
 
 ### Syntax Error
 
-This error occurs when an ontology cannot be loaded from file to a TDB dataset (using `--tdb true`). Review your ontology to ensure it is valid RDF/XML or TTL syntax.
+This error occurs when an ontology cannot be loaded from file to a TDB dataset (using `--tdb true`). Review your ontology to ensure it is valid RDF/XML or TTL syntax. Jena also supports [some other formats](https://jena.apache.org/documentation/io/#formats).

--- a/docs/query.md
+++ b/docs/query.md
@@ -77,7 +77,7 @@ For very large ontologies, it may be beneficial to load the ontology to a mappin
     robot query --input nucleus.ttl --tdb true \
      --query cell_part.sparql results/cell_part.csv
  
-Please note that this will only work with ontologies in RDF/XML (`.owl` or `.rdf`) or TTL syntax (`.ttl`). Attempting to load an ontology in a different syntax will result in a [Syntax Error](#syntax-error). ROBOT will create a directory to store the ontology as a dataset, which defaults to `.tdb`. You can change the location of the TDB directory by using `--tdb-directory <directory>`.
+Please note that this will only work with ontologies in RDF/XML or Turtle syntax, and not with Manchester Syntax. Attempting to load an ontology in a different syntax will result in a [Syntax Error](errors#syntax-error). ROBOT will create a directory to store the ontology as a dataset, which defaults to `.tdb`. You can change the location of the TDB directory by using `--tdb-directory <directory>`.
 
 Once the query operation is complete, ROBOT will remove the TDB directory. If you are performing many query commands on one ontology, you can include `--keep-tdb-mappings true` to prevent ROBOT from removing the TDB directory. This will greatly reduce the execution time of subsequent queries.
 

--- a/docs/query.md
+++ b/docs/query.md
@@ -102,11 +102,3 @@ The query was not able to be parsed. Often, this is as a result of an undefined 
 ### Query Type Error
 
 Each SPARQL query should be a SELECT, ASK, DESCRIBE, or CONSTRUCT.
-
-### Syntax Error
-
-This error occurs when an ontology cannot be loaded from file to a TDB dataset. Review your ontology to ensure it is valid RDF/XML or TTL syntax.
-
-### TDB Format Error
-
-`--tdb true` can only be used with RDF/XML (`.owl` or `.rdf`) or TTL syntax (`.ttl`).

--- a/docs/report.md
+++ b/docs/report.md
@@ -100,9 +100,7 @@ INFO    file:./relative/path/to/other_query.rq
 
 ## Executing on Disk
 
-`report` may fail on some very large ontologies of ROBOT cannot fit the entire ontology into memory.
-
-`report` allows you to load the ontology to a mapping file on disk with the `--tdb true` option. This is supported by [Jena TDB Datasets](http://jena.apache.org/documentation/tdb/datasets.html):
+`report` may fail on some very large ontologies when ROBOT cannot fit the entire ontology into memory. You can either increase the available memory (see [Java Options](global#java-options)), or use the `--tdb true` option to load the ontology as an [Apache Jena TDB Dataset](http://jena.apache.org/documentation/tdb/datasets.html) instead of with OWL API:
 
 ```
 robot report --input edit.owl \
@@ -110,11 +108,9 @@ robot report --input edit.owl \
   --output my-report.tsv
 ```
 
-Please note that this will only work with ontologies in RDF/XML (`.owl` or `.rdf`) or TTL syntax (`.ttl`). Attempting to load an ontology in a different syntax will result in a [Syntax Error](#syntax-error). ROBOT will create a directory to store the ontology as a dataset, which defaults to `.tdb`. You can change the location of the TDB directory by using `--tdb-directory <directory>`.
+Please note that this will only work with ontologies in RDF/XML or Turtle syntax, and not with Manchester Syntax. Attempting to load an ontology in a different syntax will result in a [Syntax Error](errors#syntax-error). ROBOT will create a directory to store the ontology as a dataset, which defaults to `.tdb`. You can change the location of the TDB directory by using `--tdb-directory <directory>`.
 
-Once the report is complete, ROBOT will remove the TDB directory. You can include `--keep-tdb-mappings true` to prevent ROBOT from removing the TDB directory (which may be beneficial if you want to reuse it with [query](/query#executing-on-disk)). This will greatly reduce the execution time of subsequent TDB-based operations on the ontology.
-
-The `--labels` option cannot be used with TDB, as the ontology is never loaded as an OWL API object.
+Once the report is complete, ROBOT will remove the TDB directory. You can include `--keep-tdb-mappings true` to prevent ROBOT from removing the TDB directory (which may be beneficial if you want to reuse it with [query](query#executing-on-disk)). This will greatly reduce the execution time of subsequent TDB-based operations on the ontology.
 
 ## Limiting Results
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -113,6 +113,18 @@ Please note that this will only work with ontologies in RDF/XML (`.owl` or `.rdf
 
 Once the report is complete, ROBOT will remove the TDB directory. You can include `--keep-tdb-mappings true` to prevent ROBOT from removing the TDB directory (which may be beneficial if you want to reuse it with [query](/query#executing-on-disk)). This will greatly reduce the execution time of subsequent TDB-based operations on the ontology.
 
+## Limiting Results
+
+Large numbers of results from the report queries may cause an `OutOfMemoryError`. To prevent this, you can limit the number of results with `--limit <INTEGER>`:
+
+```
+robot report --input edit.owl \
+  --limit 10000 \
+  --output my-report.tsv
+```
+
+This example will only include the first 10,000 results for each report query, meaning that some violation counts may be incomplete. Typically, you should not need to include a limit, but when working with large ontologies (using TDB), there may be hundreds of thousands of results.
+
 ---
 
 ## Error Messages
@@ -120,6 +132,10 @@ Once the report is complete, ROBOT will remove the TDB directory. You can includ
 ### Fail On Error
 
 Only `info`, `warn`, and `error` are valid inputs for `--fail-on`.
+
+### Limit Number Error
+
+The argument for the `--limit` option must be a number.
 
 ### Missing Entity Binding
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -7,6 +7,7 @@
 3. [Failing (`--fail-on`)](#failing)
 4. [Queries](#queries)
 5. [Profiles (`--profile`)](#profiles)
+6. [Executing on Disk (`--tdb`)](#executing-on-disk)
 
 ## Overview
 
@@ -95,6 +96,22 @@ ERROR   deprecated_class
 INFO    file:///absolute/path/to/other_query.rq
 INFO    file:./relative/path/to/other_query.rq
 ```
+
+## Executing on Disk
+
+`report` may fail on some very large ontologies, due to ROBOT loading the entire ontology into memory.
+
+`report` allows you to load the ontology to a mapping file on disk with the `--tdb true` option. This is supported by [Jena TDB Datasets](http://jena.apache.org/documentation/tdb/datasets.html):
+
+```
+robot report --input edit.owl \
+  --tdb true \
+  --output my-report.tsv
+```
+
+Please note that this will only work with ontologies in RDF/XML (`.owl` or `.rdf`) or TTL syntax (`.ttl`). Attempting to load an ontology in a different syntax will result in a [Syntax Error](#syntax-error). ROBOT will create a directory to store the ontology as a dataset, which defaults to `.tdb`. You can change the location of the TDB directory by using `--tdb-directory <directory>`.
+
+Once the report is complete, ROBOT will remove the TDB directory. You can include `--keep-tdb-mappings true` to prevent ROBOT from removing the TDB directory (which may be beneficial if you want to reuse it with [query](/query#executing-on-disk)). This will greatly reduce the execution time of subsequent TDB-based operations on the ontology.
 
 ---
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -8,6 +8,7 @@
 4. [Queries](#queries)
 5. [Profiles (`--profile`)](#profiles)
 6. [Executing on Disk (`--tdb`)](#executing-on-disk)
+7. [Limiting Results (`--limit`)](#limiting-results)
 
 ## Overview
 
@@ -112,6 +113,8 @@ robot report --input edit.owl \
 Please note that this will only work with ontologies in RDF/XML (`.owl` or `.rdf`) or TTL syntax (`.ttl`). Attempting to load an ontology in a different syntax will result in a [Syntax Error](#syntax-error). ROBOT will create a directory to store the ontology as a dataset, which defaults to `.tdb`. You can change the location of the TDB directory by using `--tdb-directory <directory>`.
 
 Once the report is complete, ROBOT will remove the TDB directory. You can include `--keep-tdb-mappings true` to prevent ROBOT from removing the TDB directory (which may be beneficial if you want to reuse it with [query](/query#executing-on-disk)). This will greatly reduce the execution time of subsequent TDB-based operations on the ontology.
+
+The `--labels` option cannot be used with TDB, as the ontology is never loaded as an OWL API object.
 
 ## Limiting Results
 

--- a/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
@@ -271,9 +271,15 @@ public class QueryCommand implements Command {
     String catalogPath = state.getCatalogPath();
     if (catalogPath == null) {
       String ontologyPath = state.getOntologyPath();
-      File catalogFile = ioHelper.guessCatalogFile(new File(ontologyPath));
-      if (catalogFile != null) {
-        catalogPath = catalogFile.getPath();
+      // If loading from IRI, ontologyPath might be null
+      // In which case, we cannot get a catalog
+      if (ontologyPath == null) {
+        catalogPath = null;
+      } else {
+        File catalogFile = ioHelper.guessCatalogFile(new File(ontologyPath));
+        if (catalogFile != null) {
+          catalogPath = catalogFile.getPath();
+        }
       }
     }
     // Make sure the file exists

--- a/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
@@ -34,7 +34,7 @@ public class QueryCommand implements Command {
 
   /** Error message when a query is not provided */
   private static final String missingQueryError =
-    NS + "MISSING QUERY ERROR at least one query must be provided";
+      NS + "MISSING QUERY ERROR at least one query must be provided";
 
   /** Store the command-line options for the command. */
   private Options options;
@@ -180,7 +180,7 @@ public class QueryCommand implements Command {
    * @throws Exception on issue loading ontology or running queries
    */
   private static void executeInMemory(
-    CommandLine line, OWLOntology inputOntology, List<List<String>> queries) throws Exception {
+      CommandLine line, OWLOntology inputOntology, List<List<String>> queries) throws Exception {
     boolean useGraphs = CommandLineHelper.getBooleanValue(line, "use-graphs", false);
     Dataset dataset = QueryOperation.loadOntologyAsDataset(inputOntology, useGraphs);
     try {
@@ -200,9 +200,9 @@ public class QueryCommand implements Command {
    * @throws IOException on problem running queries
    */
   private static void executeOnDisk(CommandLine line, List<List<String>> queries)
-    throws IOException {
+      throws IOException {
     String inputPath =
-      CommandLineHelper.getRequiredValue(line, "input", "an input is required for TDB");
+        CommandLineHelper.getRequiredValue(line, "input", "an input is required for TDB");
     String tdbDir = CommandLineHelper.getDefaultValue(line, "tdb-directory", ".tdb");
     boolean keepMappings = CommandLineHelper.getBooleanValue(line, "keep-tdb-mappings", false);
     Dataset dataset = QueryOperation.loadTriplesAsDataset(inputPath, tdbDir);
@@ -232,8 +232,8 @@ public class QueryCommand implements Command {
    * @throws Exception on file or ontology loading issues
    */
   private static OWLOntology executeUpdate(
-    CommandState state, OWLOntology inputOntology, IOHelper ioHelper, List<String> updatePaths)
-    throws Exception {
+      CommandState state, OWLOntology inputOntology, IOHelper ioHelper, List<String> updatePaths)
+      throws Exception {
     Map<String, String> updates = new LinkedHashMap<>();
     for (String updatePath : updatePaths) {
       File f = new File(updatePath);
@@ -319,7 +319,7 @@ public class QueryCommand implements Command {
    * @throws IOException on issue reading or writing files
    */
   private static void runQueries(CommandLine line, Dataset dataset, List<List<String>> queries)
-    throws IOException {
+      throws IOException {
     String format = CommandLineHelper.getOptionalValue(line, "format");
     String outputDir = CommandLineHelper.getDefaultValue(line, "output-dir", "");
 

--- a/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
@@ -12,7 +12,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.shared.JenaException;
 import org.apache.jena.tdb.TDBFactory;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.slf4j.Logger;
@@ -207,16 +206,7 @@ public class QueryCommand implements Command {
     String tdbDir = CommandLineHelper.getDefaultValue(line, "tdb-directory", ".tdb");
     boolean keepMappings = CommandLineHelper.getBooleanValue(line, "keep-tdb-mappings", false);
 
-    if (!inputPath.endsWith(".rdf") && !inputPath.endsWith(".owl") && !inputPath.endsWith(".ttl")) {
-      throw new IllegalArgumentException(IOHelper.tdbFormatError);
-    }
-
-    Dataset dataset;
-    try {
-      dataset = IOHelper.loadToTDBDataset(inputPath, tdbDir);
-    } catch (JenaException e) {
-      throw new IOException(String.format(IOHelper.syntaxError, inputPath, e.getMessage()));
-    }
+    Dataset dataset = IOHelper.loadToTDBDataset(inputPath, tdbDir);
 
     try {
       runQueries(line, dataset, queries);

--- a/robot-command/src/main/java/org/obolibrary/robot/ReportCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ReportCommand.java
@@ -121,7 +121,7 @@ public class ReportCommand implements Command {
       // TDB is backed on disk and loads directly from path
       // Avoids extra time loading OWLOntology object for big ontologies
       String inputPath =
-        CommandLineHelper.getRequiredValue(line, "input", "An input ontology is required");
+          CommandLineHelper.getRequiredValue(line, "input", "An input ontology is required");
       success = ReportOperation.tdbReport(inputPath, outputPath, reportOptions);
     } else {
       state = CommandLineHelper.updateInputOntology(ioHelper, state, line);

--- a/robot-command/src/main/java/org/obolibrary/robot/ReportCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ReportCommand.java
@@ -30,6 +30,10 @@ public class ReportCommand implements Command {
     o.addOption("F", "fail-on", true, "logging level to fail on");
     o.addOption("l", "labels", true, "if true, use labels for output");
     o.addOption("P", "print", true, "specify a number of violations to print");
+    o.addOption("t", "tdb", true, "if true, load RDF/XML or TTL onto disk");
+    o.addOption("k", "keep-tdb-mappings", true, "if true, do not remove the TDB directory");
+    o.addOption("d", "tdb-directory", true, "directory to put TDB mappings (default: .tdb)");
+    o.addOption("L", "limit", true, "specify a number of results to limit queries to");
     options = o;
   }
 
@@ -98,8 +102,6 @@ public class ReportCommand implements Command {
     }
 
     IOHelper ioHelper = CommandLineHelper.getIOHelper(line);
-    state = CommandLineHelper.updateInputOntology(ioHelper, state, line);
-    OWLOntology ontology = state.getOntology();
 
     // Override default report options with command-line options
     Map<String, String> reportOptions = ReportOperation.getDefaultOptions();
@@ -112,10 +114,24 @@ public class ReportCommand implements Command {
     // output is optional - no output means the file will not be written anywhere
     String outputPath = CommandLineHelper.getOptionalValue(line, "output");
 
+    boolean success;
+
+    boolean tdb = CommandLineHelper.getBooleanValue(line, "tdb", false);
+    if (tdb) {
+      // TDB is backed on disk and loads directly from path
+      // Avoids extra time loading OWLOntology object for big ontologies
+      String inputPath =
+        CommandLineHelper.getRequiredValue(line, "input", "An input ontology is required");
+      success = ReportOperation.tdbReport(inputPath, outputPath, reportOptions);
+    } else {
+      state = CommandLineHelper.updateInputOntology(ioHelper, state, line);
+      OWLOntology ontology = state.getOntology();
+      success = ReportOperation.report(ontology, ioHelper, outputPath, reportOptions);
+    }
+
     // Success is based on failOn
     // If any violations are found of the fail-on level, this will be false
     // If fail-on is "none" or if no violations are found, this will be true
-    boolean success = ReportOperation.report(ontology, ioHelper, outputPath, reportOptions);
     if (!success) {
       logger.error("Report failed!");
       System.exit(1);

--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -38,7 +38,7 @@
             <dependency>
               <groupId>${project.groupId}</groupId>
               <artifactId>${project.artifactId}</artifactId>
-              <version>1.2.0</version>
+              <version>1.4.1</version>
               <type>jar</type>
             </dependency>
           </oldVersion>
@@ -51,7 +51,7 @@
             <!-- see documentation: http://siom79.github.io/japicmp/MavenPlugin.html -->
             <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
             <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
-            <!-- include on breaking changes 
+            <!-- include on breaking changes
             <excludes></excludes>
             -->
           </parameter>

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -107,14 +107,13 @@ public class IOHelper {
       NS + "PREFIX LOAD ERROR Could not load prefix '%s' for '%s'";
 
   /**
-   * Error message when a JenaException is thrown from reading file to model due to a syntax error.
-   * Expects: file name, error message.
+   * Error message when Jena cannot load a file to a dataset, probably not RDF/XML (including OWL)
+   * or TTL.
    */
-  protected static final String syntaxError = NS + "SYNTAX ERROR %s cannot be read:\n%s";
-
-  /** Error message when --tdb is true but the input is not RDF/XML (including OWL) or TTL */
-  protected static final String tdbFormatError =
-      NS + "TDB FORMAT ERROR input file must be owl, rdf, or ttl.";
+  private static final String syntaxError =
+      NS
+          + "SYNTAX ERROR unable to load '%s' with Jena - "
+          + "check that this file is in RDF/XML or TTL syntax and try again.";
 
   /** Path to default context as a resource. */
   private static String defaultContextPath = "/obo_context.jsonld";
@@ -520,7 +519,7 @@ public class IOHelper {
       dataset.abort();
       dataset.end();
       dataset.close();
-      throw e;
+      throw new JenaException(String.format(syntaxError, inputPath));
     } finally {
       dataset.end();
     }

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -203,6 +203,32 @@ public class IOHelper {
   }
 
   /**
+   * Given a directory containing TDB mappings, remove the files and directory. If successful,
+   * return true.
+   *
+   * @param tdbDir directory to remove
+   * @return boolean indicating success
+   */
+  protected static boolean cleanTDB(String tdbDir) {
+    File dir = new File(tdbDir);
+    boolean success = true;
+    if (dir.exists()) {
+      String[] files = dir.list();
+      if (files != null) {
+        for (String file : files) {
+          File f = new File(dir.getPath(), file);
+          success = f.delete();
+        }
+      }
+      // Only delete if all the files in dir were deleted
+      if (success) {
+        success = dir.delete();
+      }
+    }
+    return success;
+  }
+
+  /**
    * Try to guess the location of the catalog.xml file. Looks in the directory of the given ontology
    * file for a catalog file.
    *

--- a/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
@@ -9,13 +9,11 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.*;
 import org.apache.jena.riot.resultset.ResultSetLang;
-import org.apache.jena.shared.JenaException;
 import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.tdb.TDB;
 import org.apache.jena.tdb.TDBFactory;
 import org.apache.jena.update.UpdateAction;
-import org.apache.jena.util.FileManager;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.formats.TurtleDocumentFormat;
 import org.semanticweb.owlapi.model.*;
@@ -40,16 +38,6 @@ public class QueryOperation {
 
   /** Error message when query type is illegal. Expects: query type. */
   private static final String queryTypeError = NS + "QUERY TYPE ERROR unknown query type: %s";
-
-  /**
-   * Error message when a JenaException is thrown from reading file to model due to a syntax error.
-   * Expects: file name, error message.
-   */
-  private static final String syntaxError = NS + "SYNTAX ERROR %s cannot be read:\n%s";
-
-  /** Error message when --tdb is true but the input is not RDF/XML (including OWL) or TTL */
-  protected static final String tdbFormatError =
-      NS + "TDB FORMAT ERROR input file must be owl, rdf, or ttl.";
 
   /**
    * Load an ontology into a DatasetGraph. The ontology is not changed.
@@ -131,53 +119,6 @@ public class QueryOperation {
     String content = new String(os.toByteArray(), StandardCharsets.UTF_8);
     RDFParser.fromString(content).lang(RDFLanguages.TTL).parse(model);
     return model;
-  }
-
-  /**
-   * Given a path to an RDF/XML or TTL file and a RDF language, load the file as the default model
-   * of a TDB dataset backed by a directory to improve processing time. Return the new dataset.
-   *
-   * <p>WARNING - this creates a directory at given tdbDir location!
-   *
-   * @param inputPath input path of RDF/XML or TTL file
-   * @param tdbDir location to put TDB mappings
-   * @return Dataset instantiated with triples
-   * @throws IOException if TDB directory can't be written to
-   */
-  public static Dataset loadTriplesAsDataset(String inputPath, String tdbDir) throws IOException {
-    // Dataset backed by a temp dir
-    if (!inputPath.endsWith(".rdf") && !inputPath.endsWith(".owl") && !inputPath.endsWith(".ttl")) {
-      throw new IllegalArgumentException(tdbFormatError);
-    }
-
-    Dataset dataset;
-    if (new File(tdbDir).isDirectory()) {
-      dataset = TDBFactory.createDataset(tdbDir);
-      if (!dataset.isEmpty()) {
-        return dataset;
-      }
-    }
-    dataset = TDBFactory.createDataset(tdbDir);
-    logger.debug(String.format("Parsing input '%s' to dataset", inputPath));
-    // Track parsing time
-    long start = System.nanoTime();
-    Model m;
-    dataset.begin(ReadWrite.WRITE);
-    try {
-      m = dataset.getDefaultModel();
-      FileManager.get().readModel(m, inputPath);
-      dataset.commit();
-    } catch (JenaException e) {
-      dataset.abort();
-      dataset.end();
-      dataset.close();
-      throw new IOException(String.format(syntaxError, inputPath, e.getMessage()));
-    } finally {
-      dataset.end();
-    }
-    long time = (System.nanoTime() - start) / 1000000000;
-    logger.debug(String.format("Parsing complete - took %s seconds", String.valueOf(time)));
-    return dataset;
   }
 
   /**

--- a/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
@@ -36,7 +36,7 @@ public class QueryOperation {
 
   /** Error message when query parsing fails. Expects: error message from parse. */
   private static final String queryParseError =
-    NS + "QUERY PARSE ERROR query cannot be parsed:\n%s";
+      NS + "QUERY PARSE ERROR query cannot be parsed:\n%s";
 
   /** Error message when query type is illegal. Expects: query type. */
   private static final String queryTypeError = NS + "QUERY TYPE ERROR unknown query type: %s";
@@ -49,7 +49,7 @@ public class QueryOperation {
 
   /** Error message when --tdb is true but the input is not RDF/XML (including OWL) or TTL */
   protected static final String tdbFormatError =
-    NS + "TDB FORMAT ERROR input file must be owl, rdf, or ttl.";
+      NS + "TDB FORMAT ERROR input file must be owl, rdf, or ttl.";
 
   /**
    * Load an ontology into a DatasetGraph. The ontology is not changed.
@@ -76,7 +76,7 @@ public class QueryOperation {
    * @throws OWLOntologyStorageException on issue writing ontology to TTL format
    */
   public static Dataset loadOntologyAsDataset(OWLOntology ontology)
-    throws OWLOntologyStorageException {
+      throws OWLOntologyStorageException {
     return loadOntologyAsDataset(ontology, false);
   }
 
@@ -90,7 +90,7 @@ public class QueryOperation {
    * @throws OWLOntologyStorageException on issue writing ontology to TTL format
    */
   public static Dataset loadOntologyAsDataset(OWLOntology ontology, boolean useGraphs)
-    throws OWLOntologyStorageException {
+      throws OWLOntologyStorageException {
     Set<OWLOntology> ontologies = new HashSet<>();
     ontologies.add(ontology);
     if (useGraphs) {
@@ -207,7 +207,7 @@ public class QueryOperation {
    * @throws IOException on issue loading ontology
    */
   public static OWLOntology convertModel(Model model, IOHelper ioHelper, String catalogPath)
-    throws IOException {
+      throws IOException {
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     RDFDataMgr.write(os, model, Lang.TTL);
     return ioHelper.loadOntology(new ByteArrayInputStream(os.toByteArray()), catalogPath);
@@ -309,14 +309,14 @@ public class QueryOperation {
    */
   @Deprecated
   public static boolean execVerify(
-    Map<File, Tuple<ResultSetRewindable, OutputStream>> queriesResults) throws IOException {
+      Map<File, Tuple<ResultSetRewindable, OutputStream>> queriesResults) throws IOException {
     boolean isViolation = false;
     for (File outFile : queriesResults.keySet()) {
       Tuple<ResultSetRewindable, OutputStream> resultAndStream = queriesResults.get(outFile);
       ResultSetRewindable results = resultAndStream.left();
       OutputStream outStream = resultAndStream.right();
       System.out.println(
-        "Rule " + outFile.getCanonicalPath() + ": " + results.size() + " violation(s)");
+          "Rule " + outFile.getCanonicalPath() + ": " + results.size() + " violation(s)");
       if (results.size() > 0) {
         isViolation = true;
         ResultSetMgr.write(System.err, results, Lang.CSV);
@@ -340,7 +340,7 @@ public class QueryOperation {
    */
   @Deprecated
   public static boolean execVerify(DatasetGraph dsg, String ruleName, String query)
-    throws IOException {
+      throws IOException {
     return execVerify(DatasetFactory.wrap(dsg), ruleName, query);
   }
 
@@ -355,7 +355,7 @@ public class QueryOperation {
    * @throws IOException on query parse error
    */
   public static boolean execVerify(Dataset dataset, String ruleName, String query)
-    throws IOException {
+      throws IOException {
     ResultSetRewindable results = ResultSetFactory.copyResults(execQuery(dataset, query));
     System.out.println("Rule " + ruleName + ": " + results.size() + " violation(s)");
     if (results.size() == 0) {
@@ -542,7 +542,7 @@ public class QueryOperation {
    * @throws FileNotFoundException if output file is not found
    */
   public static void runConstruct(Dataset dataset, String query, File output, Lang outputFormat)
-    throws FileNotFoundException {
+      throws FileNotFoundException {
     writeResult(execConstruct(dataset, query), outputFormat, new FileOutputStream(output));
   }
 
@@ -558,7 +558,7 @@ public class QueryOperation {
    */
   @Deprecated
   public static void runQuery(DatasetGraph dsg, String query, File output, Lang outputFormat)
-    throws IOException {
+      throws IOException {
     runQuery(DatasetFactory.wrap(dsg), query, output, outputFormat);
   }
 
@@ -572,7 +572,7 @@ public class QueryOperation {
    * @throws IOException if output file is not found or query cannot be parsed
    */
   public static void runQuery(Dataset dataset, String query, File output, Lang outputFormat)
-    throws IOException {
+      throws IOException {
     if (outputFormat == null) {
       outputFormat = Lang.CSV;
     }
@@ -592,7 +592,7 @@ public class QueryOperation {
    */
   @Deprecated
   public static boolean runSparqlQuery(
-    DatasetGraph dsg, String query, String formatName, OutputStream output) throws IOException {
+      DatasetGraph dsg, String query, String formatName, OutputStream output) throws IOException {
     return runSparqlQuery(DatasetFactory.wrap(dsg), query, formatName, output);
   }
 
@@ -608,8 +608,8 @@ public class QueryOperation {
    * @throws IOException on issue parsing query
    */
   public static boolean runSparqlQuery(
-    Dataset dataset, String queryString, String formatName, OutputStream output)
-    throws IOException {
+      Dataset dataset, String queryString, String formatName, OutputStream output)
+      throws IOException {
     dataset.begin(ReadWrite.READ);
     boolean result;
     try (QueryExecution qExec = QueryExecutionFactory.create(queryString, dataset)) {
@@ -632,7 +632,7 @@ public class QueryOperation {
    * @return true if there are results
    */
   public static boolean runSparqlQuery(
-    QueryExecution qExec, String formatName, OutputStream output) {
+      QueryExecution qExec, String formatName, OutputStream output) {
     Query query = qExec.getQuery();
     if (formatName == null) {
       formatName = getDefaultFormatName(query);
@@ -663,7 +663,7 @@ public class QueryOperation {
    * @throws FileNotFoundException if output file cannot be found
    */
   public static void runUpdate(Model model, String updateString, File output, Lang outputFormat)
-    throws FileNotFoundException {
+      throws FileNotFoundException {
     if (outputFormat == null) {
       outputFormat = Lang.TTL;
     }
@@ -685,8 +685,8 @@ public class QueryOperation {
    */
   @Deprecated
   public static boolean runVerify(
-    DatasetGraph dsg, String ruleName, String query, Path outputPath, Lang outputFormat)
-    throws IOException {
+      DatasetGraph dsg, String ruleName, String query, Path outputPath, Lang outputFormat)
+      throws IOException {
     return runVerify(DatasetFactory.wrap(dsg), ruleName, query, outputPath, outputFormat);
   }
 
@@ -703,8 +703,8 @@ public class QueryOperation {
    * @return true if the are results (so file is written), false otherwise
    */
   public static boolean runVerify(
-    Dataset dataset, String ruleName, String query, Path outputPath, Lang outputFormat)
-    throws IOException {
+      Dataset dataset, String ruleName, String query, Path outputPath, Lang outputFormat)
+      throws IOException {
     if (outputFormat == null) {
       outputFormat = Lang.CSV;
     }

--- a/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
@@ -36,7 +36,7 @@ public class QueryOperation {
 
   /** Error message when query parsing fails. Expects: error message from parse. */
   private static final String queryParseError =
-      NS + "QUERY PARSE ERROR query cannot be parsed:\n%s";
+    NS + "QUERY PARSE ERROR query cannot be parsed:\n%s";
 
   /** Error message when query type is illegal. Expects: query type. */
   private static final String queryTypeError = NS + "QUERY TYPE ERROR unknown query type: %s";
@@ -46,6 +46,10 @@ public class QueryOperation {
    * Expects: file name, error message.
    */
   private static final String syntaxError = NS + "SYNTAX ERROR %s cannot be read:\n%s";
+
+  /** Error message when --tdb is true but the input is not RDF/XML (including OWL) or TTL */
+  protected static final String tdbFormatError =
+    NS + "TDB FORMAT ERROR input file must be owl, rdf, or ttl.";
 
   /**
    * Load an ontology into a DatasetGraph. The ontology is not changed.
@@ -72,7 +76,7 @@ public class QueryOperation {
    * @throws OWLOntologyStorageException on issue writing ontology to TTL format
    */
   public static Dataset loadOntologyAsDataset(OWLOntology ontology)
-      throws OWLOntologyStorageException {
+    throws OWLOntologyStorageException {
     return loadOntologyAsDataset(ontology, false);
   }
 
@@ -86,7 +90,7 @@ public class QueryOperation {
    * @throws OWLOntologyStorageException on issue writing ontology to TTL format
    */
   public static Dataset loadOntologyAsDataset(OWLOntology ontology, boolean useGraphs)
-      throws OWLOntologyStorageException {
+    throws OWLOntologyStorageException {
     Set<OWLOntology> ontologies = new HashSet<>();
     ontologies.add(ontology);
     if (useGraphs) {
@@ -142,6 +146,10 @@ public class QueryOperation {
    */
   public static Dataset loadTriplesAsDataset(String inputPath, String tdbDir) throws IOException {
     // Dataset backed by a temp dir
+    if (!inputPath.endsWith(".rdf") && !inputPath.endsWith(".owl") && !inputPath.endsWith(".ttl")) {
+      throw new IllegalArgumentException(tdbFormatError);
+    }
+
     Dataset dataset;
     if (new File(tdbDir).isDirectory()) {
       dataset = TDBFactory.createDataset(tdbDir);
@@ -199,7 +207,7 @@ public class QueryOperation {
    * @throws IOException on issue loading ontology
    */
   public static OWLOntology convertModel(Model model, IOHelper ioHelper, String catalogPath)
-      throws IOException {
+    throws IOException {
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     RDFDataMgr.write(os, model, Lang.TTL);
     return ioHelper.loadOntology(new ByteArrayInputStream(os.toByteArray()), catalogPath);
@@ -301,14 +309,14 @@ public class QueryOperation {
    */
   @Deprecated
   public static boolean execVerify(
-      Map<File, Tuple<ResultSetRewindable, OutputStream>> queriesResults) throws IOException {
+    Map<File, Tuple<ResultSetRewindable, OutputStream>> queriesResults) throws IOException {
     boolean isViolation = false;
     for (File outFile : queriesResults.keySet()) {
       Tuple<ResultSetRewindable, OutputStream> resultAndStream = queriesResults.get(outFile);
       ResultSetRewindable results = resultAndStream.left();
       OutputStream outStream = resultAndStream.right();
       System.out.println(
-          "Rule " + outFile.getCanonicalPath() + ": " + results.size() + " violation(s)");
+        "Rule " + outFile.getCanonicalPath() + ": " + results.size() + " violation(s)");
       if (results.size() > 0) {
         isViolation = true;
         ResultSetMgr.write(System.err, results, Lang.CSV);
@@ -332,7 +340,7 @@ public class QueryOperation {
    */
   @Deprecated
   public static boolean execVerify(DatasetGraph dsg, String ruleName, String query)
-      throws IOException {
+    throws IOException {
     return execVerify(DatasetFactory.wrap(dsg), ruleName, query);
   }
 
@@ -347,7 +355,7 @@ public class QueryOperation {
    * @throws IOException on query parse error
    */
   public static boolean execVerify(Dataset dataset, String ruleName, String query)
-      throws IOException {
+    throws IOException {
     ResultSetRewindable results = ResultSetFactory.copyResults(execQuery(dataset, query));
     System.out.println("Rule " + ruleName + ": " + results.size() + " violation(s)");
     if (results.size() == 0) {
@@ -534,7 +542,7 @@ public class QueryOperation {
    * @throws FileNotFoundException if output file is not found
    */
   public static void runConstruct(Dataset dataset, String query, File output, Lang outputFormat)
-      throws FileNotFoundException {
+    throws FileNotFoundException {
     writeResult(execConstruct(dataset, query), outputFormat, new FileOutputStream(output));
   }
 
@@ -550,7 +558,7 @@ public class QueryOperation {
    */
   @Deprecated
   public static void runQuery(DatasetGraph dsg, String query, File output, Lang outputFormat)
-      throws IOException {
+    throws IOException {
     runQuery(DatasetFactory.wrap(dsg), query, output, outputFormat);
   }
 
@@ -564,7 +572,7 @@ public class QueryOperation {
    * @throws IOException if output file is not found or query cannot be parsed
    */
   public static void runQuery(Dataset dataset, String query, File output, Lang outputFormat)
-      throws IOException {
+    throws IOException {
     if (outputFormat == null) {
       outputFormat = Lang.CSV;
     }
@@ -584,7 +592,7 @@ public class QueryOperation {
    */
   @Deprecated
   public static boolean runSparqlQuery(
-      DatasetGraph dsg, String query, String formatName, OutputStream output) throws IOException {
+    DatasetGraph dsg, String query, String formatName, OutputStream output) throws IOException {
     return runSparqlQuery(DatasetFactory.wrap(dsg), query, formatName, output);
   }
 
@@ -600,8 +608,8 @@ public class QueryOperation {
    * @throws IOException on issue parsing query
    */
   public static boolean runSparqlQuery(
-      Dataset dataset, String queryString, String formatName, OutputStream output)
-      throws IOException {
+    Dataset dataset, String queryString, String formatName, OutputStream output)
+    throws IOException {
     dataset.begin(ReadWrite.READ);
     boolean result;
     try (QueryExecution qExec = QueryExecutionFactory.create(queryString, dataset)) {
@@ -624,7 +632,7 @@ public class QueryOperation {
    * @return true if there are results
    */
   public static boolean runSparqlQuery(
-      QueryExecution qExec, String formatName, OutputStream output) {
+    QueryExecution qExec, String formatName, OutputStream output) {
     Query query = qExec.getQuery();
     if (formatName == null) {
       formatName = getDefaultFormatName(query);
@@ -655,7 +663,7 @@ public class QueryOperation {
    * @throws FileNotFoundException if output file cannot be found
    */
   public static void runUpdate(Model model, String updateString, File output, Lang outputFormat)
-      throws FileNotFoundException {
+    throws FileNotFoundException {
     if (outputFormat == null) {
       outputFormat = Lang.TTL;
     }
@@ -677,8 +685,8 @@ public class QueryOperation {
    */
   @Deprecated
   public static boolean runVerify(
-      DatasetGraph dsg, String ruleName, String query, Path outputPath, Lang outputFormat)
-      throws IOException {
+    DatasetGraph dsg, String ruleName, String query, Path outputPath, Lang outputFormat)
+    throws IOException {
     return runVerify(DatasetFactory.wrap(dsg), ruleName, query, outputPath, outputFormat);
   }
 
@@ -695,8 +703,8 @@ public class QueryOperation {
    * @return true if the are results (so file is written), false otherwise
    */
   public static boolean runVerify(
-      Dataset dataset, String ruleName, String query, Path outputPath, Lang outputFormat)
-      throws IOException {
+    Dataset dataset, String ruleName, String query, Path outputPath, Lang outputFormat)
+    throws IOException {
     if (outputFormat == null) {
       outputFormat = Lang.CSV;
     }

--- a/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/QueryOperation.java
@@ -122,6 +122,22 @@ public class QueryOperation {
   }
 
   /**
+   * Given a path to an RDF/XML or TTL file and a RDF language, load the file as the default model
+   * of a TDB dataset backed by a directory to improve processing time. Return the new dataset.
+   *
+   * <p>WARNING - this creates a directory at given tdbDir location!
+   *
+   * @deprecated moved to {@link org.obolibrary.robot.IOHelper#loadToTDBDataset(String, String)}
+   * @param inputPath input path of RDF/XML or TTL file
+   * @param tdbDir location to put TDB mappings
+   * @return Dataset instantiated with triples
+   */
+  @Deprecated
+  public static Dataset loadTriplesAsDataset(String inputPath, String tdbDir) {
+    return IOHelper.loadToTDBDataset(inputPath, tdbDir);
+  }
+
+  /**
    * Given a Model, return the OWLOntology representation of the axioms.
    *
    * @deprecated Use {@link #convertModel(Model, IOHelper, String)}

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -27,6 +27,7 @@ import org.apache.jena.shared.JenaException;
 import org.apache.jena.tdb.TDBFactory;
 import org.obolibrary.robot.checks.Report;
 import org.obolibrary.robot.checks.Violation;
+import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,7 +91,7 @@ public class ReportOperation {
     options.put("print", "0");
     options.put("fail-on", "error");
     options.put("labels", "false");
-    options.put("format", "tsv");
+    options.put("format", null);
     options.put("profile", null);
     options.put("tdb", "false");
     options.put("tdb-directory", ".tdb");
@@ -379,9 +380,21 @@ public class ReportOperation {
     options.put("tdb", "true");
 
     String profilePath = OptionsHelper.getOption(options, "profile", null);
+
     boolean useLabels = OptionsHelper.optionIsTrue(options, "labels");
+    Map<IRI, String> labelMap = null;
     if (useLabels) {
-      logger.warn("Cannot use labels with TDB - ignoring labels option.");
+      labelMap = new HashMap<>();
+      // Run query over dataset to retrive all labels
+      String query =
+          "SELECT ?s ?label WHERE { ?s <http://www.w3.org/2000/01/rdf-schema#label> ?label }";
+      ResultSet labelResults = QueryOperation.execQuery(dataset, query);
+      while (labelResults.hasNext()) {
+        QuerySolution qs = labelResults.next();
+        IRI iri = IRI.create(qs.getResource("s").getURI());
+        String label = qs.getLiteral("label").getString();
+        labelMap.put(iri, label);
+      }
     }
 
     // The profile is a map of rule name and reporting level
@@ -389,8 +402,8 @@ public class ReportOperation {
     // The queries is a map of rule name and query string
     Map<String, String> queries = getQueryStrings(profile.keySet());
 
-    // Create the report object
-    Report report = new Report();
+    // Create the report object (maybe using labels)
+    Report report = new Report(labelMap);
 
     for (String queryName : queries.keySet()) {
       String fullQueryString = queries.get(queryName);
@@ -471,6 +484,7 @@ public class ReportOperation {
     } else {
       result = report.toTSV();
     }
+
     if (outputPath != null) {
       // If output is provided, write to that file
       try (FileWriter fw = new FileWriter(outputPath);

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -8,7 +8,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.math.BigDecimal;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -53,23 +52,23 @@ public class ReportOperation {
 
   /** Error message when 'limit' is not a number. */
   private static final String limitNumberError =
-    NS + "LIMIT NUMBER ERROR --limit argument '%s' must be an integer.";
+      NS + "LIMIT NUMBER ERROR --limit argument '%s' must be an integer.";
 
   /** Error message when the query does not have ?entity. */
   private static final String missingEntityBinding =
-    NS + "MISSING ENTITY BINDING query '%s' must include an '?entity'";
+      NS + "MISSING ENTITY BINDING query '%s' must include an '?entity'";
 
   /** Error message when a user-provided report query does not exist. */
   private static final String missingQueryError =
-    NS + "MISSING QUERY ERROR query at '%s' does not exist.";
+      NS + "MISSING QUERY ERROR query at '%s' does not exist.";
 
   /** Error message when 'print' is not a number. */
   private static final String printNumberError =
-    NS + "PRINT NUMBER ERROR --print argument '%s' must be an integer.";
+      NS + "PRINT NUMBER ERROR --print argument '%s' must be an integer.";
 
   /** Error message when user provides a rule level other than INFO, WARN, or ERROR. */
   private static final String reportLevelError =
-    NS + "REPORT LEVEL ERROR '%s' is not a valid reporting level.";
+      NS + "REPORT LEVEL ERROR '%s' is not a valid reporting level.";
 
   /** Reporting level INFO. */
   private static final String INFO = "INFO";
@@ -126,8 +125,8 @@ public class ReportOperation {
    * @throws Exception on any error
    */
   public static boolean report(
-    OWLOntology ontology, String profilePath, String outputPath, String format, String failOn)
-    throws Exception {
+      OWLOntology ontology, String profilePath, String outputPath, String format, String failOn)
+      throws Exception {
     return report(ontology, null, profilePath, outputPath, format, failOn, false);
   }
 
@@ -148,13 +147,13 @@ public class ReportOperation {
    * @throws Exception on any error
    */
   public static boolean report(
-    OWLOntology ontology,
-    IOHelper ioHelper,
-    String profilePath,
-    String outputPath,
-    String format,
-    String failOn)
-    throws Exception {
+      OWLOntology ontology,
+      IOHelper ioHelper,
+      String profilePath,
+      String outputPath,
+      String format,
+      String failOn)
+      throws Exception {
     return report(ontology, ioHelper, profilePath, outputPath, format, failOn, false);
   }
 
@@ -169,7 +168,7 @@ public class ReportOperation {
    * @throws Exception on any reporting error
    */
   public static void report(OWLOntology ontology, IOHelper ioHelper, Map<String, String> options)
-    throws Exception {
+      throws Exception {
     report(ontology, ioHelper, null, options);
   }
 
@@ -192,14 +191,14 @@ public class ReportOperation {
    * @throws Exception on any error
    */
   public static boolean report(
-    OWLOntology ontology,
-    IOHelper ioHelper,
-    String profilePath,
-    String outputPath,
-    String format,
-    String failOn,
-    boolean useLabels)
-    throws Exception {
+      OWLOntology ontology,
+      IOHelper ioHelper,
+      String profilePath,
+      String outputPath,
+      String format,
+      String failOn,
+      boolean useLabels)
+      throws Exception {
     Map<String, String> options = getDefaultOptions();
     if (profilePath != null) {
       options.put("profile", profilePath);
@@ -231,8 +230,8 @@ public class ReportOperation {
    * @throws Exception on any reporting error
    */
   public static boolean report(
-    OWLOntology ontology, IOHelper ioHelper, String outputPath, Map<String, String> options)
-    throws Exception {
+      OWLOntology ontology, IOHelper ioHelper, String outputPath, Map<String, String> options)
+      throws Exception {
     // Generate the report object with violation details
     Report report = getReport(ontology, ioHelper, options);
     return processReport(report, outputPath, options);
@@ -249,7 +248,7 @@ public class ReportOperation {
    * @throws Exception on any reporting error
    */
   public static Report getReport(
-    OWLOntology ontology, IOHelper ioHelper, Map<String, String> options) throws Exception {
+      OWLOntology ontology, IOHelper ioHelper, Map<String, String> options) throws Exception {
     // Get options specified in map or default options
     if (options == null) {
       options = getDefaultOptions();
@@ -308,7 +307,7 @@ public class ReportOperation {
    * @throws Exception on any reporting error
    */
   public static boolean tdbReport(String inputPath, String outputPath, Map<String, String> options)
-    throws Exception {
+      throws Exception {
     Report report = getTDBReport(inputPath, options);
     return processReport(report, outputPath, options);
   }
@@ -324,7 +323,7 @@ public class ReportOperation {
    * @throws Exception on any query or reporting error
    */
   public static Report getTDBReport(String inputPath, Map<String, String> options)
-    throws Exception {
+      throws Exception {
     String tdbDir = OptionsHelper.getOption(options, "tdb-directory", ".tdb");
     Dataset dataset = QueryOperation.loadTriplesAsDataset(inputPath, tdbDir);
 
@@ -414,7 +413,7 @@ public class ReportOperation {
    * @throws IOException on issue writing to file
    */
   public static boolean processReport(Report report, String outputPath, Map<String, String> options)
-    throws IOException {
+      throws IOException {
     // Print violations to terminal
     Integer violationCount = report.getTotalViolations();
     if (violationCount != 0) {
@@ -462,7 +461,7 @@ public class ReportOperation {
     if (outputPath != null) {
       // If output is provided, write to that file
       try (FileWriter fw = new FileWriter(outputPath);
-           BufferedWriter bw = new BufferedWriter(fw)) {
+          BufferedWriter bw = new BufferedWriter(fw)) {
         logger.debug("Writing report to: " + outputPath);
         bw.write(result);
       }
@@ -531,7 +530,7 @@ public class ReportOperation {
    * @throws URISyntaxException on issue converting URL to URI
    */
   private static Map<String, String> getQueryStrings(Set<String> rules)
-    throws IOException, URISyntaxException {
+      throws IOException, URISyntaxException {
     Set<String> defaultRules = new HashSet<>();
     Set<String> userRules = new HashSet<>();
     Map<String, String> queries = new HashMap<>();
@@ -557,7 +556,7 @@ public class ReportOperation {
    * @throws IOException on any issue reading the file
    */
   private static Map<String, String> getUserQueryStrings(Set<String> rules)
-    throws URISyntaxException, IOException {
+      throws URISyntaxException, IOException {
     Map<String, String> queries = new HashMap<>();
     for (String rule : rules) {
       if (rule.startsWith("file:///")) {
@@ -590,7 +589,7 @@ public class ReportOperation {
    * @throws IOException on any issue with accessing files or file contents
    */
   private static Map<String, String> getDefaultQueryStrings(Set<String> rules)
-    throws IOException, URISyntaxException {
+      throws IOException, URISyntaxException {
     URL dirURL = ReportOperation.class.getClassLoader().getResource(queryDir);
     Map<String, String> queries = new HashMap<>();
     // Handle simple file path, probably accessed during testing
@@ -598,7 +597,7 @@ public class ReportOperation {
       String[] queryFilePaths = new File(dirURL.toURI()).list();
       if (queryFilePaths == null || queryFilePaths.length == 0) {
         throw new IOException(
-          "Cannot access report query files. There are no files in the directory.");
+            "Cannot access report query files. There are no files in the directory.");
       }
       for (String qPath : queryFilePaths) {
         String ruleName = qPath.substring(qPath.lastIndexOf("/")).split(".")[0];
@@ -618,7 +617,7 @@ public class ReportOperation {
     }
     if (dirURL == null) {
       throw new IOException(
-        "Cannot access report query files in JAR. The resource does not exist.");
+          "Cannot access report query files in JAR. The resource does not exist.");
     }
     String protocol = dirURL.getProtocol();
     if (protocol.equals("jar")) {
@@ -629,7 +628,7 @@ public class ReportOperation {
         entries = jar.entries();
         if (!entries.hasMoreElements()) {
           throw new IOException(
-            "Cannot access report query files in JAR. There are no entries in the JAR.");
+              "Cannot access report query files in JAR. There are no entries in the JAR.");
         }
         // Track rules that have successfully been retrieved
         while (entries.hasMoreElements()) {
@@ -638,8 +637,8 @@ public class ReportOperation {
           if (resourceName.startsWith(queryDir) && !resourceName.endsWith("/")) {
             // Get just the rule name
             String ruleName =
-              resourceName.substring(
-                resourceName.lastIndexOf("/") + 1, resourceName.indexOf(".rq"));
+                resourceName.substring(
+                    resourceName.lastIndexOf("/") + 1, resourceName.indexOf(".rq"));
             // Only add it to the queries if the rule set contains that rule
             // If rules == null, include all rules
             if (rules == null || rules.contains(ruleName)) {
@@ -723,8 +722,8 @@ public class ReportOperation {
    * @throws IOException on issue parsing query
    */
   private static List<Violation> getViolations(
-    Dataset dataset, String queryName, String query, Map<String, String> options)
-    throws Exception {
+      Dataset dataset, String queryName, String query, Map<String, String> options)
+      throws Exception {
     boolean tdb = OptionsHelper.optionIsTrue(options, "tdb");
     String limitString = OptionsHelper.getOption(options, "limit", null);
     Integer limit = null;
@@ -746,9 +745,9 @@ public class ReportOperation {
         // If query fails, return null
         // And warn that report may be incomplete
         logger.error(
-          String.format(
-            "Could not complete query '%s' - report may be incomplete.\nCause:\n%s",
-            queryName, e.getMessage()));
+            String.format(
+                "Could not complete query '%s' - report may be incomplete.\nCause:\n%s",
+                queryName, e.getMessage()));
         return null;
       } finally {
         // Always end the transaction
@@ -762,16 +761,17 @@ public class ReportOperation {
         // If query fails, return null
         // And warn that report may be incomplete
         logger.error(
-          String.format(
-            "Could not complete query '%s' - report may be incomplete.\nCause:\n%s",
-            queryName, e.getMessage()));
+            String.format(
+                "Could not complete query '%s' - report may be incomplete.\nCause:\n%s",
+                queryName, e.getMessage()));
         return null;
       }
     }
   }
 
   /**
-   * Given a query name, a result set, and a limit for results, return a list of Violation objects for those results.
+   * Given a query name, a result set, and a limit for results, return a list of Violation objects
+   * for those results.
    *
    * @param queryName name of query that produced result set
    * @param violationSet ResultSet of query results
@@ -780,7 +780,7 @@ public class ReportOperation {
    * @throws Exception on malformed query
    */
   private static List<Violation> getViolationsFromResults(
-    String queryName, ResultSet violationSet, Integer limit) throws Exception {
+      String queryName, ResultSet violationSet, Integer limit) throws Exception {
     List<Violation> violations = new ArrayList<>();
 
     // Counter for stopping at limit
@@ -798,9 +798,9 @@ public class ReportOperation {
         qs = violationSet.next();
       } catch (Exception e) {
         logger.error(
-          String.format(
-            "Could not retrieve all results for query '%s' - report may be incomplete.\nCause:\n%s",
-            queryName, e.getMessage()));
+            String.format(
+                "Could not retrieve all results for query '%s' - report may be incomplete.\nCause:\n%s",
+                queryName, e.getMessage()));
         return violations;
       }
 

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -8,6 +8,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.math.BigDecimal;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -22,11 +23,8 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import javax.validation.constraints.NotNull;
 import org.apache.commons.io.FileUtils;
-import org.apache.jena.query.Dataset;
-import org.apache.jena.query.DatasetFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
-import org.apache.jena.sparql.core.DatasetGraph;
+import org.apache.jena.query.*;
+import org.apache.jena.tdb.TDBFactory;
 import org.obolibrary.robot.checks.Report;
 import org.obolibrary.robot.checks.Violation;
 import org.semanticweb.owlapi.model.OWLOntology;
@@ -53,21 +51,25 @@ public class ReportOperation {
   /** Error message when user profiles an invalid fail-on level. */
   private static final String failOnError = NS + "FAIL ON ERROR '%s' is not a valid fail-on level.";
 
+  /** Error message when 'limit' is not a number. */
+  private static final String limitNumberError =
+    NS + "LIMIT NUMBER ERROR --limit argument '%s' must be an integer.";
+
   /** Error message when the query does not have ?entity. */
   private static final String missingEntityBinding =
-      NS + "MISSING ENTITY BINDING query '%s' must include an '?entity'";
+    NS + "MISSING ENTITY BINDING query '%s' must include an '?entity'";
 
   /** Error message when a user-provided report query does not exist. */
   private static final String missingQueryError =
-      NS + "MISSING QUERY ERROR query at '%s' does not exist.";
+    NS + "MISSING QUERY ERROR query at '%s' does not exist.";
 
   /** Error message when 'print' is not a number. */
   private static final String printNumberError =
-      NS + "PRINT NUMBER ERROR --print argument '%s' must be an integer.";
+    NS + "PRINT NUMBER ERROR --print argument '%s' must be an integer.";
 
   /** Error message when user provides a rule level other than INFO, WARN, or ERROR. */
   private static final String reportLevelError =
-      NS + "REPORT LEVEL ERROR '%s' is not a valid reporting level.";
+    NS + "REPORT LEVEL ERROR '%s' is not a valid reporting level.";
 
   /** Reporting level INFO. */
   private static final String INFO = "INFO";
@@ -90,6 +92,9 @@ public class ReportOperation {
     options.put("labels", "false");
     options.put("format", "tsv");
     options.put("profile", null);
+    options.put("tdb", "false");
+    options.put("tdb-directory", ".tdb");
+    options.put("keep-tdb-mappings", "false");
     return options;
   }
 
@@ -121,8 +126,8 @@ public class ReportOperation {
    * @throws Exception on any error
    */
   public static boolean report(
-      OWLOntology ontology, String profilePath, String outputPath, String format, String failOn)
-      throws Exception {
+    OWLOntology ontology, String profilePath, String outputPath, String format, String failOn)
+    throws Exception {
     return report(ontology, null, profilePath, outputPath, format, failOn, false);
   }
 
@@ -143,13 +148,13 @@ public class ReportOperation {
    * @throws Exception on any error
    */
   public static boolean report(
-      OWLOntology ontology,
-      IOHelper ioHelper,
-      String profilePath,
-      String outputPath,
-      String format,
-      String failOn)
-      throws Exception {
+    OWLOntology ontology,
+    IOHelper ioHelper,
+    String profilePath,
+    String outputPath,
+    String format,
+    String failOn)
+    throws Exception {
     return report(ontology, ioHelper, profilePath, outputPath, format, failOn, false);
   }
 
@@ -164,7 +169,7 @@ public class ReportOperation {
    * @throws Exception on any reporting error
    */
   public static void report(OWLOntology ontology, IOHelper ioHelper, Map<String, String> options)
-      throws Exception {
+    throws Exception {
     report(ontology, ioHelper, null, options);
   }
 
@@ -187,14 +192,14 @@ public class ReportOperation {
    * @throws Exception on any error
    */
   public static boolean report(
-      OWLOntology ontology,
-      IOHelper ioHelper,
-      String profilePath,
-      String outputPath,
-      String format,
-      String failOn,
-      boolean useLabels)
-      throws Exception {
+    OWLOntology ontology,
+    IOHelper ioHelper,
+    String profilePath,
+    String outputPath,
+    String format,
+    String failOn,
+    boolean useLabels)
+    throws Exception {
     Map<String, String> options = getDefaultOptions();
     if (profilePath != null) {
       options.put("profile", profilePath);
@@ -226,43 +231,32 @@ public class ReportOperation {
    * @throws Exception on any reporting error
    */
   public static boolean report(
-      OWLOntology ontology, IOHelper ioHelper, String outputPath, Map<String, String> options)
-      throws Exception {
+    OWLOntology ontology, IOHelper ioHelper, String outputPath, Map<String, String> options)
+    throws Exception {
+    // Generate the report object with violation details
+    Report report = getReport(ontology, ioHelper, options);
+    return processReport(report, outputPath, options);
+  }
+
+  /**
+   * Given an ontology, an IOHelper, and a map of options, create a Report object and run the report
+   * queries specified in a profile (from options, or default). Return the completed Report object.
+   *
+   * @param ontology OWLOntology to report on
+   * @param ioHelper IOHelper to resolve labels
+   * @param options Map of report options
+   * @return Report object with violation details
+   * @throws Exception on any reporting error
+   */
+  public static Report getReport(
+    OWLOntology ontology, IOHelper ioHelper, Map<String, String> options) throws Exception {
     // Get options specified in map or default options
     if (options == null) {
       options = getDefaultOptions();
     }
-    String failOn = OptionsHelper.getOption(options, "fail-on", "error");
-    String profilePath = OptionsHelper.getOption(options, "profile", "0");
-    String printString = OptionsHelper.getOption(options, "print").trim();
+
+    String profilePath = OptionsHelper.getOption(options, "profile", null);
     boolean useLabels = OptionsHelper.optionIsTrue(options, "labels");
-
-    // Format is determined either by --format or the extension of the output path
-    String format = OptionsHelper.getOption(options, "format");
-    if (format == null && outputPath != null) {
-      format = outputPath.substring(outputPath.lastIndexOf(".") + 1);
-      if (!format.equalsIgnoreCase("csv") && !format.equalsIgnoreCase("yaml")) {
-        // Anything other than .yaml or .csv is written as TSV
-        format = "tsv";
-      }
-    } else if (format == null) {
-      // Null format means no output file, will be printed as TSV
-      format = "tsv";
-    }
-
-    // Parse print N lines option to an int
-    int print;
-    try {
-      print = Integer.parseInt(printString);
-    } catch (NumberFormatException e) {
-      // Not a number
-      throw new IllegalArgumentException(String.format(printNumberError, printString));
-    }
-
-    // Set failOn if null to default
-    if (failOn == null) {
-      failOn = ERROR;
-    }
 
     // The profile is a map of rule name and reporting level
     Map<String, String> profile = getProfile(profilePath);
@@ -277,7 +271,6 @@ public class ReportOperation {
       report = new Report(ontology, useLabels);
     }
 
-    // Load into dataset without imports
     Dataset dataset = QueryOperation.loadOntologyAsDataset(ontology, false);
     for (String queryName : queries.keySet()) {
       String fullQueryString = queries.get(queryName);
@@ -291,14 +284,138 @@ public class ReportOperation {
       }
       queryString = String.join("\n", lines);
       // Use the query to get violations
-      List<Violation> violations = getViolations(dataset, queryString);
+      List<Violation> violations = getViolations(dataset, queryName, queryString, options);
       // If violations is not returned properly, the query did not have the correct format
       if (violations == null) {
         throw new Exception(String.format(missingEntityBinding, queryName));
       }
-      report.addViolations(queryName, profile.get(queryName), getViolations(dataset, queryString));
+      report.addViolations(queryName, profile.get(queryName), violations);
     }
 
+    return report;
+  }
+
+  /**
+   * Given an input path, an output path (or null), and a map of options, report on the ontology
+   * using the rules within the profile specified by the options and write results to the output
+   * path. Ontology is loaded to dataset backed on disk. The labels option is not supported with
+   * TDB.
+   *
+   * @param inputPath String path of ontology to load
+   * @param outputPath String path to write report file to, or null
+   * @param options map of report options
+   * @return false if there are violations at or above the fail-on level, true otherwise
+   * @throws Exception on any reporting error
+   */
+  public static boolean tdbReport(String inputPath, String outputPath, Map<String, String> options)
+    throws Exception {
+    Report report = getTDBReport(inputPath, options);
+    return processReport(report, outputPath, options);
+  }
+
+  /**
+   * Given an input path to an ontology and a map of options, create a Report object and run (on TDB
+   * dataset) the report queries specified in a profile (from options, or default). Return the
+   * completed Report object. The labels option is not supported with TDB.
+   *
+   * @param inputPath path to load triples to TDB
+   * @param options map of report options
+   * @return Report object with violation details
+   * @throws Exception on any query or reporting error
+   */
+  public static Report getTDBReport(String inputPath, Map<String, String> options)
+    throws Exception {
+    String tdbDir = OptionsHelper.getOption(options, "tdb-directory", ".tdb");
+    Dataset dataset = QueryOperation.loadTriplesAsDataset(inputPath, tdbDir);
+
+    Report report;
+    boolean keepMappings = OptionsHelper.optionIsTrue(options, "keep-tdb-mappings");
+    try {
+      report = getTDBReport(dataset, options);
+    } finally {
+      // Close and release
+      dataset.close();
+      TDBFactory.release(dataset);
+      if (!keepMappings) {
+        // Maybe delete
+        boolean success = IOHelper.cleanTDB(tdbDir);
+        if (!success) {
+          logger.error(String.format("Unable to remove directory '%s'", tdbDir));
+        }
+      }
+    }
+
+    return report;
+  }
+
+  /**
+   * Given a dataset and a map of options, create a Report object and run (on TDB dataset) the
+   * report queries specified in a profile (from options, or default). Return the completed Report
+   * object. The labels option is not supported with TDB.
+   *
+   * @param dataset TDB Dataset to perform Report operation on
+   * @param options Map of report options
+   * @return Report object with violation details
+   * @throws Exception on any reporting error
+   */
+  public static Report getTDBReport(Dataset dataset, Map<String, String> options) throws Exception {
+    // Get options specified in map or default options
+    if (options == null) {
+      options = getDefaultOptions();
+    }
+    // Make sure TDB is true here
+    options.put("tdb", "true");
+
+    String profilePath = OptionsHelper.getOption(options, "profile", null);
+    boolean useLabels = OptionsHelper.optionIsTrue(options, "labels");
+    if (useLabels) {
+      logger.warn("Cannot use labels with TDB - ignoring labels option.");
+    }
+
+    // The profile is a map of rule name and reporting level
+    Map<String, String> profile = getProfile(profilePath);
+    // The queries is a map of rule name and query string
+    Map<String, String> queries = getQueryStrings(profile.keySet());
+
+    // Create the report object
+    Report report = new Report();
+
+    for (String queryName : queries.keySet()) {
+      String fullQueryString = queries.get(queryName);
+      String queryString;
+      // Remove any comments
+      List<String> lines = new ArrayList<>();
+      for (String line : fullQueryString.split("\n")) {
+        if (!line.startsWith("#")) {
+          lines.add(line);
+        }
+      }
+      queryString = String.join("\n", lines);
+      // Use the query to get violations
+      List<Violation> violations = getViolations(dataset, queryName, queryString, options);
+      // If violations is not returned properly, the query did not have the correct format
+      if (violations == null) {
+        throw new Exception(String.format(missingEntityBinding, queryName));
+      }
+      report.addViolations(queryName, profile.get(queryName), violations);
+    }
+
+    return report;
+  }
+
+  /**
+   * Given a Report, an output path, and a map of report options, process the Report results and
+   * save the report to the output path.
+   *
+   * @param report completed Report object
+   * @param outputPath path to save report to
+   * @param options Map of report options
+   * @return true if report passed, false if it failed
+   * @throws IOException on issue writing to file
+   */
+  public static boolean processReport(Report report, String outputPath, Map<String, String> options)
+    throws IOException {
+    // Print violations to terminal
     Integer violationCount = report.getTotalViolations();
     if (violationCount != 0) {
       System.out.println("Violations: " + violationCount);
@@ -308,6 +425,30 @@ public class ReportOperation {
       System.out.println(INFO + ":       " + report.getTotalViolations(INFO));
     } else {
       System.out.println("No violations found.");
+    }
+
+    // Maybe print some of the lines
+    String printString = OptionsHelper.getOption(options, "print", "0").trim();
+    // Parse print N lines option to an int
+    int print;
+    try {
+      print = Integer.parseInt(printString);
+    } catch (NumberFormatException e) {
+      // Not a number
+      throw new IllegalArgumentException(String.format(printNumberError, printString));
+    }
+
+    // Format is determined either by --format or the extension of the output path
+    String format = OptionsHelper.getOption(options, "format");
+    if (format == null && outputPath != null) {
+      format = outputPath.substring(outputPath.lastIndexOf(".") + 1);
+      if (!format.equalsIgnoreCase("csv") && !format.equalsIgnoreCase("yaml")) {
+        // Anything other than .yaml or .csv is written as TSV
+        format = "tsv";
+      }
+    } else if (format == null) {
+      // Null format means no output file, will be printed as TSV
+      format = "tsv";
     }
 
     String result;
@@ -321,7 +462,7 @@ public class ReportOperation {
     if (outputPath != null) {
       // If output is provided, write to that file
       try (FileWriter fw = new FileWriter(outputPath);
-          BufferedWriter bw = new BufferedWriter(fw)) {
+           BufferedWriter bw = new BufferedWriter(fw)) {
         logger.debug("Writing report to: " + outputPath);
         bw.write(result);
       }
@@ -338,6 +479,12 @@ public class ReportOperation {
       } else {
         System.out.println(result);
       }
+    }
+
+    String failOn = OptionsHelper.getOption(options, "fail-on", "error");
+    // Set failOn if null to default
+    if (failOn == null) {
+      failOn = ERROR;
     }
 
     // If a fail-on is provided, return false if there are violations of the given level
@@ -384,7 +531,7 @@ public class ReportOperation {
    * @throws URISyntaxException on issue converting URL to URI
    */
   private static Map<String, String> getQueryStrings(Set<String> rules)
-      throws IOException, URISyntaxException {
+    throws IOException, URISyntaxException {
     Set<String> defaultRules = new HashSet<>();
     Set<String> userRules = new HashSet<>();
     Map<String, String> queries = new HashMap<>();
@@ -410,7 +557,7 @@ public class ReportOperation {
    * @throws IOException on any issue reading the file
    */
   private static Map<String, String> getUserQueryStrings(Set<String> rules)
-      throws URISyntaxException, IOException {
+    throws URISyntaxException, IOException {
     Map<String, String> queries = new HashMap<>();
     for (String rule : rules) {
       if (rule.startsWith("file:///")) {
@@ -443,7 +590,7 @@ public class ReportOperation {
    * @throws IOException on any issue with accessing files or file contents
    */
   private static Map<String, String> getDefaultQueryStrings(Set<String> rules)
-      throws IOException, URISyntaxException {
+    throws IOException, URISyntaxException {
     URL dirURL = ReportOperation.class.getClassLoader().getResource(queryDir);
     Map<String, String> queries = new HashMap<>();
     // Handle simple file path, probably accessed during testing
@@ -451,7 +598,7 @@ public class ReportOperation {
       String[] queryFilePaths = new File(dirURL.toURI()).list();
       if (queryFilePaths == null || queryFilePaths.length == 0) {
         throw new IOException(
-            "Cannot access report query files. There are no files in the directory.");
+          "Cannot access report query files. There are no files in the directory.");
       }
       for (String qPath : queryFilePaths) {
         String ruleName = qPath.substring(qPath.lastIndexOf("/")).split(".")[0];
@@ -471,7 +618,7 @@ public class ReportOperation {
     }
     if (dirURL == null) {
       throw new IOException(
-          "Cannot access report query files in JAR. The resource does not exist.");
+        "Cannot access report query files in JAR. The resource does not exist.");
     }
     String protocol = dirURL.getProtocol();
     if (protocol.equals("jar")) {
@@ -482,7 +629,7 @@ public class ReportOperation {
         entries = jar.entries();
         if (!entries.hasMoreElements()) {
           throw new IOException(
-              "Cannot access report query files in JAR. There are no entries in the JAR.");
+            "Cannot access report query files in JAR. There are no entries in the JAR.");
         }
         // Track rules that have successfully been retrieved
         while (entries.hasMoreElements()) {
@@ -491,8 +638,8 @@ public class ReportOperation {
           if (resourceName.startsWith(queryDir) && !resourceName.endsWith("/")) {
             // Get just the rule name
             String ruleName =
-                resourceName.substring(
-                    resourceName.lastIndexOf("/") + 1, resourceName.indexOf(".rq"));
+              resourceName.substring(
+                resourceName.lastIndexOf("/") + 1, resourceName.indexOf(".rq"));
             // Only add it to the queries if the rule set contains that rule
             // If rules == null, include all rules
             if (rules == null || rules.contains(ruleName)) {
@@ -568,20 +715,6 @@ public class ReportOperation {
   }
 
   /**
-   * Given an ontology as a DatasetGraph and a query, return the violations found by that query.
-   *
-   * @deprecated use {@link #getViolations(Dataset, String)} instead.
-   * @param dsg the ontology as a graph
-   * @param query the query
-   * @return List of Violations
-   * @throws IOException on issue parsing query
-   */
-  @Deprecated
-  private static List<Violation> getViolations(DatasetGraph dsg, String query) throws IOException {
-    return getViolations(DatasetFactory.wrap(dsg), query);
-  }
-
-  /**
    * Given an ontology as a Dataset and a query, return the violations found by that query.
    *
    * @param dataset the ontology/ontologies as a dataset
@@ -589,22 +722,99 @@ public class ReportOperation {
    * @return List of Violations
    * @throws IOException on issue parsing query
    */
-  private static List<Violation> getViolations(Dataset dataset, String query) throws IOException {
-    ResultSet violationSet = QueryOperation.execQuery(dataset, query);
+  private static List<Violation> getViolations(
+    Dataset dataset, String queryName, String query, Map<String, String> options)
+    throws Exception {
+    boolean tdb = OptionsHelper.optionIsTrue(options, "tdb");
+    String limitString = OptionsHelper.getOption(options, "limit", null);
+    Integer limit = null;
+    if (limitString != null) {
+      try {
+        limit = Integer.parseInt(limitString);
+      } catch (NumberFormatException e) {
+        throw new Exception(String.format(limitNumberError, limitString));
+      }
+    }
 
-    List<Violation> violations = new ArrayList<>();
-
-    while (violationSet.hasNext()) {
-      QuerySolution qs = violationSet.next();
-      // entity should never be null
-      String entity = getQueryResultOrNull(qs, "entity");
-      if (entity == null) {
+    if (tdb) {
+      // If using TDB we must be in a read transaction to query
+      dataset.begin(ReadWrite.READ);
+      try {
+        ResultSet violationSet = QueryOperation.execQuery(dataset, query);
+        return getViolationsFromResults(queryName, violationSet, limit);
+      } catch (Exception e) {
+        // If query fails, return null
+        // And warn that report may be incomplete
+        logger.error(
+          String.format(
+            "Could not complete query '%s' - report may be incomplete.\nCause:\n%s",
+            queryName, e.getMessage()));
+        return null;
+      } finally {
+        // Always end the transaction
+        dataset.end();
+      }
+    } else {
+      try {
+        ResultSet violationSet = QueryOperation.execQuery(dataset, query);
+        return getViolationsFromResults(queryName, violationSet, limit);
+      } catch (Exception e) {
+        // If query fails, return null
+        // And warn that report may be incomplete
+        logger.error(
+          String.format(
+            "Could not complete query '%s' - report may be incomplete.\nCause:\n%s",
+            queryName, e.getMessage()));
         return null;
       }
+    }
+  }
+
+  /**
+   * Given a query name, a result set, and a limit for results, return a list of Violation objects for those results.
+   *
+   * @param queryName name of query that produced result set
+   * @param violationSet ResultSet of query results
+   * @param limit number of results to limit, or null for no limit
+   * @return list of Violation objects
+   * @throws Exception on malformed query
+   */
+  private static List<Violation> getViolationsFromResults(
+    String queryName, ResultSet violationSet, Integer limit) throws Exception {
+    List<Violation> violations = new ArrayList<>();
+
+    // Counter for stopping at limit
+    int c = 0;
+    while (violationSet.hasNext()) {
+      if (limit != null && limit <= c) {
+        // Stop checking violations
+        break;
+      }
+
+      // Wrap in try catch in case GC overflows
+      // Will return results up to this point with warning that report may be incomplete
+      QuerySolution qs;
+      try {
+        qs = violationSet.next();
+      } catch (Exception e) {
+        logger.error(
+          String.format(
+            "Could not retrieve all results for query '%s' - report may be incomplete.\nCause:\n%s",
+            queryName, e.getMessage()));
+        return violations;
+      }
+
+      // entity should never be null (missing entity binding error)
+      String entity = getQueryResultOrNull(qs, "entity");
+      if (entity == null) {
+        throw new Exception(String.format(missingEntityBinding, queryName));
+      }
+
       // skip RDFS and OWL terms
       if (entity.contains("/rdf-schema#") || entity.contains("/owl#")) {
         continue;
       }
+
       Violation violation = new Violation(entity);
       // try and get a property and value from the query
       String property = getQueryResultOrNull(qs, "property");
@@ -614,6 +824,9 @@ public class ReportOperation {
         violation.addStatement(property, value);
       }
       violations.add(violation);
+
+      // Increase counter
+      c++;
     }
     return violations;
   }

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -23,7 +23,6 @@ import java.util.jar.JarFile;
 import javax.validation.constraints.NotNull;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.query.*;
-import org.apache.jena.shared.JenaException;
 import org.apache.jena.tdb.TDBFactory;
 import org.obolibrary.robot.checks.Report;
 import org.obolibrary.robot.checks.Violation;
@@ -310,17 +309,7 @@ public class ReportOperation {
    */
   public static boolean tdbReport(String inputPath, String outputPath, Map<String, String> options)
       throws Exception {
-    // Validate that the input can be loaded to TDB
-    if (!inputPath.endsWith(".rdf") && !inputPath.endsWith(".owl") && !inputPath.endsWith(".ttl")) {
-      throw new IllegalArgumentException(IOHelper.tdbFormatError);
-    }
-
-    Report report;
-    try {
-      report = getTDBReport(inputPath, options);
-    } catch (JenaException e) {
-      throw new IOException(String.format(IOHelper.syntaxError, inputPath, e.getMessage()));
-    }
+    Report report = getTDBReport(inputPath, options);
     return processReport(report, outputPath, options);
   }
 
@@ -338,7 +327,8 @@ public class ReportOperation {
       throws Exception {
     String tdbDir = OptionsHelper.getOption(options, "tdb-directory", ".tdb");
 
-    // May throw JenaException if syntax is bad
+    // Load dataset
+    // Fail if the input path is not in RDF/XML or TTL
     Dataset dataset = IOHelper.loadToTDBDataset(inputPath, tdbDir);
 
     Report report;

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
@@ -11,9 +11,7 @@ import java.util.Set;
 import org.obolibrary.robot.IOHelper;
 import org.obolibrary.robot.QuotedEntityChecker;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.PrefixManager;
+import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.util.SimpleShortFormProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,25 +34,25 @@ public class Report {
   private static final String NEW_LINE = System.getProperty("line.separator");
 
   /** Map of rules and the violations for INFO level. */
-  public Map<String, List<Violation>> info;
+  public Map<String, List<Violation>> info = new HashMap<>();
 
   /** Map of rules and the violations for WARN level. */
-  public Map<String, List<Violation>> warn;
+  public Map<String, List<Violation>> warn = new HashMap<>();
 
   /** Map of rules and the violations for ERROR level. */
-  public Map<String, List<Violation>> error;
+  public Map<String, List<Violation>> error = new HashMap<>();
 
   /** Boolean to use labels for output - defaults to false. */
   private boolean useLabels = false;
 
   /** Count of violations for INFO. */
-  private Integer infoCount;
+  private Integer infoCount = 0;
 
   /** Count of violations for WARN. */
-  private Integer warnCount;
+  private Integer warnCount = 0;
 
   /** Count of violations for ERROR. */
-  private Integer errorCount;
+  private Integer errorCount = 0;
 
   /** IOHelper to use. */
   private IOHelper ioHelper;
@@ -93,6 +91,29 @@ public class Report {
   }
 
   /**
+   * Create a new report object with a QuotedEntityChecker loaded with entries from the label map.
+   * Use labels for report output.
+   *
+   * @param labelMap Map of IRI to label for all entities in the ontology
+   */
+  public Report(Map<IRI, String> labelMap) throws IOException {
+    this.ioHelper = new IOHelper();
+    checker = new QuotedEntityChecker();
+    checker.setIOHelper(ioHelper);
+    checker.addProvider(new SimpleShortFormProvider());
+    checker.addProperty(OWLManager.getOWLDataFactory().getRDFSLabel());
+    if (labelMap != null) {
+      useLabels = true;
+      OWLDataFactory df = OWLManager.getOWLDataFactory();
+      for (Entry<IRI, String> entry : labelMap.entrySet()) {
+        // Set all the entities as class - will not matter for retrieving label
+        OWLEntity e = df.getOWLEntity(EntityType.CLASS, entry.getKey());
+        checker.add(e, entry.getValue());
+      }
+    }
+  }
+
+  /**
    * Create a new report object with an ontology and an IOHelper.
    *
    * @param ontology OWLOntology to get labels from
@@ -120,16 +141,7 @@ public class Report {
         checker.addAll(ontology);
       }
     }
-
     this.useLabels = useLabels;
-
-    info = new HashMap<>();
-    warn = new HashMap<>();
-    error = new HashMap<>();
-
-    infoCount = 0;
-    warnCount = 0;
-    errorCount = 0;
   }
 
   /**


### PR DESCRIPTION
## Executing on Disk

`report` may fail on some very large ontologies, due to ROBOT loading the entire ontology into memory.

`report` allows you to load the ontology to a mapping file on disk with the `--tdb true` option. This is supported by [Jena TDB Datasets](http://jena.apache.org/documentation/tdb/datasets.html):

```
robot report --input edit.owl \
  --tdb true \
  --output my-report.tsv
```

Please note that this will only work with ontologies in RDF/XML (`.owl` or `.rdf`) or TTL syntax (`.ttl`). Attempting to load an ontology in a different syntax will result in a [Syntax Error](#syntax-error). ROBOT will create a directory to store the ontology as a dataset, which defaults to `.tdb`. You can change the location of the TDB directory by using `--tdb-directory <directory>`.

Once the report is complete, ROBOT will remove the TDB directory. You can include `--keep-tdb-mappings true` to prevent ROBOT from removing the TDB directory (which may be beneficial if you want to reuse it with [query](/query#executing-on-disk)). This will greatly reduce the execution time of subsequent TDB-based operations on the ontology.

The `--labels` option cannot be used with TDB, as the ontology is never loaded as an OWL API object.

## Limiting Results

Large numbers of results from the report queries may cause an `OutOfMemoryError`. To prevent this, you can limit the number of results with `--limit <INTEGER>`:

```
robot report --input edit.owl \
  --limit 10000 \
  --output my-report.tsv
```

This example will only include the first 10,000 results for each report query, meaning that some violation counts may be incomplete. Typically, you should not need to include a limit, but when working with large ontologies (using TDB), there may be hundreds of thousands of results.
