### PR TITLE
Fix QuotedEntityChecker returns values from axiom annotations #589

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/QuotedEntityChecker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/QuotedEntityChecker.java
@@ -225,7 +225,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
       ontologies.addAll(parentOntology.getImports());
       for (OWLAnnotationProperty property : properties) {
         // Get the labels for all entities
-        for (OWLAnnotation ann : EntitySearcher.getAnnotations(entity, ontologies, property)) {
+        for (OWLAnnotation ann : EntitySearcher.getAnnotationObjects(entity, ontologies, property)) {
           OWLLiteral value = ann.getValue().asLiteral().orNull();
           // If it has a label, add it to the map (will replace short form)
           if (value != null) {


### PR DESCRIPTION
`getAnnotations` did a bit more work than users actually expected. `getAnnotationObjects` is the best choice in the most common use cases.