### PR TITLE
Better error handling for index out of bounds in query options

### DIFF
--- a/docs/query.md
+++ b/docs/query.md
@@ -91,6 +91,10 @@ The ontology is never loaded as an `OWLOntology` object, since doing so loads th
 
 The file provided for `--update` does not exist. Check the path and try again.
 
+### Missing Output Error
+
+The `--query`, `--select`, and `--construct` options require two arguments: a query file and an output file (`--query <query> <output>`). 
+
 ### Missing Query Error
 
 You must specify a query to execute with `--query` or `--queries`.

--- a/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
@@ -32,6 +32,9 @@ public class QueryCommand implements Command {
   /** Error message when update file provided does not exist. */
   private static final String missingFileError = NS + "MISSING FILE ERROR file '%s' does not exist";
 
+  /** Error message when --query does not have two arguments. */
+  private static final String missingOutputError = NS + "MISSING OUTPUT ERROR --%s requires two arguments: query and output";
+
   /** Error message when a query is not provided */
   private static final String missingQueryError =
       NS + "MISSING QUERY ERROR at least one query must be provided";
@@ -294,15 +297,27 @@ public class QueryCommand implements Command {
     List<List<String>> queries = new ArrayList<>();
     List<String> qs = CommandLineHelper.getOptionalValues(line, "query");
     for (int i = 0; i < qs.size(); i += 2) {
-      queries.add(qs.subList(i, i + 2));
+      try {
+        queries.add(qs.subList(i, i + 2));
+      } catch (IndexOutOfBoundsException e) {
+        throw new IllegalArgumentException(String.format(missingOutputError, "query"));
+      }
     }
     qs = CommandLineHelper.getOptionalValues(line, "select");
     for (int i = 0; i < qs.size(); i += 2) {
-      queries.add(qs.subList(i, i + 2));
+      try {
+        queries.add(qs.subList(i, i + 2));
+      } catch (IndexOutOfBoundsException e) {
+        throw new IllegalArgumentException(String.format(missingOutputError, "select"));
+      }
     }
     qs = CommandLineHelper.getOptionalValues(line, "construct");
     for (int i = 0; i < qs.size(); i += 2) {
-      queries.add(qs.subList(i, i + 2));
+      try {
+        queries.add(qs.subList(i, i + 2));
+      } catch (IndexOutOfBoundsException e) {
+        throw new IllegalArgumentException(String.format(missingOutputError, "construct"));
+      }
     }
     qs = CommandLineHelper.getOptionalValues(line, "queries");
     for (String q : qs) {


### PR DESCRIPTION
See discussion in #592 - not providing two arguments to `--query` will cause an exception with no details.