### PR TITLE
Add row length error message

### DIFF
--- a/docs/template.md
+++ b/docs/template.md
@@ -323,6 +323,10 @@ An IRI cannot be created from the provided ID. This is most likely because the I
 
 The valid `PROPERTY_TYPE` values are: `subproperty`, `equivalent`, `disjoint`, and (for object properties only) `inverse`.
 
+### Row Length Error
+
+A row in the template has more columns than the header row. Check the row given in the error message and make sure all columns are in the correct location.
+
 ### Template File Error
 
 The template cannot be found in the current directory. Make sure the file exists and your path is correct.

--- a/docs/template.md
+++ b/docs/template.md
@@ -254,7 +254,7 @@ A class row may only use one of: `subclass`, `equivalent`, and `disjoint`. To ad
 
 ### Column Mismatch Error
 
-There number of header columns (first row) must be equal to the number of template string columns (second row).
+Each column that has a template string in row two must have a header string in row one. It is OK to have a header string with no template string.
 
 ### Data Property Characteristic Error
 
@@ -322,10 +322,6 @@ An IRI cannot be created from the provided ID. This is most likely because the I
 ### Property Type Error
 
 The valid `PROPERTY_TYPE` values are: `subproperty`, `equivalent`, `disjoint`, and (for object properties only) `inverse`.
-
-### Row Length Error
-
-A row in the template has more columns than the header row. Check the row given in the error message and make sure all columns are in the correct location.
 
 ### Template File Error
 

--- a/robot-core/src/main/java/org/obolibrary/robot/Template.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/Template.java
@@ -99,12 +99,10 @@ public class Template {
           + "CLASS TYPE SPLIT ERROR the SPLIT functionality should not be used for CLASS_TYPE in column %d in table \"%s\".";
 
   /**
-   * Error message when the number of header columns does not match the number of template columns.
-   * Expects: table name, header count, template count.
+   * Error message when a template column does not have a header.
+   * Expects: column number, table name
    */
-  private static final String columnMismatchError =
-      NS
-          + "COLUMN MISMATCH ERROR the number of header columns (%2$d) must match the number of template columns (%3$d) in table \"%1$s\".";
+  private static final String columnMismatchError = NS + "COLUMN MISMATCH ERROR the template string in column %d must have a corresponding header in table \"%s\"";
 
   /** Error message when a data property has a characteristic other than 'functional'. */
   private static final String dataPropertyCharacteristicError =
@@ -130,11 +128,6 @@ public class Template {
   private static final String propertyTypeSplitError =
       NS
           + "PROPERTY TYPE SPLIT ERROR the SPLIT functionality should not be used for PROPERTY_TYPE in column %d in table \"%s\".";
-
-  /** Error message when a row has more columns than the header columns. */
-  private static final String rowLengthError =
-      NS
-          + "ROW LENGTH ERROR row %d in table '%s' has %d columns, which is more than the expected %d.";
 
   /** Error message when property characteristic not valid. */
   private static final String unknownCharacteristicError =
@@ -403,21 +396,28 @@ public class Template {
     // Get and validate headers
     headers = rows.get(0);
     templates = rows.get(1);
-    if (headers.size() != templates.size()) {
-      throw new ColumnException(
-          String.format(columnMismatchError, name, headers.size(), templates.size()));
-    }
 
     for (int column = 0; column < templates.size(); column++) {
-      String template = templates.get(column);
-
-      // If the template is null or the column is empty, skip this column
-      if (template == null) {
+      String template = templates.get(column).trim();
+      if (template.isEmpty()) {
+        // If the template is empty, skip this column
         continue;
       }
-      template = template.trim();
-      if (template.isEmpty()) {
-        continue;
+
+      // Validate that there's a header in this column
+      // It's OK if there's a header without a template
+      String header;
+      try {
+        header = headers.get(column).trim();
+      } catch (IndexOutOfBoundsException e) {
+        // Template row is longer than header row
+        // Which means there is at least one header missing
+        throw new ColumnException(String.format(columnMismatchError, column + 1, name));
+      }
+      if (header.isEmpty()) {
+        // Template string is not empty
+        // Header string is empty
+        throw new ColumnException(String.format(columnMismatchError, column + 1, name));
       }
 
       // Validate the template string
@@ -621,9 +621,6 @@ public class Template {
    */
   private void processRow(List<String> row) throws Exception {
     rowNum++;
-    if (row.size() > headers.size()) {
-      throw new Exception(String.format(rowLengthError, rowNum, name, row.size(), headers.size()));
-    }
 
     String id = null;
     try {

--- a/robot-core/src/main/java/org/obolibrary/robot/Template.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/Template.java
@@ -2008,7 +2008,14 @@ public class Template {
     int lastAnnotation = -1;
     while (column < row.size() - 1) {
       column++;
-      String template = templates.get(column);
+      // Row might be longer than column
+      // That's OK, just skip it
+      String template;
+      try {
+        template = templates.get(column);
+      } catch (IndexOutOfBoundsException e) {
+        break;
+      }
       Matcher m = Pattern.compile("^>.*").matcher(template);
       if (m.matches()) {
 

--- a/robot-core/src/main/java/org/obolibrary/robot/Template.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/Template.java
@@ -99,10 +99,11 @@ public class Template {
           + "CLASS TYPE SPLIT ERROR the SPLIT functionality should not be used for CLASS_TYPE in column %d in table \"%s\".";
 
   /**
-   * Error message when a template column does not have a header.
-   * Expects: column number, table name
+   * Error message when a template column does not have a header. Expects: column number, table name
    */
-  private static final String columnMismatchError = NS + "COLUMN MISMATCH ERROR the template string in column %d must have a corresponding header in table \"%s\"";
+  private static final String columnMismatchError =
+      NS
+          + "COLUMN MISMATCH ERROR the template string in column %d must have a corresponding header in table \"%s\"";
 
   /** Error message when a data property has a characteristic other than 'functional'. */
   private static final String dataPropertyCharacteristicError =


### PR DESCRIPTION
Add an error message when a row has more columns than the header in a template.

Also remove unused `private` method. Axiom annotations were reworked in #569 but I missed removing this old method.