### PR TITLE
Add language tags to annotation selectors

### DIFF
--- a/docs/remove.md
+++ b/docs/remove.md
@@ -95,6 +95,7 @@ Terms can also be selected from the set based on their annotations. This can be 
 - `CURIE=<IRI>`, e.g. `rdfs:seeAlso=<http://purl.obolibrary.org/obo/EX_123>`
 - `CURIE='literal'`, e.g. `rdfs:label='example label'`
 - `CURIE='literal'^^datatype`, e.g. `rdfs:label='example label'^^xsd:string`
+- `CURIE='literal'@language`, e.g. `rdfs:label='example label'@en`
 - `CURIE=~'regex pattern'`, e.g. `rdfs:label=~'example.*'`
 
 It is also possible to select terms based on parts of their IRI. You may include an IRI pattern using one or more wildcard characters (`*` and/or `?`) enclosed in angle brackets. This MUST be enclosed in quotes to work on the command line.


### PR DESCRIPTION
See #571 - allows selecting annotations with language tags:
`CURIE='literal'@language`, e.g. `rdfs:label='example label'@en`