### PR TITLE
Add more efficient mode for `reduce` when only considering named classes.

### DIFF
--- a/docs/reduce.md
+++ b/docs/reduce.md
@@ -7,3 +7,12 @@ ROBOT can be used to remove redundant subClassOf axioms:
       --output results/reduced.owl
 
 See [reason](/reason) for details on supported reasoners (EMR is not supported in `reduce`).
+
+Available options for `reduce`:
+* `--preserve-annotated-axioms`: if set to true, axioms that have axiom annotations will not be removed, even if found to be redundant (default `false`).
+* `--named-classes-only`: if set to true, only subclass axioms between named classes will be checked for redundancy. Anonymous class expressions will be ignored (default `false`).
+
+### Warning
+
+Reciprocal subclass axioms (e.g. `A SubClassOf B`, `B SubClassOf A`), entailing equivalence between `A` and `B`, may be removed by `reduce`. In this case it is important to
+assert an equivalence axiom (`A EquivalentTo B`) using the `reason` command before running reduce.

--- a/robot-command/src/main/java/org/obolibrary/robot/ReduceCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ReduceCommand.java
@@ -29,6 +29,8 @@ public class ReduceCommand implements Command {
         "preserve-annotated-axioms",
         true,
         "preserve annotated axioms when removing redundant subclass axioms");
+    o.addOption(
+        "c", "named-classes-only", true, "only reduce subclass axioms between named classes");
     o.addOption("i", "input", true, "reduce ontology from a file");
     o.addOption("I", "input-iri", true, "reduce ontology from an IRI");
     o.addOption("o", "output", true, "save reduceed ontology to a file");

--- a/robot-core/src/test/java/org/obolibrary/robot/ReduceOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ReduceOperationTest.java
@@ -29,6 +29,16 @@ public class ReduceOperationTest extends CoreTest {
 
     ReduceOperation.reduce(reasoned, reasonerFactory, options);
     assertIdentical("/without_redundant_subclasses.owl", reasoned);
+
+    OWLOntology reasoned2 = loadOntology("/redundant_subclasses.owl");
+
+    Map<String, String> options2 = new HashMap<String, String>();
+    options2.put("remove-redundant-subclass-axioms", "true");
+    options2.put("preserve-annotated-axioms", "true");
+    options2.put("named-classes-only", "true");
+
+    ReduceOperation.reduce(reasoned2, reasonerFactory, options2);
+    assertIdentical("/without_redundant_subclasses.owl", reasoned2);
   }
 
   @Test
@@ -155,5 +165,23 @@ public class ReduceOperationTest extends CoreTest {
 
     ReduceOperation.reduce(reasoned, reasonerFactory, options);
     assertIdentical("/reduce-domain-test.owl", reasoned);
+  }
+
+  /** Test reduce only named classes vs. including expressions */
+  @Test
+  public void testReducedNamedOnly() throws OWLOntologyCreationException, IOException {
+    OWLReasonerFactory reasonerFactory = new org.semanticweb.elk.owlapi.ElkReasonerFactory();
+
+    OWLOntology ontologyA = loadOntology("/reduce-named-only-test.ofn");
+    Map<String, String> optionsA = new HashMap<String, String>();
+    optionsA.put("named-classes-only", "true");
+    ReduceOperation.reduce(ontologyA, reasonerFactory, optionsA);
+    assertIdentical("/reduce-named-only-test-named-only-true-reduced.ofn", ontologyA);
+
+    OWLOntology ontologyB = loadOntology("/reduce-named-only-test.ofn");
+    Map<String, String> optionsB = new HashMap<String, String>();
+    optionsB.put("named-classes-only", "false");
+    ReduceOperation.reduce(ontologyB, reasonerFactory, optionsB);
+    assertIdentical("/reduce-named-only-test-named-only-false-reduced.ofn", ontologyB);
   }
 }

--- a/robot-core/src/test/resources/reduce-named-only-test-named-only-false-reduced.ofn
+++ b/robot-core/src/test/resources/reduce-named-only-test-named-only-false-reduced.ofn
@@ -1,0 +1,38 @@
+Prefix(:=<http://robot.obolibrary.org/reduce/test#>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://robot.obolibrary.org/reduce/test>
+
+Declaration(Class(<http://robot.obolibrary.org/reduce/test/A>))
+Declaration(Class(<http://robot.obolibrary.org/reduce/test/B>))
+Declaration(Class(<http://robot.obolibrary.org/reduce/test/C>))
+Declaration(Class(<http://robot.obolibrary.org/reduce/test/D>))
+Declaration(ObjectProperty(<http://robot.obolibrary.org/reduce/test/r>))
+
+############################
+#   Classes
+############################
+
+# Class: <http://robot.obolibrary.org/reduce/test/A> (<http://robot.obolibrary.org/reduce/test/A>)
+
+SubClassOf(<http://robot.obolibrary.org/reduce/test/A> ObjectSomeValuesFrom(<http://robot.obolibrary.org/reduce/test/r> <http://robot.obolibrary.org/reduce/test/C>))
+
+# Class: <http://robot.obolibrary.org/reduce/test/B> (<http://robot.obolibrary.org/reduce/test/B>)
+
+SubClassOf(<http://robot.obolibrary.org/reduce/test/B> <http://robot.obolibrary.org/reduce/test/A>)
+
+# Class: <http://robot.obolibrary.org/reduce/test/C> (<http://robot.obolibrary.org/reduce/test/C>)
+
+SubClassOf(<http://robot.obolibrary.org/reduce/test/C> <http://robot.obolibrary.org/reduce/test/B>)
+
+# Class: <http://robot.obolibrary.org/reduce/test/D> (<http://robot.obolibrary.org/reduce/test/D>)
+
+SubClassOf(<http://robot.obolibrary.org/reduce/test/D> <http://robot.obolibrary.org/reduce/test/C>)
+
+
+)

--- a/robot-core/src/test/resources/reduce-named-only-test-named-only-true-reduced.ofn
+++ b/robot-core/src/test/resources/reduce-named-only-test-named-only-true-reduced.ofn
@@ -1,0 +1,40 @@
+Prefix(:=<http://robot.obolibrary.org/reduce/test#>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://robot.obolibrary.org/reduce/test>
+
+Declaration(Class(<http://robot.obolibrary.org/reduce/test/A>))
+Declaration(Class(<http://robot.obolibrary.org/reduce/test/B>))
+Declaration(Class(<http://robot.obolibrary.org/reduce/test/C>))
+Declaration(Class(<http://robot.obolibrary.org/reduce/test/D>))
+Declaration(ObjectProperty(<http://robot.obolibrary.org/reduce/test/r>))
+
+############################
+#   Classes
+############################
+
+# Class: <http://robot.obolibrary.org/reduce/test/A> (<http://robot.obolibrary.org/reduce/test/A>)
+
+SubClassOf(<http://robot.obolibrary.org/reduce/test/A> ObjectSomeValuesFrom(<http://robot.obolibrary.org/reduce/test/r> <http://robot.obolibrary.org/reduce/test/C>))
+
+# Class: <http://robot.obolibrary.org/reduce/test/B> (<http://robot.obolibrary.org/reduce/test/B>)
+
+SubClassOf(<http://robot.obolibrary.org/reduce/test/B> <http://robot.obolibrary.org/reduce/test/A>)
+SubClassOf(<http://robot.obolibrary.org/reduce/test/B> ObjectSomeValuesFrom(<http://robot.obolibrary.org/reduce/test/r> <http://robot.obolibrary.org/reduce/test/C>))
+
+# Class: <http://robot.obolibrary.org/reduce/test/C> (<http://robot.obolibrary.org/reduce/test/C>)
+
+SubClassOf(<http://robot.obolibrary.org/reduce/test/C> <http://robot.obolibrary.org/reduce/test/B>)
+
+# Class: <http://robot.obolibrary.org/reduce/test/D> (<http://robot.obolibrary.org/reduce/test/D>)
+
+SubClassOf(<http://robot.obolibrary.org/reduce/test/D> <http://robot.obolibrary.org/reduce/test/C>)
+SubClassOf(<http://robot.obolibrary.org/reduce/test/D> ObjectSomeValuesFrom(<http://robot.obolibrary.org/reduce/test/r> <http://robot.obolibrary.org/reduce/test/C>))
+
+
+)

--- a/robot-core/src/test/resources/reduce-named-only-test.ofn
+++ b/robot-core/src/test/resources/reduce-named-only-test.ofn
@@ -1,0 +1,41 @@
+Prefix(:=<http://robot.obolibrary.org/reduce/test#>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://robot.obolibrary.org/reduce/test>
+
+Declaration(Class(<http://robot.obolibrary.org/reduce/test/A>))
+Declaration(Class(<http://robot.obolibrary.org/reduce/test/B>))
+Declaration(Class(<http://robot.obolibrary.org/reduce/test/C>))
+Declaration(Class(<http://robot.obolibrary.org/reduce/test/D>))
+Declaration(ObjectProperty(<http://robot.obolibrary.org/reduce/test/r>))
+
+############################
+#   Classes
+############################
+
+# Class: <http://robot.obolibrary.org/reduce/test/A> (<http://robot.obolibrary.org/reduce/test/A>)
+
+SubClassOf(<http://robot.obolibrary.org/reduce/test/A> ObjectSomeValuesFrom(<http://robot.obolibrary.org/reduce/test/r> <http://robot.obolibrary.org/reduce/test/C>))
+
+# Class: <http://robot.obolibrary.org/reduce/test/B> (<http://robot.obolibrary.org/reduce/test/B>)
+
+SubClassOf(<http://robot.obolibrary.org/reduce/test/B> <http://robot.obolibrary.org/reduce/test/A>)
+SubClassOf(<http://robot.obolibrary.org/reduce/test/B> ObjectSomeValuesFrom(<http://robot.obolibrary.org/reduce/test/r> <http://robot.obolibrary.org/reduce/test/C>))
+
+# Class: <http://robot.obolibrary.org/reduce/test/C> (<http://robot.obolibrary.org/reduce/test/C>)
+
+SubClassOf(<http://robot.obolibrary.org/reduce/test/C> <http://robot.obolibrary.org/reduce/test/B>)
+
+# Class: <http://robot.obolibrary.org/reduce/test/D> (<http://robot.obolibrary.org/reduce/test/D>)
+
+SubClassOf(<http://robot.obolibrary.org/reduce/test/D> <http://robot.obolibrary.org/reduce/test/B>)
+SubClassOf(<http://robot.obolibrary.org/reduce/test/D> <http://robot.obolibrary.org/reduce/test/C>)
+SubClassOf(<http://robot.obolibrary.org/reduce/test/D> ObjectSomeValuesFrom(<http://robot.obolibrary.org/reduce/test/r> <http://robot.obolibrary.org/reduce/test/C>))
+
+
+)


### PR DESCRIPTION
This is prompted by a failure GO had when trying to update to a newer ROBOT version. The `reduce` command was failing to complete on the large go-lego ontology. This additional implementation walks the reasoner taxonomy, and so is more efficient than the previous approach, but it is also limited to only considering subclass axioms between named classes (there are some corner cases where the approach of generating a name for the anonymous expressions doesn't work with the new algorithm). There is a new command-line option `--named-classes-only` to engage the faster version.