### PR TITLE
Switch whitespace queries to regex

### DIFF
--- a/robot-core/src/main/resources/report_queries/annotation_whitespace.rq
+++ b/robot-core/src/main/resources/report_queries/annotation_whitespace.rq
@@ -10,10 +10,10 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT DISTINCT ?entity ?property ?value WHERE {
   {?property a owl:AnnotationProperty .
    ?entity ?property ?value .
-   FILTER STRENDS(str(?value), " ")}
+   FILTER REGEX(str(?value), "[ \t\r\n]+$")}
   UNION
   {?property a owl:AnnotationProperty .
    ?entity ?property ?value .
-   FILTER STRSTARTS(str(?value), " ")}
+   FILTER REGEX(str(?value), "^[ \t\r\n]+")}
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/annotation_whitespace.rq
+++ b/robot-core/src/main/resources/report_queries/annotation_whitespace.rq
@@ -10,10 +10,10 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT DISTINCT ?entity ?property ?value WHERE {
   {?property a owl:AnnotationProperty .
    ?entity ?property ?value .
-   FILTER REGEX(str(?value), "[ \t\r\n]+$")}
+   FILTER REGEX(str(?value), "[\\s\r\n]+$")}
   UNION
   {?property a owl:AnnotationProperty .
    ?entity ?property ?value .
-   FILTER REGEX(str(?value), "^[ \t\r\n]+")}
+   FILTER REGEX(str(?value), "^[\\s\r\n]+")}
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/label_whitespace.rq
+++ b/robot-core/src/main/resources/report_queries/label_whitespace.rq
@@ -11,13 +11,13 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   {
    VALUES ?property {rdfs:label}
    ?entity ?property ?value .
-   FILTER STRENDS(str(?value), " ")
+   FILTER REGEX(str(?value), "[ \t\r\n]+$")
   }
   UNION
   {
    VALUES ?property {rdfs:label}
    ?entity ?property ?value .
-   FILTER STRSTARTS(str(?value), " ")
+   FILTER REGEX(str(?value), "^[ \t\r\n]+")
   }
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/label_whitespace.rq
+++ b/robot-core/src/main/resources/report_queries/label_whitespace.rq
@@ -11,13 +11,13 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   {
    VALUES ?property {rdfs:label}
    ?entity ?property ?value .
-   FILTER REGEX(str(?value), "[ \t\r\n]+$")
+   FILTER REGEX(str(?value), "[\\s\r\n]+$")
   }
   UNION
   {
    VALUES ?property {rdfs:label}
    ?entity ?property ?value .
-   FILTER REGEX(str(?value), "^[ \t\r\n]+")
+   FILTER REGEX(str(?value), "^[\\s\r\n]+")
   }
 }
 ORDER BY ?entity


### PR DESCRIPTION
The report queries to catch annotation and label whitespace only look for a space character at the start or end of the string. This misses leading/trailing tabs and newlines, which can cause issues (https://github.com/DiseaseOntology/HumanDiseaseOntology/issues/782).

This switches to a regex pattern to look for spaces, tabs, and newlines at the start or end of labels and other annotations.