### PR TITLE
Fix method for axiom annotations from templates

### DIFF
--- a/robot-core/src/test/resources/legacy-template.csv
+++ b/robot-core/src/test/resources/legacy-template.csv
@@ -1,5 +1,5 @@
-Label,Label Comment,Nested Comment,ID,Synonyms,Type,Parent,Parts,Parts Annotation
-A rdfs:label,>AL rdfs:comment@en,>>A rdfs:comment,ID,A IAO:0000118 SPLIT=|,CLASS_TYPE,C %,C part_of some %,>C rdfs:comment
+Label,Label Comment,Nested Comment,See Also,ID,Synonyms,Type,Parent,Parts,Parts Annotation
+A rdfs:label,>AL rdfs:comment@en,>>A rdfs:comment,>AI rdfs:seeAlso,ID,A IAO:0000118 SPLIT=|,CLASS_TYPE,C %,C part_of some %,>C rdfs:comment
 skip this row
-test 3,test 3 comment,test 3 comment comment,GO:1234,synonym 1|synonym 2,subclass,test2,test one,test one comment
-test 4,test 4 comment,,GO:1235,,equivalent,test one,(test2 and 'test 3'),test2 and test 3 comment
+test 3,test 3 comment,test 3 comment comment,http://robot.obolibrary.org/,GO:1234,synonym 1|synonym 2,subclass,test2,test one,test one comment
+test 4,test 4 comment,,,GO:1235,,equivalent,test one,(test2 and 'test 3'),test2 and test 3 comment

--- a/robot-core/src/test/resources/template.csv
+++ b/robot-core/src/test/resources/template.csv
@@ -1,5 +1,5 @@
-Label,Label Comment,Nested Comment,ID,Synonyms,Parent,Parts,Parts Annotation,Equivalent,Eq Annotation
-A rdfs:label,>AL rdfs:comment@en,>>A rdfs:comment,ID,A IAO:0000118 SPLIT=|,SC %,SC part_of some %,>A rdfs:comment,EC %,>A rdfs:comment
+Label,Label Comment,Nested Comment,See Also,ID,Synonyms,Parent,Parts,Parts Annotation,Equivalent,Eq Annotation
+A rdfs:label,>AL rdfs:comment@en,>>A rdfs:comment,>AI rdfs:seeAlso,ID,A IAO:0000118 SPLIT=|,SC %,SC part_of some %,>A rdfs:comment,EC %,>A rdfs:comment
 skip this row
-test 3,test 3 comment,test 3 comment comment,GO:1234,synonym 1|synonym 2,test2,test one,test one comment,,
-test 4,test 4 comment,,GO:1235,,,,,'test one' and (part_of some (test2 and 'test 3')),test2 and test 3 comment
+test 3,test 3 comment,test 3 comment comment,http://robot.obolibrary.org/,GO:1234,synonym 1|synonym 2,test2,test one,test one comment,,
+test 4,test 4 comment,,,GO:1235,,,,,'test one' and (part_of some (test2 and 'test 3')),test2 and test 3 comment

--- a/robot-core/src/test/resources/template.owl
+++ b/robot-core/src/test/resources/template.owl
@@ -8,10 +8,10 @@
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
     <Ontology rdf:about="http://test.com/template.owl"/>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Classes
@@ -19,7 +19,7 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/GO_1234 -->
@@ -54,13 +54,14 @@
                 <annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
                 <annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test 3</annotatedTarget>
                 <rdfs:comment xml:lang="en">test 3 comment</rdfs:comment>
+                <rdfs:seeAlso rdf:resource="http://robot.obolibrary.org/"/>
             </Axiom>
         </annotatedSource>
         <annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#comment"/>
         <annotatedTarget xml:lang="en">test 3 comment</annotatedTarget>
         <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test 3 comment comment</rdfs:comment>
     </Annotation>
-    
+
 
 
     <!-- http://purl.obolibrary.org/obo/GO_1235 -->


### PR DESCRIPTION
If you have two axiom annotations next to each other:

| A prop:0 | >A prop:1 | >A prop:2 |
| --- | --- | --- |
| val 0 | val 1 | val 2 |

"val 2" will become a nested axiom annotation on the "val 1" axiom annotation, which is an annotation on "val 0". Instead, these should both be axiom annotations on the "val 0" annotation.

This is only an issue when you use two different `>` columns on one axiom.

The original template test still passes fine, but I can update the template to test different `>` columns if you'd like.