### PR TITLE
Ensure owl:deprecated has a boolean value #592

### DIFF
--- a/robot-core/src/main/resources/report_profile.txt
+++ b/robot-core/src/main/resources/report_profile.txt
@@ -1,5 +1,5 @@
 WARN	annotation_whitespace
-ERROR deprecated_boolean_datatype
+ERROR	deprecated_boolean_datatype
 ERROR	deprecated_class_reference
 ERROR	deprecated_property_reference
 ERROR	duplicate_definition

--- a/robot-core/src/main/resources/report_profile.txt
+++ b/robot-core/src/main/resources/report_profile.txt
@@ -1,4 +1,5 @@
 WARN	annotation_whitespace
+ERROR deprecated_boolean_datatype
 ERROR	deprecated_class_reference
 ERROR	deprecated_property_reference
 ERROR	duplicate_definition

--- a/robot-core/src/main/resources/report_queries/deprecated_boolean_datatype.rq
+++ b/robot-core/src/main/resources/report_queries/deprecated_boolean_datatype.rq
@@ -1,0 +1,15 @@
+# # Deprecated Boolean Data Type
+#
+# **Problem:** When an entity is deprecated using the owl:deprecated annotation property, the value of the annotation must be a boolean data type. 
+#
+# **Solution:** Replace deprecated value with a boolean data type.
+
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?entity ?deprecated_value
+WHERE {
+  ?entity owl:deprecated ?deprecated_value .
+  FILTER (datatype(?deprecated_value) != xsd:boolean)
+}
+ORDER BY ?entity


### PR DESCRIPTION
@beckyjackson  @jamesaoverton @cmungall 

I've added a new report named `deprecated_boolean_datatype.rq` and updated the `report_profile.txt` to have level ERROR.

The query finds all entities that have a non-boolean value for an owl:deprecated annotation propery.

This addresses issue #592 