### PR TITLE
Add integration test on OBI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,14 +7,14 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'mvn clean package'
+                sh 'rm -rf bin/original-robot.jar'
             }
         }
 
         stage('Test') {
             steps {
                 script {
-                    if (env.BRANCH_NAME == 'obi-test') {
+                    if (env.BRANCH_NAME == 'master') {
                         try {
                             sh 'git clone https://github.com/obi-ontology/obi.git'
                             sh 'mkdir -p obi/build'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,10 @@ pipeline {
         }
         stage('Test') {
             steps {
-                sh 'rm -f bin/original-robot.jar'
+                sh 'git clone https://github.com/obi-ontology/obi.git || true'
+                sh 'mkdir -p obi/build'
+                sh 'cp bin/robot.jar obi/build/robot.jar'
+                sh 'cd obi && make test || cd .. && rm -rf obi'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,10 +9,7 @@ pipeline {
         }
         stage('Test') {
             steps {
-                sh 'git clone https://github.com/obi-ontology/obi.git || true'
-                sh 'mkdir -p obi/build'
-                sh 'cp bin/robot.jar obi/build/robot.jar'
-                sh 'cd obi && make test || cd .. && rm -rf obi'
+                sh 'rm -f bin/original-robot.jar'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,6 @@ pipeline {
         }
         stage('Test') {
             steps {
-                sh 'git clone https://github.com/obi-ontology/obi.git'
                 sh 'mkdir -p obi/build'
                 sh 'cp bin/robot.jar obi/build/robot.jar'
                 sh 'cd obi && make test'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'rm -rf bin/original-robot.jar'
+                sh 'mvn clean package'
             }
         }
 
@@ -24,7 +24,7 @@ pipeline {
                             sh 'rm -rf obi'
                         }
                     } else {
-                        sh 'java -jar bin/robot.jar help'
+                        sh 'java -jar bin/robot.jar notacommand'
                     }
                 }
             }
@@ -37,7 +37,7 @@ pipeline {
         }
         failure {
         echo "There has been a failure in the ${env.BRANCH_NAME} pipeline."
-        mail bcc: '', body: "There has been a pipeline failure in ${env.BRANCH_NAME}. Please see: https://build.obolibrary.io/job/ontodev/job/robot/${env.BRANCH_NAME}", cc: '', from: '', replyTo: '', subject: "ROBOT Integration Test FAIL", to: "${TARGET_ADMIN_EMAILS}"
+        mail bcc: '', body: "There has been a pipeline failure in ${env.BRANCH_NAME}. Please see: https://build.obolibrary.io/job/ontodev/job/robot/job/${env.BRANCH_NAME}", cc: '', from: '', replyTo: '', subject: "ROBOT Integration Test FAIL", to: "${TARGET_ADMIN_EMAILS}"
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,10 +9,10 @@ pipeline {
         }
         stage('Test') {
             steps {
+                sh 'git clone https://github.com/obi-ontology/obi.git || true'
                 sh 'mkdir -p obi/build'
                 sh 'cp bin/robot.jar obi/build/robot.jar'
-                sh 'cd obi && make test'
-                sh 'rm -rf obi'
+                sh 'cd obi && make test || cd .. && rm -rf obi'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         stage('Test') {
             steps {
                 script {
-                    if (env.BRANCH_NAME == 'master') {
+                    if (env.BRANCH_NAME == 'obi-test') {
                         try {
                             sh 'git clone https://github.com/obi-ontology/obi.git'
                             sh 'mkdir -p obi/build'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,17 @@ pipeline {
         stage('Build') {
             steps {
                 sh 'mvn clean package'
-                sh 'ls ./bin'
+            }
+        }
+        stage('Test') {
+            steps {
+                sh 'git clone https://github.com/obi-ontology/obi.git'
+                sh 'mkdir -p obi/build'
+                sh 'cp bin/robot.jar obi/build/robot.jar'
+                sh 'cd obi'
+                sh 'make test'
+                sh 'cd ..'
+                sh 'rm -rf obi'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         stage('Test') {
             steps {
                 script {
-                    if (env.BRANCH_NAME == 'obi-test') {
+                    if (env.BRANCH_NAME == 'master') {
                         try {
                             sh 'git clone https://github.com/obi-ontology/obi.git'
                             sh 'mkdir -p obi/build'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,9 +12,7 @@ pipeline {
                 sh 'git clone https://github.com/obi-ontology/obi.git'
                 sh 'mkdir -p obi/build'
                 sh 'cp bin/robot.jar obi/build/robot.jar'
-                sh 'cd obi'
-                sh 'make test'
-                sh 'cd ..'
+                sh 'cd obi && make test'
                 sh 'rm -rf obi'
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,12 +7,23 @@ pipeline {
                 sh 'mvn clean package'
             }
         }
+
         stage('Test') {
             steps {
-                sh 'git clone https://github.com/obi-ontology/obi.git || true'
-                sh 'mkdir -p obi/build'
-                sh 'cp bin/robot.jar obi/build/robot.jar'
-                sh 'cd obi && make test || cd .. && rm -rf obi'
+                script {
+                    if (env.BRANCH_NAME == 'obi-test') {
+                        try {
+                            sh 'git clone https://github.com/obi-ontology/obi.git'
+                            sh 'mkdir -p obi/build'
+                            sh 'cp bin/robot.jar obi/build/robot.jar'
+                            sh 'cd obi && make test'
+                        } finally {
+                            sh 'rm -rf obi'
+                        }
+                    } else {
+                        sh 'java -jar bin/robot.jar help'
+                    }
+                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
     agent any
+    environment {
+        TARGET_ADMIN_EMAILS = 'james@overton.ca'
+    }
 
     stages {
         stage('Build') {
@@ -31,6 +34,10 @@ pipeline {
     post {
         always {
             archiveArtifacts artifacts: 'bin/*.jar', fingerprint: true
+        }
+        failure {
+        echo "There has been a failure in the ${env.BRANCH_NAME} pipeline."
+        mail bcc: '', body: "There has been a pipeline failure in ${env.BRANCH_NAME}. Please see: https://build.obolibrary.io/job/ontodev/job/robot/${env.BRANCH_NAME}", cc: '', from: '', replyTo: '', subject: "ROBOT Integration Test FAIL", to: "${TARGET_ADMIN_EMAILS}"
         }
     }
 }


### PR DESCRIPTION
Right now, this only tests for the `obi-test` branch. We need to change this to `BRANCH_NAME = 'master'` (line 14) before merging it in.

This clones OBI and uses the build ROBOT JAR to `make test`.

We can add other ontology repos to test in the future, as well, following this pattern (assuming the repo uses a `build/robot.jar` and has `make test`)
```
try {
    sh 'git clone [REPO URL]'
    sh 'mkdir -p [REPO]/build'
    sh 'cp bin/robot.jar [REPO]/build/robot.jar'
    sh 'cd [REPO] && make test'
} finally {
    sh 'rm -rf [REPO]'
}
```