### PR TITLE
[WIP] Add support for anonymous class assertions in templates

### DIFF
--- a/docs/template.md
+++ b/docs/template.md
@@ -134,7 +134,8 @@ In this template, Class 5 would be a subclass of `part_of some 'Class 4'`.
 
 If the `TYPE` is a defined class, `owl:Individual`, or `owl:NamedIndividual`, an instance will be created. If the `TYPE` does not include a defined class, that instance will have no class assertions (unless you use the `TI` template string to add an anonymous type). You may include a `SPLIT=` in `TYPE` if you wish to provide more than one class assertion for an individual.
 
-- `TI %`: the individual will be asserted to be a type of the *class expression* in the column
+- **class assertion**:
+    - `TI %`: the individual will be asserted to be a type of the *class expression* in the column
 - **individual assertion**:
     - `I <property>`: when creating an individual, replace property with an object property or data property to add assertions (either by label or CURIE). The value of each axiom will be the value of the cell in this column. For object property assertions, this is another individual. For data property assertions, this is a literal value. If using a property label here, **do not** wrap the label in single quotes.
     - `SI %`: the individual in the column will be asserted to be the same individual
@@ -144,7 +145,7 @@ If the `TYPE` is a defined class, `owl:Individual`, or `owl:NamedIndividual`, an
 
 | Label        | Entity Type | Individual Role      |Property Assertions | Different Individuals | 
 | ------------ | ----------- | -------------------- |------------------- | --------------------- |
-| LABEL        | TYPE        | IT 'has role' some % |I part_of           | DI %                  |
+| LABEL        | TYPE        | TI 'has role' some % |I part_of           | DI %                  |
 | Individual 1 | Class 1     | Role Class 1         |Individual 2        |                       |
 | Individual 2 | Class 1     | Role Class 2         |                    | Individual 1          |
 

--- a/docs/template.md
+++ b/docs/template.md
@@ -132,8 +132,9 @@ In this template, Class 5 would be a subclass of `part_of some 'Class 4'`.
 
 ### Individual Template Strings
 
-If the `TYPE` is a defined class, `owl:Individual`, or `owl:NamedIndividual`, an instance will be created. If the `TYPE` does not include a defined class, that instance will have no class assertions. You may include a `SPLIT=` in `TYPE` if you wish to provide more than one class assertion for an individual.
+If the `TYPE` is a defined class, `owl:Individual`, or `owl:NamedIndividual`, an instance will be created. If the `TYPE` does not include a defined class, that instance will have no class assertions (unless you use the `TI` template string to add an anonymous type). You may include a `SPLIT=` in `TYPE` if you wish to provide more than one class assertion for an individual.
 
+- `TI %`: the individual will be asserted to be a type of the *class expression* in the column
 - **individual assertion**:
     - `I <property>`: when creating an individual, replace property with an object property or data property to add assertions (either by label or CURIE). The value of each axiom will be the value of the cell in this column. For object property assertions, this is another individual. For data property assertions, this is a literal value. If using a property label here, **do not** wrap the label in single quotes.
     - `SI %`: the individual in the column will be asserted to be the same individual
@@ -141,11 +142,11 @@ If the `TYPE` is a defined class, `owl:Individual`, or `owl:NamedIndividual`, an
 
 #### Example of Individual Template Strings
 
-| Label        | Entity Type | Property Assertions | Different Individuals |
-| ------------ | ----------- | ------------------- | --------------------- |
-| LABEL        | TYPE        | I part_of           | DI %                  |
-| Individual 1 | Class 1     | Individual 2        |                       |
-| Individual 2 | Class 1     |                     | Individual 1          |
+| Label        | Entity Type | Individual Role      |Property Assertions | Different Individuals | 
+| ------------ | ----------- | -------------------- |------------------- | --------------------- |
+| LABEL        | TYPE        | IT 'has role' some % |I part_of           | DI %                  |
+| Individual 1 | Class 1     | Role Class 1         |Individual 2        |                       |
+| Individual 2 | Class 1     | Role Class 2         |                    | Individual 1          |
 
 <!-- ### Datatype Template Strings -->
 

--- a/robot-core/src/main/java/org/obolibrary/robot/Template.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/Template.java
@@ -1,7 +1,6 @@
 package org.obolibrary.robot;
 
 import java.util.*;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import org.obolibrary.robot.exceptions.ColumnException;
@@ -81,70 +80,71 @@ public class Template {
 
   /** Error message when an annotation property has a characteristic. */
   private static final String annotationPropertyCharacteristicError =
-      NS
-          + "ANNOTATION PROPERTY CHARACTERISTIC ERROR annotation property '%s' should not have any characteristics at line %d, column %d in table \"%s\"";
+    NS
+      + "ANNOTATION PROPERTY CHARACTERISTIC ERROR annotation property '%s' should not have any characteristics at line %d, column %d in table \"%s\"";
 
   /** Error message when an annotation property gets a property type other than subproperty. */
   private static final String annotationPropertyTypeError =
-      NS
-          + "ANNOTATION PROPERTY TYPE ERROR annotation property %s type '%s' must be 'subproperty' at row %d, column %d in table \"%s\".";
+    NS
+      + "ANNOTATION PROPERTY TYPE ERROR annotation property %s type '%s' must be 'subproperty' at row %d, column %d in table \"%s\".";
 
   /** Error message when an invalid class type is provided. */
   private static final String classTypeError =
-      NS + "CLASS TYPE ERROR class %s has unknown type '%s' at row %d, column %d in table \"%s\".";
+    NS + "CLASS TYPE ERROR class %s has unknown type '%s' at row %d, column %d in table \"%s\".";
 
   /** Error message when CLASS_TYPE has a SPLIT. */
   private static final String classTypeSplitError =
-      NS
-          + "CLASS TYPE SPLIT ERROR the SPLIT functionality should not be used for CLASS_TYPE in column %d in table \"%s\".";
+    NS
+      + "CLASS TYPE SPLIT ERROR the SPLIT functionality should not be used for CLASS_TYPE in column %d in table \"%s\".";
 
   /**
-   * Error message when a template column does not have a header. Expects: column number, table name
+   * Error message when the number of header columns does not match the number of template columns.
+   * Expects: table name, header count, template count.
    */
-  private static final String columnMismatchError =
-      NS
-          + "COLUMN MISMATCH ERROR the template string in column %d must have a corresponding header in table \"%s\"";
+  static final String columnMismatchError =
+    NS
+      + "COLUMN MISMATCH ERROR the number of header columns (%2$d) must match the number of template columns (%3$d) in table \"%1$s\".";
 
   /** Error message when a data property has a characteristic other than 'functional'. */
   private static final String dataPropertyCharacteristicError =
-      NS
-          + "DATA PROPERTY CHARACTERISTIC ERROR data property '%s' can only have characteristic 'functional' at line %d, column %d in table \"%s\".";
+    NS
+      + "DATA PROPERTY CHARACTERISTIC ERROR data property '%s' can only have characteristic 'functional' at line %d, column %d in table \"%s\".";
 
   /** Error message when an invalid individual type is provided. */
   private static final String individualTypeError =
-      NS
-          + "INDIVIDUAL TYPE ERROR individual %s has unknown type '%s' at row %d, column %d in table \"%s\".";
+    NS
+      + "INDIVIDUAL TYPE ERROR individual %s has unknown type '%s' at row %d, column %d in table \"%s\".";
 
   /** Error message when INDIVIDUAL_TYPE has a SPLIT. */
   private static final String individualTypeSplitError =
-      NS
-          + "INDIVIDUAL TYPE SPLIT ERROR the SPLIT functionality should not be used for INDIVIDUAL_TYPE in column %d in table \"%s\".";
+    NS
+      + "INDIVIDUAL TYPE SPLIT ERROR the SPLIT functionality should not be used for INDIVIDUAL_TYPE in column %d in table \"%s\".";
 
   /** Error message when an invalid property type is provided. */
   private static final String propertyTypeError =
-      NS
-          + "PROPERTY TYPE ERROR property %s has unknown type '%s' at row %d, column %d in table \"%s\".";
+    NS
+      + "PROPERTY TYPE ERROR property %s has unknown type '%s' at row %d, column %d in table \"%s\".";
 
   /** Error message when more than one logical type is used in PROPERTY_TYPE. */
   private static final String propertyTypeSplitError =
-      NS
-          + "PROPERTY TYPE SPLIT ERROR the SPLIT functionality should not be used for PROPERTY_TYPE in column %d in table \"%s\".";
+    NS
+      + "PROPERTY TYPE SPLIT ERROR thee SPLIT functionality should not be used for PROPERTY_TYPE in column %d in table \"%s\".";
 
   /** Error message when property characteristic not valid. */
   private static final String unknownCharacteristicError =
-      NS
-          + "UNKNOWN CHARACTERISTIC ERROR property '%s' has unknown characteristic '%s' at line %d, column %d in table \"%s\".";
+    NS
+      + "UNKNOWN CHARACTERISTIC ERROR property '%s' has unknown characteristic '%s' at line %d, column %d in table \"%s\".";
 
   /**
    * Error message when a template cannot be understood. Expects: table name, column number, column
    * name, template.
    */
-  private static final String unknownTemplateError =
-      NS
-          + "UNKNOWN TEMPLATE ERROR could not interpret template string \"%4$s\" for column %2$d (\"%3$s\") in table \"%1$s\".";
+  static final String unknownTemplateError =
+    NS
+      + "UNKNOWN TEMPLATE ERROR could not interpret template string \"%4$s\" for column %2$d (\"%3$s\") in table \"%1$s\".";
 
   private static final List<String> validClassTypes =
-      new ArrayList<>(Arrays.asList("subclass", "disjoint", "equivalent"));
+    new ArrayList<>(Arrays.asList("subclass", "disjoint", "equivalent"));
 
   /**
    * Given a template name and a list of rows, create a template object with a new IOHelper and
@@ -184,7 +184,7 @@ public class Template {
    * @throws Exception on issue adding table to template object
    */
   public Template(@Nonnull String name, @Nonnull List<List<String>> rows, IOHelper ioHelper)
-      throws Exception {
+    throws Exception {
     this.name = name;
     this.ioHelper = ioHelper;
     tableRows = new ArrayList<>();
@@ -215,7 +215,7 @@ public class Template {
    * @throws Exception on issue creating IOHelper or adding table to template object
    */
   public Template(@Nonnull String name, @Nonnull List<List<String>> rows, OWLOntology inputOntology)
-      throws Exception {
+    throws Exception {
     this.name = name;
     ioHelper = new IOHelper();
     tableRows = new ArrayList<>();
@@ -250,11 +250,11 @@ public class Template {
    * @throws Exception on issue adding table to template object
    */
   public Template(
-      @Nonnull String name,
-      @Nonnull List<List<String>> rows,
-      OWLOntology inputOntology,
-      IOHelper ioHelper)
-      throws Exception {
+    @Nonnull String name,
+    @Nonnull List<List<String>> rows,
+    OWLOntology inputOntology,
+    IOHelper ioHelper)
+    throws Exception {
     this.name = name;
     this.ioHelper = ioHelper;
     tableRows = new ArrayList<>();
@@ -289,12 +289,12 @@ public class Template {
    * @throws Exception on issue adding table to template object
    */
   public Template(
-      @Nonnull String name,
-      @Nonnull List<List<String>> rows,
-      OWLOntology inputOntology,
-      IOHelper ioHelper,
-      QuotedEntityChecker checker)
-      throws Exception {
+    @Nonnull String name,
+    @Nonnull List<List<String>> rows,
+    OWLOntology inputOntology,
+    IOHelper ioHelper,
+    QuotedEntityChecker checker)
+    throws Exception {
     this.name = name;
     this.ioHelper = ioHelper;
     if (checker == null) {
@@ -397,34 +397,27 @@ public class Template {
     // Get and validate headers
     headers = rows.get(0);
     templates = rows.get(1);
+    if (headers.size() != templates.size()) {
+      throw new ColumnException(
+        String.format(columnMismatchError, name, headers.size(), templates.size()));
+    }
 
     for (int column = 0; column < templates.size(); column++) {
-      String template = templates.get(column).trim();
-      if (template.isEmpty()) {
-        // If the template is empty, skip this column
+      String template = templates.get(column);
+
+      // If the template is null or the column is empty, skip this column
+      if (template == null) {
         continue;
       }
-
-      // Validate that there's a header in this column
-      // It's OK if there's a header without a template
-      String header;
-      try {
-        header = headers.get(column).trim();
-      } catch (IndexOutOfBoundsException e) {
-        // Template row is longer than header row
-        // Which means there is at least one header missing
-        throw new ColumnException(String.format(columnMismatchError, column + 1, name));
-      }
-      if (header.isEmpty()) {
-        // Template string is not empty
-        // Header string is empty
-        throw new ColumnException(String.format(columnMismatchError, column + 1, name));
+      template = template.trim();
+      if (template.isEmpty()) {
+        continue;
       }
 
       // Validate the template string
       if (!TemplateHelper.validateTemplateString(template)) {
         throw new ColumnException(
-            String.format(unknownTemplateError, name, column + 1, headers.get(column), template));
+          String.format(unknownTemplateError, name, column + 1, headers.get(column), template));
       }
 
       // Get the location of important columns
@@ -497,7 +490,7 @@ public class Template {
     // Without one, we cannot continue
     if (idColumn == -1 && labelColumn == -1) {
       throw new ColumnException(
-          "Template row must include an \"ID\" or \"LABEL\" column in table: " + name);
+        "Template row must include an \"ID\" or \"LABEL\" column in table: " + name);
     }
 
     // Add the rest of the tableRows to Template
@@ -507,7 +500,7 @@ public class Template {
   }
 
   /** Add the labels from the rows of the template to the QuotedEntityChecker. */
-  private void addLabels() {
+  private void addLabels() throws RowParseException {
     // If there's no label column, we can't add labels
     if (labelColumn == -1) {
       return;
@@ -555,7 +548,10 @@ public class Template {
       }
 
       // Try to resolve a CURIE
-      IRI typeIRI = ioHelper.createIRI(type);
+      IRI typeIRI = checker.getIRI(type, false);
+      if (typeIRI == null) {
+        typeIRI = ioHelper.createIRI(type);
+      }
 
       // Set to IRI string or to type string
       String typeOrIRI = type;
@@ -622,7 +618,6 @@ public class Template {
    */
   private void processRow(List<String> row) throws Exception {
     rowNum++;
-
     String id = null;
     try {
       id = row.get(idColumn);
@@ -753,13 +748,13 @@ public class Template {
     if (!validClassTypes.contains(classType)) {
       // Unknown class type
       throw new RowParseException(
-          String.format(
-              classTypeError,
-              cls.getIRI().getShortForm(),
-              classType,
-              rowNum,
-              classTypeColumn,
-              name));
+        String.format(
+          classTypeError,
+          cls.getIRI().getShortForm(),
+          classType,
+          rowNum,
+          classTypeColumn,
+          name));
     }
 
     // Iterate through all columns and add annotations as we go
@@ -793,38 +788,38 @@ public class Template {
       } else if (template.startsWith("SC")) {
         // Subclass expression
         subclassExpressionColumns.put(
-            column,
-            TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column + 1));
+          column,
+          TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column + 1));
       } else if (template.startsWith("EC")) {
         // Equivalent expression
         equivalentExpressionColumns.put(
-            column,
-            TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column + 1));
+          column,
+          TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column + 1));
       } else if (template.startsWith("DC")) {
         // Disjoint expression
         disjointExpressionColumns.put(
-            column,
-            TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column + 1));
+          column,
+          TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column + 1));
       } else if (template.startsWith("C") && !template.startsWith("CLASS_TYPE")) {
         // Use class type to determine what to do with the expression
         switch (classType) {
           case "subclass":
             subclassExpressionColumns.put(
-                column,
-                TemplateHelper.getClassExpressions(
-                    name, parser, template, value, rowNum, column + 1));
+              column,
+              TemplateHelper.getClassExpressions(
+                name, parser, template, value, rowNum, column + 1));
             break;
           case "equivalent":
             intersectionEquivalentExpressionColumns.put(
-                column,
-                TemplateHelper.getClassExpressions(
-                    name, parser, template, value, rowNum, column + 1));
+              column,
+              TemplateHelper.getClassExpressions(
+                name, parser, template, value, rowNum, column + 1));
             break;
           case "disjoint":
             disjointExpressionColumns.put(
-                column,
-                TemplateHelper.getClassExpressions(
-                    name, parser, template, value, rowNum, column + 1));
+              column,
+              TemplateHelper.getClassExpressions(
+                name, parser, template, value, rowNum, column + 1));
             break;
           default:
             break;
@@ -860,8 +855,8 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addSubClassAxioms(
-      OWLClass cls, Map<Integer, Set<OWLClassExpression>> expressionColumns, List<String> row)
-      throws Exception {
+    OWLClass cls, Map<Integer, Set<OWLClassExpression>> expressionColumns, List<String> row)
+    throws Exception {
     // Generate axioms
     for (int column : expressionColumns.keySet()) {
       // Maybe get an annotation on the expression
@@ -885,8 +880,8 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addEquivalentClassesAxioms(
-      OWLClass cls, Map<Integer, Set<OWLClassExpression>> expressionColumns, List<String> row)
-      throws Exception {
+    OWLClass cls, Map<Integer, Set<OWLClassExpression>> expressionColumns, List<String> row)
+    throws Exception {
     Set<OWLAnnotation> axiomAnnotations = new HashSet<>();
     Set<OWLClassExpression> expressions = new HashSet<>();
     expressions.add(cls);
@@ -911,8 +906,8 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addIntersectionEquivalentClassesAxioms(
-      OWLClass cls, Map<Integer, Set<OWLClassExpression>> expressionColumns, List<String> row)
-      throws Exception {
+    OWLClass cls, Map<Integer, Set<OWLClassExpression>> expressionColumns, List<String> row)
+    throws Exception {
     Set<OWLAnnotation> axiomAnnotations = new HashSet<>();
     Set<OWLClassExpression> expressions = new HashSet<>();
     for (int column : expressionColumns.keySet()) {
@@ -937,8 +932,8 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addDisjointClassAxioms(
-      OWLClass cls, Map<Integer, Set<OWLClassExpression>> expressionColumns, List<String> row)
-      throws Exception {
+    OWLClass cls, Map<Integer, Set<OWLClassExpression>> expressionColumns, List<String> row)
+    throws Exception {
     for (int column : expressionColumns.keySet()) {
       // Maybe get an annotation on the expression
       Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
@@ -964,8 +959,8 @@ public class Template {
   private void addObjectPropertyAxioms(IRI iri, List<String> row) throws Exception {
     // Add the declaration
     axioms.add(
-        dataFactory.getOWLDeclarationAxiom(
-            dataFactory.getOWLEntity(EntityType.OBJECT_PROPERTY, iri)));
+      dataFactory.getOWLDeclarationAxiom(
+        dataFactory.getOWLEntity(EntityType.OBJECT_PROPERTY, iri)));
 
     // Maybe get a property type (default subproperty)
     String propertyType = getPropertyType(row);
@@ -1003,13 +998,13 @@ public class Template {
           break;
         default:
           throw new Exception(
-              String.format(
-                  unknownCharacteristicError,
-                  property.getIRI().getShortForm(),
-                  c,
-                  rowNum,
-                  characteristicColumn,
-                  name));
+            String.format(
+              unknownCharacteristicError,
+              property.getIRI().getShortForm(),
+              c,
+              rowNum,
+              characteristicColumn,
+              name));
       }
     }
 
@@ -1035,32 +1030,32 @@ public class Template {
       } else if (template.startsWith("SP")) {
         // Subproperty expressions
         Set<OWLObjectPropertyExpression> expressions =
-            TemplateHelper.getObjectPropertyExpressions(
-                name, checker, template, value, rowNum, column);
+          TemplateHelper.getObjectPropertyExpressions(
+            name, checker, template, value, rowNum, column);
         addSubObjectPropertyAxioms(property, expressions, row, column);
       } else if (template.startsWith("EP")) {
         // Equivalent properties expressions
         Set<OWLObjectPropertyExpression> expressions =
-            TemplateHelper.getObjectPropertyExpressions(
-                name, checker, template, value, rowNum, column);
+          TemplateHelper.getObjectPropertyExpressions(
+            name, checker, template, value, rowNum, column);
         addEquivalentObjectPropertiesAxioms(property, expressions, row, column);
       } else if (template.startsWith("DP")) {
         // Disjoint properties expressions
         Set<OWLObjectPropertyExpression> expressions =
-            TemplateHelper.getObjectPropertyExpressions(
-                name, checker, template, value, rowNum, column);
+          TemplateHelper.getObjectPropertyExpressions(
+            name, checker, template, value, rowNum, column);
         addDisjointObjectPropertiesAxioms(property, expressions, row, column);
       } else if (template.startsWith("IP")) {
         // Inverse properties expressions
         Set<OWLObjectPropertyExpression> expressions =
-            TemplateHelper.getObjectPropertyExpressions(
-                name, checker, template, value, rowNum, column);
+          TemplateHelper.getObjectPropertyExpressions(
+            name, checker, template, value, rowNum, column);
         addInverseObjectPropertiesAxioms(property, expressions, row, column);
       } else if (template.startsWith("P") && !template.startsWith("PROPERTY_TYPE")) {
         // Use the property type to determine what type of expression
         Set<OWLObjectPropertyExpression> expressions =
-            TemplateHelper.getObjectPropertyExpressions(
-                name, checker, template, value, rowNum, column);
+          TemplateHelper.getObjectPropertyExpressions(
+            name, checker, template, value, rowNum, column);
         switch (propertyType) {
           case "subproperty":
             addSubObjectPropertyAxioms(property, expressions, row, column);
@@ -1077,18 +1072,18 @@ public class Template {
           default:
             // Unknown property type
             throw new RowParseException(
-                String.format(
-                    propertyTypeError, iri.getShortForm(), propertyType, rowNum, column + 1, name));
+              String.format(
+                propertyTypeError, iri.getShortForm(), propertyType, rowNum, column + 1, name));
         }
       } else if (template.startsWith("DOMAIN")) {
         // Handle domains
         Set<OWLClassExpression> expressions =
-            TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column);
+          TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column);
         addObjectPropertyDomains(property, expressions, row, column);
       } else if (template.startsWith("RANGE")) {
         // Handle ranges
         Set<OWLClassExpression> expressions =
-            TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column);
+          TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column);
         addObjectPropertyRanges(property, expressions, row, column);
       }
     }
@@ -1106,11 +1101,11 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addSubObjectPropertyAxioms(
-      OWLObjectProperty property,
-      Set<OWLObjectPropertyExpression> expressions,
-      List<String> row,
-      int column)
-      throws Exception {
+    OWLObjectProperty property,
+    Set<OWLObjectPropertyExpression> expressions,
+    List<String> row,
+    int column)
+    throws Exception {
     // Maybe get an annotation on the expression
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
@@ -1132,18 +1127,18 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addEquivalentObjectPropertiesAxioms(
-      OWLObjectProperty property,
-      Set<OWLObjectPropertyExpression> expressions,
-      List<String> row,
-      int column)
-      throws Exception {
+    OWLObjectProperty property,
+    Set<OWLObjectPropertyExpression> expressions,
+    List<String> row,
+    int column)
+    throws Exception {
     // Maybe get an annotation on the expression
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
     // Generate axioms
     for (OWLObjectPropertyExpression expr : expressions) {
       axioms.add(
-          dataFactory.getOWLEquivalentObjectPropertiesAxiom(property, expr, axiomAnnotations));
+        dataFactory.getOWLEquivalentObjectPropertiesAxiom(property, expr, axiomAnnotations));
     }
   }
 
@@ -1159,11 +1154,11 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addDisjointObjectPropertiesAxioms(
-      OWLObjectProperty property,
-      Set<OWLObjectPropertyExpression> expressions,
-      List<String> row,
-      int column)
-      throws Exception {
+    OWLObjectProperty property,
+    Set<OWLObjectPropertyExpression> expressions,
+    List<String> row,
+    int column)
+    throws Exception {
     // Maybe get an annotation on the expression
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
@@ -1184,11 +1179,11 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addInverseObjectPropertiesAxioms(
-      OWLObjectProperty property,
-      Set<OWLObjectPropertyExpression> expressions,
-      List<String> row,
-      int column)
-      throws Exception {
+    OWLObjectProperty property,
+    Set<OWLObjectPropertyExpression> expressions,
+    List<String> row,
+    int column)
+    throws Exception {
     // Maybe get an annotation on the expression
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
@@ -1210,8 +1205,8 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addObjectPropertyDomains(
-      OWLObjectProperty property, Set<OWLClassExpression> expressions, List<String> row, int column)
-      throws Exception {
+    OWLObjectProperty property, Set<OWLClassExpression> expressions, List<String> row, int column)
+    throws Exception {
     // Maybe get an annotation on the expression
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
@@ -1233,8 +1228,8 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addObjectPropertyRanges(
-      OWLObjectProperty property, Set<OWLClassExpression> expressions, List<String> row, int column)
-      throws Exception {
+    OWLObjectProperty property, Set<OWLClassExpression> expressions, List<String> row, int column)
+    throws Exception {
     // Maybe get an annotation on the expression
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
@@ -1257,8 +1252,8 @@ public class Template {
   private void addDataPropertyAxioms(IRI iri, List<String> row) throws Exception {
     // Add the declaration
     axioms.add(
-        dataFactory.getOWLDeclarationAxiom(
-            dataFactory.getOWLEntity(EntityType.DATA_PROPERTY, iri)));
+      dataFactory.getOWLDeclarationAxiom(
+        dataFactory.getOWLEntity(EntityType.DATA_PROPERTY, iri)));
 
     OWLDataProperty property = dataFactory.getOWLDataProperty(iri);
 
@@ -1272,12 +1267,12 @@ public class Template {
     for (String c : characteristics) {
       if (!c.equalsIgnoreCase("functional")) {
         throw new Exception(
-            String.format(
-                dataPropertyCharacteristicError,
-                property.getIRI().getShortForm(),
-                rowNum,
-                characteristicColumn,
-                name));
+          String.format(
+            dataPropertyCharacteristicError,
+            property.getIRI().getShortForm(),
+            rowNum,
+            characteristicColumn,
+            name));
       }
       axioms.add(dataFactory.getOWLFunctionalDataPropertyAxiom(property));
     }
@@ -1309,31 +1304,31 @@ public class Template {
       } else if (template.startsWith("SP")) {
         // Subproperty expressions
         Set<OWLDataPropertyExpression> expressions =
-            TemplateHelper.getDataPropertyExpressions(
-                name, checker, template, value, rowNum, column);
+          TemplateHelper.getDataPropertyExpressions(
+            name, checker, template, value, rowNum, column);
         addSubDataPropertyAxioms(property, expressions, row, column);
       } else if (template.startsWith("EP")) {
         // Equivalent properties expressions
         Set<OWLDataPropertyExpression> expressions =
-            TemplateHelper.getDataPropertyExpressions(
-                name, checker, template, value, rowNum, column);
+          TemplateHelper.getDataPropertyExpressions(
+            name, checker, template, value, rowNum, column);
         addEquivalentDataPropertiesAxioms(property, expressions, row, column);
       } else if (template.startsWith("DP")) {
         // Disjoint properties expressions
         Set<OWLDataPropertyExpression> expressions =
-            TemplateHelper.getDataPropertyExpressions(
-                name, checker, template, value, rowNum, column);
+          TemplateHelper.getDataPropertyExpressions(
+            name, checker, template, value, rowNum, column);
         addDisjointDataPropertiesAxioms(property, expressions, row, column);
       } else if (template.startsWith("IP")) {
         // Cannot use inverse with data properties
         throw new RowParseException(
-            String.format(
-                propertyTypeError, iri.getShortForm(), propertyType, rowNum, column + 1, name));
+          String.format(
+            propertyTypeError, iri.getShortForm(), propertyType, rowNum, column + 1, name));
       } else if (template.startsWith("P ") && !template.startsWith("PROPERTY_TYPE")) {
         // Use property type to handle expression type
         Set<OWLDataPropertyExpression> expressions =
-            TemplateHelper.getDataPropertyExpressions(
-                name, checker, template, value, rowNum, column);
+          TemplateHelper.getDataPropertyExpressions(
+            name, checker, template, value, rowNum, column);
         switch (propertyType) {
           case "subproperty":
             addSubDataPropertyAxioms(property, expressions, row, column);
@@ -1347,18 +1342,18 @@ public class Template {
           default:
             // Unknown property type
             throw new RowParseException(
-                String.format(
-                    propertyTypeError, iri.getShortForm(), propertyType, rowNum, column + 1, name));
+              String.format(
+                propertyTypeError, iri.getShortForm(), propertyType, rowNum, column + 1, name));
         }
       } else if (template.startsWith("DOMAIN")) {
         // Handle domains
         Set<OWLClassExpression> expressions =
-            TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column);
+          TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column);
         addDataPropertyDomains(property, expressions, row, column);
       } else if (template.startsWith("RANGE")) {
         // Handle ranges
         Set<OWLDatatype> datatypes =
-            TemplateHelper.getDatatypes(name, checker, value, split, rowNum, column);
+          TemplateHelper.getDatatypes(name, checker, value, split, rowNum, column);
         addDataPropertyRanges(property, datatypes, row, column);
       }
     }
@@ -1376,11 +1371,11 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addSubDataPropertyAxioms(
-      OWLDataProperty property,
-      Set<OWLDataPropertyExpression> expressions,
-      List<String> row,
-      int column)
-      throws Exception {
+    OWLDataProperty property,
+    Set<OWLDataPropertyExpression> expressions,
+    List<String> row,
+    int column)
+    throws Exception {
     // Maybe get an annotation on the expression
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
@@ -1404,11 +1399,11 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addEquivalentDataPropertiesAxioms(
-      OWLDataProperty property,
-      Set<OWLDataPropertyExpression> expressions,
-      List<String> row,
-      int column)
-      throws Exception {
+    OWLDataProperty property,
+    Set<OWLDataPropertyExpression> expressions,
+    List<String> row,
+    int column)
+    throws Exception {
     // Maybe get an annotation on the expression
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
@@ -1430,11 +1425,11 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addDisjointDataPropertiesAxioms(
-      OWLDataProperty property,
-      Set<OWLDataPropertyExpression> expressions,
-      List<String> row,
-      int column)
-      throws Exception {
+    OWLDataProperty property,
+    Set<OWLDataPropertyExpression> expressions,
+    List<String> row,
+    int column)
+    throws Exception {
     // Maybe get an annotation on the expression
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
@@ -1455,8 +1450,8 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addDataPropertyDomains(
-      OWLDataProperty property, Set<OWLClassExpression> expressions, List<String> row, int column)
-      throws Exception {
+    OWLDataProperty property, Set<OWLClassExpression> expressions, List<String> row, int column)
+    throws Exception {
     // Maybe get an annotation on the expression
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
@@ -1478,8 +1473,8 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addDataPropertyRanges(
-      OWLDataProperty property, Set<OWLDatatype> datatypes, List<String> row, int column)
-      throws Exception {
+    OWLDataProperty property, Set<OWLDatatype> datatypes, List<String> row, int column)
+    throws Exception {
     // Maybe get an annotation on the expression
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
@@ -1502,16 +1497,16 @@ public class Template {
   private void addAnnotationPropertyAxioms(IRI iri, List<String> row) throws Exception {
     // Add the declaration
     axioms.add(
-        dataFactory.getOWLDeclarationAxiom(
-            dataFactory.getOWLEntity(EntityType.ANNOTATION_PROPERTY, iri)));
+      dataFactory.getOWLDeclarationAxiom(
+        dataFactory.getOWLEntity(EntityType.ANNOTATION_PROPERTY, iri)));
 
     String propertyType = getPropertyType(row);
 
     if (!propertyType.equals("subproperty")) {
       // Annotation properties can only have type "subproperty"
       throw new RowParseException(
-          String.format(
-              annotationPropertyTypeError, iri, propertyType, rowNum, propertyTypeColumn, name));
+        String.format(
+          annotationPropertyTypeError, iri, propertyType, rowNum, propertyTypeColumn, name));
     }
 
     // Annotation properties should not have characteristics
@@ -1519,12 +1514,12 @@ public class Template {
       String propertyCharacteristicString = row.get(characteristicColumn);
       if (propertyCharacteristicString != null && !propertyCharacteristicString.trim().isEmpty()) {
         throw new RowParseException(
-            String.format(
-                annotationPropertyCharacteristicError,
-                iri.getShortForm(),
-                rowNum,
-                characteristicColumn,
-                name));
+          String.format(
+            annotationPropertyCharacteristicError,
+            iri.getShortForm(),
+            rowNum,
+            characteristicColumn,
+            name));
       }
     }
 
@@ -1557,10 +1552,10 @@ public class Template {
           axioms.add(dataFactory.getOWLAnnotationAssertionAxiom(iri, annotation));
         }
       } else if (template.startsWith("SP")
-          || template.startsWith("P") && !template.startsWith("PROPERTY_TYPE")) {
+        || template.startsWith("P") && !template.startsWith("PROPERTY_TYPE")) {
         // Handle property logic
         Set<OWLAnnotationProperty> parents =
-            TemplateHelper.getAnnotationProperties(checker, value, split);
+          TemplateHelper.getAnnotationProperties(checker, value, split);
         addSubAnnotationPropertyAxioms(property, parents, row, column);
       } else if (template.startsWith("DOMAIN")) {
         // Handle domains
@@ -1586,18 +1581,18 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addSubAnnotationPropertyAxioms(
-      OWLAnnotationProperty property,
-      Set<OWLAnnotationProperty> parents,
-      List<String> row,
-      int column)
-      throws Exception {
+    OWLAnnotationProperty property,
+    Set<OWLAnnotationProperty> parents,
+    List<String> row,
+    int column)
+    throws Exception {
     // Maybe get an annotation on the subproperty axiom
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
     // Generate axioms
     for (OWLAnnotationProperty parent : parents) {
       axioms.add(
-          dataFactory.getOWLSubAnnotationPropertyOfAxiom(property, parent, axiomAnnotations));
+        dataFactory.getOWLSubAnnotationPropertyOfAxiom(property, parent, axiomAnnotations));
     }
   }
 
@@ -1613,8 +1608,8 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addAnnotationPropertyDomains(
-      OWLAnnotationProperty property, Set<IRI> iris, List<String> row, int column)
-      throws Exception {
+    OWLAnnotationProperty property, Set<IRI> iris, List<String> row, int column)
+    throws Exception {
     // Maybe get an annotation on the expression
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
@@ -1636,8 +1631,8 @@ public class Template {
    * @throws Exception on issue getting axiom annotations
    */
   private void addAnnotationPropertyRanges(
-      OWLAnnotationProperty property, Set<IRI> iris, List<String> row, int column)
-      throws Exception {
+    OWLAnnotationProperty property, Set<IRI> iris, List<String> row, int column)
+    throws Exception {
     // Maybe get an annotation on the expression
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
@@ -1659,7 +1654,7 @@ public class Template {
   private void addDatatypeAxioms(IRI iri, List<String> row) throws Exception {
     // Add the declaration
     axioms.add(
-        dataFactory.getOWLDeclarationAxiom(dataFactory.getOWLEntity(EntityType.DATATYPE, iri)));
+      dataFactory.getOWLDeclarationAxiom(dataFactory.getOWLEntity(EntityType.DATATYPE, iri)));
 
     for (int column = 0; column < templates.size(); column++) {
       String template = templates.get(column);
@@ -1744,16 +1739,16 @@ public class Template {
 
       // Add a type if the type is not owl:Individual or owl:NamedIndividual
       if (!typeOrIRI.equalsIgnoreCase("individual")
-          && !typeOrIRI.equalsIgnoreCase("named individual")
-          && !typeOrIRI.equalsIgnoreCase("http://www.w3.org/2002/07/owl#NamedIndividual")
-          && !typeOrIRI.equalsIgnoreCase("http://www.w3.org/2002/07/owl#Individual")) {
+        && !typeOrIRI.equalsIgnoreCase("named individual")
+        && !typeOrIRI.equalsIgnoreCase("http://www.w3.org/2002/07/owl#NamedIndividual")
+        && !typeOrIRI.equalsIgnoreCase("http://www.w3.org/2002/07/owl#Individual")) {
         OWLClass typeCls = checker.getOWLClass(type);
         if (typeCls != null) {
           axioms.add(dataFactory.getOWLClassAssertionAxiom(typeCls, individual));
         } else {
           // If the class is null, assume it is a class expression
           OWLClassExpression typeExpr =
-              TemplateHelper.tryParse(name, parser, type, rowNum, typeColumn);
+            TemplateHelper.tryParse(name, parser, type, rowNum, typeColumn);
           axioms.add(dataFactory.getOWLClassAssertionAxiom(typeExpr, individual));
         }
       }
@@ -1794,9 +1789,19 @@ public class Template {
       } else if (template.startsWith("DI")) {
         // Different individuals axioms
         Set<OWLIndividual> differentIndividuals =
-            TemplateHelper.getIndividuals(checker, value, split);
+          TemplateHelper.getIndividuals(checker, value, split);
         if (!differentIndividuals.isEmpty()) {
           addDifferentIndividualsAxioms(individual, differentIndividuals, row, column);
+        }
+      } else if (template.startsWith("TI ")) {
+        if (split != null) {
+          // Add the split back on for getClassExpressions
+          template = template + " SPLIT=" + split;
+        }
+        Set<OWLClassExpression> typeExpressions =
+          TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column + 1);
+        for (OWLClassExpression ce : typeExpressions) {
+          axioms.add(dataFactory.getOWLClassAssertionAxiom(ce, individual));
         }
       } else if (template.startsWith("I") && !template.startsWith("INDIVIDUAL_TYPE")) {
         // Use individual type to determine how to handle expressions
@@ -1807,15 +1812,15 @@ public class Template {
               OWLObjectProperty objectProperty = checker.getOWLObjectProperty(propStr);
               if (objectProperty != null) {
                 Set<OWLIndividual> otherIndividuals =
-                    TemplateHelper.getIndividuals(checker, value, split);
+                  TemplateHelper.getIndividuals(checker, value, split);
                 addObjectPropertyAssertionAxioms(
-                    individual, otherIndividuals, objectProperty, row, column);
+                  individual, otherIndividuals, objectProperty, row, column);
                 break;
               }
               OWLDataProperty dataProperty = checker.getOWLDataProperty(propStr);
               if (dataProperty != null) {
                 Set<OWLLiteral> literals =
-                    TemplateHelper.getLiterals(name, checker, value, split, rowNum, column);
+                  TemplateHelper.getLiterals(name, checker, value, split, rowNum, column);
                 addDataPropertyAssertionAxioms(individual, literals, dataProperty, row, column);
                 break;
               }
@@ -1823,27 +1828,27 @@ public class Template {
             break;
           case "same":
             Set<OWLIndividual> sameIndividuals =
-                TemplateHelper.getIndividuals(checker, value, split);
+              TemplateHelper.getIndividuals(checker, value, split);
             if (!sameIndividuals.isEmpty()) {
               addSameIndividualsAxioms(individual, sameIndividuals, row, column);
             }
             break;
           case "different":
             Set<OWLIndividual> differentIndividuals =
-                TemplateHelper.getIndividuals(checker, value, split);
+              TemplateHelper.getIndividuals(checker, value, split);
             if (!differentIndividuals.isEmpty()) {
               addDifferentIndividualsAxioms(individual, differentIndividuals, row, column);
             }
             break;
           default:
             throw new RowParseException(
-                String.format(
-                    individualTypeError,
-                    iri.getShortForm(),
-                    individualType,
-                    rowNum,
-                    column + 1,
-                    name));
+              String.format(
+                individualTypeError,
+                iri.getShortForm(),
+                individualType,
+                rowNum,
+                column + 1,
+                name));
         }
       }
     }
@@ -1862,19 +1867,19 @@ public class Template {
    * @throws Exception on problem handling axiom annotations
    */
   private void addObjectPropertyAssertionAxioms(
-      OWLNamedIndividual individual,
-      Set<OWLIndividual> otherIndividuals,
-      OWLObjectPropertyExpression expression,
-      List<String> row,
-      int column)
-      throws Exception {
+    OWLNamedIndividual individual,
+    Set<OWLIndividual> otherIndividuals,
+    OWLObjectPropertyExpression expression,
+    List<String> row,
+    int column)
+    throws Exception {
     // Maybe get an annotation on the subproperty axiom
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
     for (OWLIndividual other : otherIndividuals) {
       axioms.add(
-          dataFactory.getOWLObjectPropertyAssertionAxiom(
-              expression, individual, other, axiomAnnotations));
+        dataFactory.getOWLObjectPropertyAssertionAxiom(
+          expression, individual, other, axiomAnnotations));
     }
   }
 
@@ -1891,19 +1896,19 @@ public class Template {
    * @throws Exception on problem handling axiom annotations
    */
   private void addDataPropertyAssertionAxioms(
-      OWLNamedIndividual individual,
-      Set<OWLLiteral> literals,
-      OWLDataPropertyExpression expression,
-      List<String> row,
-      int column)
-      throws Exception {
+    OWLNamedIndividual individual,
+    Set<OWLLiteral> literals,
+    OWLDataPropertyExpression expression,
+    List<String> row,
+    int column)
+    throws Exception {
     // Maybe get an annotation on the subproperty axiom
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
     for (OWLLiteral lit : literals) {
       axioms.add(
-          dataFactory.getOWLDataPropertyAssertionAxiom(
-              expression, individual, lit, axiomAnnotations));
+        dataFactory.getOWLDataPropertyAssertionAxiom(
+          expression, individual, lit, axiomAnnotations));
     }
   }
 
@@ -1918,11 +1923,11 @@ public class Template {
    * @throws Exception on problem handling axiom annotations
    */
   private void addSameIndividualsAxioms(
-      OWLNamedIndividual individual,
-      Set<OWLIndividual> sameIndividuals,
-      List<String> row,
-      int column)
-      throws Exception {
+    OWLNamedIndividual individual,
+    Set<OWLIndividual> sameIndividuals,
+    List<String> row,
+    int column)
+    throws Exception {
     // Maybe get an annotation on the subproperty axiom
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
@@ -1942,11 +1947,11 @@ public class Template {
    * @throws Exception on problem handling axiom annotations
    */
   private void addDifferentIndividualsAxioms(
-      OWLNamedIndividual individual,
-      Set<OWLIndividual> differentIndividuals,
-      List<String> row,
-      int column)
-      throws Exception {
+    OWLNamedIndividual individual,
+    Set<OWLIndividual> differentIndividuals,
+    List<String> row,
+    int column)
+    throws Exception {
     // Maybe get an annotation on the subproperty axiom
     Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
 
@@ -1969,27 +1974,78 @@ public class Template {
    * @throws Exception on issue getting OWLAnnotations
    */
   private Set<OWLAnnotation> getAnnotations(
-      String template, String value, List<String> row, int column) throws Exception {
+    String template, String value, List<String> row, int column) throws Exception {
     if (value == null || value.trim().equals("")) {
       return new HashSet<>();
     }
 
     Set<OWLAnnotation> annotations =
-        TemplateHelper.getAnnotations(name, checker, template, value, rowNum, column);
+      TemplateHelper.getAnnotations(name, checker, template, value, rowNum, column);
 
     // Maybe get an annotation on the annotation
-    Set<OWLAnnotation> axiomAnnotations = maybeGetAxiomAnnotations(row, column);
-    if (axiomAnnotations.isEmpty()) {
-      // No annotations to add
-      return annotations;
+    String nextTemplate;
+    try {
+      nextTemplate = templates.get(column + 1);
+    } catch (IndexOutOfBoundsException e) {
+      nextTemplate = null;
     }
 
-    // Add annotations and return fixed set
-    Set<OWLAnnotation> fixedAnnotations = new HashSet<>();
-    for (OWLAnnotation annotation : annotations) {
-      fixedAnnotations.add(annotation.getAnnotatedAnnotation(axiomAnnotations));
+    // Handle axiom annotations
+    if (nextTemplate != null && !nextTemplate.trim().isEmpty() && nextTemplate.startsWith(">A")) {
+      nextTemplate = nextTemplate.substring(1);
+      String nextValue;
+      try {
+        nextValue = row.get(column + 1);
+      } catch (IndexOutOfBoundsException e) {
+        nextValue = null;
+      }
+      if (nextValue != null && !nextValue.trim().equals("")) {
+        Set<OWLAnnotation> nextAnnotations =
+          TemplateHelper.getAnnotations(name, checker, nextTemplate, nextValue, rowNum, column);
+        Set<OWLAnnotation> fixedAnnotations = new HashSet<>();
+        for (OWLAnnotation annotation : annotations) {
+          fixedAnnotations.add(annotation.getAnnotatedAnnotation(nextAnnotations));
+        }
+        // Replace the annotation set with the annotated annotations
+        annotations = fixedAnnotations;
+      }
     }
-    return fixedAnnotations;
+
+    return annotations;
+  }
+
+  /**
+   * Given a row as a list of strings, the template string, and the number of the next column, maybe
+   * get axiom annotations on existing axiom annotations.
+   *
+   * @param row list of strings
+   * @param template template string for the column
+   * @param nextColumn next column number
+   * @return set of OWLAnnotations, or an empty set
+   * @throws Exception on issue getting the OWLAnnotations
+   */
+  private Set<OWLAnnotation> getAxiomAnnotations(List<String> row, String template, int nextColumn)
+    throws Exception {
+    Set<OWLAnnotation> annotations = new HashSet<>();
+    if (template.startsWith(">C")) {
+      logger.warn(
+        String.format(
+          ">A* should be used for all axiom annotations\n(Template '%s' in column %d)",
+          template, nextColumn));
+    }
+    template = template.substring(1);
+    String nextValue;
+    try {
+      nextValue = row.get(nextColumn);
+    } catch (IndexOutOfBoundsException e) {
+      nextValue = null;
+    }
+    if (nextValue == null || nextValue.trim().equals("")) {
+      return annotations;
+    }
+    annotations.addAll(
+      TemplateHelper.getAnnotations(name, checker, template, nextValue, rowNum, nextColumn));
+    return annotations;
   }
 
   /**
@@ -2003,80 +2059,22 @@ public class Template {
    * @throws Exception on issue getting the OWLAnnotations
    */
   private Set<OWLAnnotation> maybeGetAxiomAnnotations(List<String> row, int column)
-      throws Exception {
-    Map<Integer, List<Integer>> annotationsPlusAnnotations = new HashMap<>();
-    int lastAnnotation = -1;
-    while (column < row.size() - 1) {
-      column++;
-      // Row might be longer than column
-      // That's OK, just skip it
-      String template;
-      try {
-        template = templates.get(column);
-      } catch (IndexOutOfBoundsException e) {
-        break;
-      }
-      Matcher m = Pattern.compile("^>.*").matcher(template);
-      if (m.matches()) {
-
-        m = Pattern.compile("^>[^>].*").matcher(template);
-        if (m.matches()) {
-          // This is an annotation on the original axiom
-          lastAnnotation = column;
-          annotationsPlusAnnotations.put(column, new ArrayList<>());
-        }
-
-        m = Pattern.compile("^>>.*").matcher(template);
-        if (m.matches()) {
-          // This is an annotation on the last axiom annotation
-          // Update the map
-          List<Integer> cols = annotationsPlusAnnotations.get(lastAnnotation);
-          cols.add(column);
-          annotationsPlusAnnotations.put(lastAnnotation, cols);
-        }
-      } else {
-        // We are done getting the annotations
-        break;
-      }
+    throws Exception {
+    // Look at the template string of the next column
+    String nextTemplate;
+    try {
+      nextTemplate = templates.get(column + 1);
+    } catch (IndexOutOfBoundsException e) {
+      nextTemplate = null;
     }
 
-    Set<OWLAnnotation> annotations = new HashSet<>();
-    for (Map.Entry<Integer, List<Integer>> annPlusAnns : annotationsPlusAnnotations.entrySet()) {
-      int annColumn = annPlusAnns.getKey();
-      List<Integer> moreAnns = annPlusAnns.getValue();
-
-      String template = templates.get(annColumn);
-      String value = row.get(annColumn).trim();
-      if (value.isEmpty()) {
-        continue;
-      }
-      Set<OWLAnnotation> firstAnnotations =
-          TemplateHelper.getAnnotations(name, checker, template, value, rowNum, annColumn);
-
-      if (moreAnns.isEmpty()) {
-        annotations.addAll(firstAnnotations);
-        continue;
-      }
-
-      Set<OWLAnnotation> moreAnnotations = new HashSet<>();
-      for (int m : moreAnns) {
-        template = templates.get(m);
-        while (template.startsWith(">")) {
-          template = template.substring(1);
-        }
-        value = row.get(m).trim();
-        if (value.isEmpty()) {
-          continue;
-        }
-        moreAnnotations.addAll(
-            TemplateHelper.getAnnotations(name, checker, template, value, rowNum, annColumn));
-      }
-
-      for (OWLAnnotation f : firstAnnotations) {
-        annotations.add(f.getAnnotatedAnnotation(moreAnnotations));
-      }
+    Set<OWLAnnotation> axiomAnnotations = new HashSet<>();
+    // If the next template string is not null, not empty, and it starts with >
+    // Get the axiom annotations from the row
+    if (nextTemplate != null && !nextTemplate.trim().isEmpty() && (nextTemplate.startsWith(">"))) {
+      axiomAnnotations = getAxiomAnnotations(row, nextTemplate, column + 1);
     }
-    return annotations;
+    return axiomAnnotations;
   }
 
   /**

--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
@@ -1,15 +1,8 @@
 package org.obolibrary.robot;
 
 import com.google.common.collect.Sets;
-import com.opencsv.CSVParserBuilder;
-import com.opencsv.CSVReader;
-import com.opencsv.CSVReaderBuilder;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
+import com.opencsv.*;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -54,50 +47,50 @@ public class TemplateHelper {
   /**
    * Error message when annotation property cannot be resolved. Expects: annotation property name.
    */
-  private static final String annotationPropertyError =
-      NS + "ANNOTATION PROPERTY ERROR could not handle annotation property: %s";
+  static final String annotationPropertyError =
+    NS + "ANNOTATION PROPERTY ERROR could not handle annotation property: %s";
 
   /** Error message when a given class expression is not able to be parsed. */
   protected static final String manchesterParseError =
-      NS
-          + "MANCHESTER PARSE ERROR the expression '%s' at row %d, column %d in table \"%s\" cannot be parsed: %s";
+    NS
+      + "MANCHESTER PARSE ERROR the expression '%s' at row %d, column %d in table \"%s\" cannot be parsed: %s";
 
   /** Error message when the CLASS_TYPE is not subclass or equivalent. */
   private static final String classTypeError =
-      NS + "CLASS TYPE ERROR '%s' is not a valid CLASS_TYPE";
+    NS + "CLASS TYPE ERROR '%s' is not a valid CLASS_TYPE";
 
   /** Error message when datatype cannot be resolved. Expects: datatype name. */
   private static final String datatypeError =
-      NS + "DATATYPE ERROR could not find datatype for '%s' at row %d, column %d in table \"%s\".";
+    NS + "DATATYPE ERROR could not find datatype for '%s' at row %d, column %d in table \"%s\".";
 
   /** Error message when template file type is not CSV, TSV, or TAB. Expects: file name. */
   private static final String fileTypeError = NS + "FILE TYPE ERROR unrecognized file type for: %s";
 
   /** Error message when the template does not have an ID column. Expects: table name. */
-  private static final String idError = NS + "ID ERROR an \"ID\" column is required in table %s";
+  static final String idError = NS + "ID ERROR an \"ID\" column is required in table %s";
 
   /** Error message when the IRI in an IRI annotation cannot be resolved. Expects: value. */
   private static final String iriError =
-      NS + "IRI ERROR could not create IRI annotation at row %d, column %d in table \"%s\": %s";
+    NS + "IRI ERROR could not create IRI annotation at row %d, column %d in table \"%s\": %s";
 
   /**
    * Error message when a language annotation string does not include "@{lang}". Expects: template
    * string
    */
-  private static final String languageFormatError =
-      NS
-          + "LANGUAGE FORMAT ERROR invalid language annotation template string at column %d in table \"%s\": %s";
+  static final String languageFormatError =
+    NS
+      + "LANGUAGE FORMAT ERROR invalid language annotation template string at column %d in table \"%s\": %s";
 
   /** Error message when the template file does not exist. Expects: file name. */
   private static final String templateFileError =
-      NS + "TEMPLATE FILE ERROR template %s does not exist";
+    NS + "TEMPLATE FILE ERROR template %s does not exist";
 
   /**
    * Error message when a language annotation string does not include "^^{type}". Expects: template
    * string
    */
-  private static final String typedFormatError =
-      NS + "TYPED FORMAT ERROR invalid typed annotation string at column %d in table \"%s\": %s";
+  static final String typedFormatError =
+    NS + "TYPED FORMAT ERROR invalid typed annotation string at column %d in table \"%s\": %s";
 
   /* OWL entity type IRIs */
 
@@ -124,7 +117,7 @@ public class TemplateHelper {
    * @throws RowParseException if property cannot be found or created
    */
   public static Set<OWLAnnotationProperty> getAnnotationProperties(
-      QuotedEntityChecker checker, String value, String split) throws Exception {
+    QuotedEntityChecker checker, String value, String split) throws Exception {
     List<String> allValues = getAllValues(value, split);
 
     Set<OWLAnnotationProperty> properties = new HashSet<>();
@@ -145,7 +138,7 @@ public class TemplateHelper {
    * @throws RowParseException if the name cannot be resolved
    */
   public static OWLAnnotationProperty getAnnotationProperty(
-      QuotedEntityChecker checker, String name) throws Exception {
+    QuotedEntityChecker checker, String name) throws Exception {
     OWLAnnotationProperty property = checker.getOWLAnnotationProperty(name);
     if (property != null) {
       return property;
@@ -164,7 +157,7 @@ public class TemplateHelper {
    */
   @Deprecated
   public static OWLAnnotation getAnnotation(
-      QuotedEntityChecker checker, String template, String value) throws Exception {
+    QuotedEntityChecker checker, String template, String value) throws Exception {
     if (template.startsWith("A ")) {
       return getStringAnnotation(checker, template, value);
     } else if (template.startsWith("AT ")) {
@@ -172,15 +165,15 @@ public class TemplateHelper {
         return getTypedAnnotation(checker, template, value);
       } else {
         throw new Exception(
-            String.format("TYPED FORMAT ERROR invalid typed annotation string: %s", template));
+          String.format("TYPED FORMAT ERROR invalid typed annotation string: %s", template));
       }
     } else if (template.startsWith("AL ")) {
       if (template.contains("@")) {
         return getLanguageAnnotation(checker, template, value);
       } else {
         throw new Exception(
-            String.format(
-                "LANGUAGE FORMAT ERROR invalid language annotation template string: %s", template));
+          String.format(
+            "LANGUAGE FORMAT ERROR invalid language annotation template string: %s", template));
       }
     } else if (template.startsWith("AI ")) {
       return getIRIAnnotation(checker, template, value);
@@ -203,12 +196,12 @@ public class TemplateHelper {
    */
   @Deprecated
   public static OWLAnnotation getAnnotation(
-      String tableName,
-      QuotedEntityChecker checker,
-      IOHelper ioHelper,
-      String template,
-      String value)
-      throws Exception {
+    String tableName,
+    QuotedEntityChecker checker,
+    IOHelper ioHelper,
+    String template,
+    String value)
+    throws Exception {
     if (template.startsWith("A ")) {
       return getStringAnnotation(checker, template, value);
     } else if (template.startsWith("AT ")) {
@@ -216,15 +209,15 @@ public class TemplateHelper {
         return getTypedAnnotation(checker, template, value);
       } else {
         throw new Exception(
-            String.format("TYPED FORMAT ERROR invalid typed annotation string: %s", template));
+          String.format("TYPED FORMAT ERROR invalid typed annotation string: %s", template));
       }
     } else if (template.startsWith("AL ")) {
       if (template.contains("@")) {
         return getLanguageAnnotation(checker, template, value);
       } else {
         throw new Exception(
-            String.format(
-                "LANGUAGE FORMAT ERROR invalid language annotation template string: %s", template));
+          String.format(
+            "LANGUAGE FORMAT ERROR invalid language annotation template string: %s", template));
       }
     } else if (template.startsWith("AI ")) {
       IRI iri = ioHelper.createIRI(value);
@@ -251,8 +244,8 @@ public class TemplateHelper {
    */
   @Deprecated
   public static OWLAnnotation getAnnotation(
-      QuotedEntityChecker checker, IOHelper ioHelper, String template, String value)
-      throws Exception {
+    QuotedEntityChecker checker, IOHelper ioHelper, String template, String value)
+    throws Exception {
     if (template.startsWith("A ")) {
       return getStringAnnotation(checker, template, value);
     } else if (template.startsWith("AT ")) {
@@ -294,13 +287,13 @@ public class TemplateHelper {
    * @throws ColumnException if a header annotation template cannot be parsed
    */
   public static Set<OWLAnnotation> getAnnotations(
-      String tableName,
-      QuotedEntityChecker checker,
-      String template,
-      String value,
-      int rowNum,
-      int column)
-      throws Exception {
+    String tableName,
+    QuotedEntityChecker checker,
+    String template,
+    String value,
+    int rowNum,
+    int column)
+    throws Exception {
     String split = getSplit(template);
     template = getTemplate(template);
 
@@ -358,13 +351,13 @@ public class TemplateHelper {
    * @throws RowParseException if row is malformed
    */
   public static Set<OWLClassExpression> getClassExpressions(
-      String tableName,
-      ManchesterOWLSyntaxClassExpressionParser parser,
-      String template,
-      String value,
-      int rowNum,
-      int col)
-      throws RowParseException {
+    String tableName,
+    ManchesterOWLSyntaxClassExpressionParser parser,
+    String template,
+    String value,
+    int rowNum,
+    int col)
+    throws RowParseException {
     String split = getSplit(template);
     template = getTemplate(template);
 
@@ -410,20 +403,20 @@ public class TemplateHelper {
    * @throws RowParseException if row is malformed
    */
   public static Set<OWLDataPropertyExpression> getDataPropertyExpressions(
-      String tableName,
-      QuotedEntityChecker checker,
-      String template,
-      String value,
-      int rowNum,
-      int column)
-      throws RowParseException {
+    String tableName,
+    QuotedEntityChecker checker,
+    String template,
+    String value,
+    int rowNum,
+    int column)
+    throws RowParseException {
     String split = getSplit(template);
     template = getTemplate(template);
 
     // Create a parser
     ManchesterOWLSyntaxParser parser =
-        new ManchesterOWLSyntaxParserImpl(
-            OWLOntologyLoaderConfiguration::new, OWLManager.getOWLDataFactory());
+      new ManchesterOWLSyntaxParserImpl(
+        OWLOntologyLoaderConfiguration::new, OWLManager.getOWLDataFactory());
     parser.setOWLEntityChecker(checker);
 
     // Maybe split values
@@ -449,7 +442,7 @@ public class TemplateHelper {
         } catch (OWLParserException e) {
           String cause = getManchesterErrorCause(e);
           throw new RowParseException(
-              String.format(manchesterParseError, sub, rowNum, column + 1, tableName, cause));
+            String.format(manchesterParseError, sub, rowNum, column + 1, tableName, cause));
         }
       }
     }
@@ -469,8 +462,8 @@ public class TemplateHelper {
    * @throws RowParseException if the name cannot be resolved
    */
   public static OWLDatatype getDatatype(
-      String tableName, QuotedEntityChecker checker, String name, int rowNum, int column)
-      throws RowParseException {
+    String tableName, QuotedEntityChecker checker, String name, int rowNum, int column)
+    throws RowParseException {
     OWLDatatype datatype = checker.getOWLDatatype(name);
     if (datatype != null) {
       return datatype;
@@ -503,13 +496,13 @@ public class TemplateHelper {
    * @throws RowParseException if datatype cannot be found or created
    */
   public static Set<OWLDatatype> getDatatypes(
-      String tableName,
-      QuotedEntityChecker checker,
-      String value,
-      String split,
-      int rowNum,
-      int column)
-      throws RowParseException {
+    String tableName,
+    QuotedEntityChecker checker,
+    String value,
+    String split,
+    int rowNum,
+    int column)
+    throws RowParseException {
     List<String> allValues = getAllValues(value, split);
 
     Set<OWLDatatype> datatypes = new HashSet<>();
@@ -531,7 +524,7 @@ public class TemplateHelper {
    * @return set of OWLIndividuals
    */
   public static Set<OWLIndividual> getIndividuals(
-      QuotedEntityChecker checker, String value, String split) {
+    QuotedEntityChecker checker, String value, String split) {
     if (value == null || value.trim().isEmpty()) {
       return new HashSet<>();
     }
@@ -558,7 +551,7 @@ public class TemplateHelper {
    *     created
    */
   public static OWLAnnotation getIRIAnnotation(
-      QuotedEntityChecker checker, String template, String value) throws Exception {
+    QuotedEntityChecker checker, String template, String value) throws Exception {
     IRI iri = checker.getIRI(value, true);
     if (iri == null) {
       return null;
@@ -577,7 +570,7 @@ public class TemplateHelper {
    * @throws RowParseException if the annotation property cannot be found
    */
   public static OWLAnnotation getIRIAnnotation(
-      QuotedEntityChecker checker, String template, IRI value) throws Exception {
+    QuotedEntityChecker checker, String template, IRI value) throws Exception {
     String name = template.substring(2).trim();
     OWLAnnotationProperty property = getAnnotationProperty(checker, name);
     return dataFactory.getOWLAnnotation(property, value);
@@ -592,7 +585,7 @@ public class TemplateHelper {
    * @throws ColumnException when an ID column does not exist
    */
   public static List<IRI> getIRIs(Map<String, List<List<String>>> tables, IOHelper ioHelper)
-      throws Exception {
+    throws Exception {
     List<IRI> iris = new ArrayList<>();
     for (Map.Entry<String, List<List<String>>> table : tables.entrySet()) {
       String tableName = table.getKey();
@@ -612,7 +605,7 @@ public class TemplateHelper {
    * @throws ColumnException when an ID column does not exist
    */
   public static List<IRI> getIRIs(String tableName, List<List<String>> rows, IOHelper ioHelper)
-      throws Exception {
+    throws Exception {
     // Find the ID column.
     List<String> templates = rows.get(1);
     int idColumn = -1;
@@ -664,7 +657,7 @@ public class TemplateHelper {
    */
   @Deprecated
   public static OWLAnnotation getLanguageAnnotation(
-      QuotedEntityChecker checker, String template, String value) throws Exception {
+    QuotedEntityChecker checker, String template, String value) throws Exception {
     OWLAnnotationProperty property = getAnnotationProperty(checker, template, "@");
     String lang = template.substring(template.indexOf("@") + 1).trim();
     return dataFactory.getOWLAnnotation(property, dataFactory.getOWLLiteral(value, lang));
@@ -682,7 +675,7 @@ public class TemplateHelper {
    * @throws RowParseException if the annotation property cannot be found
    */
   public static Set<OWLAnnotation> getLanguageAnnotations(
-      QuotedEntityChecker checker, String template, String split, String value) throws Exception {
+    QuotedEntityChecker checker, String template, String split, String value) throws Exception {
     OWLAnnotationProperty property = getAnnotationProperty(checker, template, "@");
     String lang = template.substring(template.indexOf("@") + 1).trim();
 
@@ -710,13 +703,13 @@ public class TemplateHelper {
    * @throws RowParseException if row is malformed
    */
   public static Set<OWLLiteral> getLiterals(
-      String tableName,
-      QuotedEntityChecker checker,
-      String value,
-      String split,
-      int rowNum,
-      int column)
-      throws RowParseException {
+    String tableName,
+    QuotedEntityChecker checker,
+    String value,
+    String split,
+    int rowNum,
+    int column)
+    throws RowParseException {
     Set<OWLLiteral> literals = new HashSet<>();
     List<String> allValues = getAllValues(value, split);
 
@@ -750,21 +743,21 @@ public class TemplateHelper {
    * @throws RowParseException if row is malformed
    */
   public static Set<OWLObjectPropertyExpression> getObjectPropertyExpressions(
-      String tableName,
-      QuotedEntityChecker checker,
-      String template,
-      String value,
-      int rowNum,
-      int column)
-      throws RowParseException {
+    String tableName,
+    QuotedEntityChecker checker,
+    String template,
+    String value,
+    int rowNum,
+    int column)
+    throws RowParseException {
     String split = getSplit(template);
     template = getTemplate(template);
 
     // Create a parser
 
     ManchesterOWLSyntaxParser parser =
-        new ManchesterOWLSyntaxParserImpl(
-            new OWLAPIConfigProvider(), OWLManager.getOWLDataFactory());
+      new ManchesterOWLSyntaxParserImpl(
+        new OWLAPIConfigProvider(), OWLManager.getOWLDataFactory());
     parser.setOWLEntityChecker(checker);
 
     // Maybe split values
@@ -790,7 +783,7 @@ public class TemplateHelper {
         } catch (OWLParserException e) {
           String cause = getManchesterErrorCause(e);
           throw new RowParseException(
-              String.format(manchesterParseError, sub, rowNum, column + 1, tableName, cause));
+            String.format(manchesterParseError, sub, rowNum, column + 1, tableName, cause));
         }
       }
     }
@@ -810,7 +803,7 @@ public class TemplateHelper {
    */
   @Deprecated
   public static OWLAnnotation getStringAnnotation(
-      QuotedEntityChecker checker, String template, String value) throws Exception {
+    QuotedEntityChecker checker, String template, String value) throws Exception {
     String name = template.substring(1).trim();
     OWLAnnotationProperty property = getAnnotationProperty(checker, name);
     return dataFactory.getOWLAnnotation(property, dataFactory.getOWLLiteral(value));
@@ -827,7 +820,7 @@ public class TemplateHelper {
    * @throws RowParseException if the annotation property cannot be found
    */
   public static Set<OWLAnnotation> getStringAnnotations(
-      QuotedEntityChecker checker, String template, String split, String value) throws Exception {
+    QuotedEntityChecker checker, String template, String split, String value) throws Exception {
 
     OWLAnnotationProperty property;
     if (template.equals("LABEL")) {
@@ -864,7 +857,7 @@ public class TemplateHelper {
    */
   @Deprecated
   public static OWLAnnotation getTypedAnnotation(
-      QuotedEntityChecker checker, String template, String value) throws Exception {
+    QuotedEntityChecker checker, String template, String value) throws Exception {
     OWLAnnotationProperty property = getAnnotationProperty(checker, template, "^^");
     String typeName = template.substring(template.indexOf("^^") + 2).trim();
     OWLDatatype datatype = getDatatype(checker, typeName);
@@ -886,14 +879,14 @@ public class TemplateHelper {
    * @throws RowParseException if the annotation property cannot be found
    */
   public static Set<OWLAnnotation> getTypedAnnotations(
-      String tableName,
-      QuotedEntityChecker checker,
-      String template,
-      String split,
-      String value,
-      int rowNum,
-      int column)
-      throws Exception {
+    String tableName,
+    QuotedEntityChecker checker,
+    String template,
+    String split,
+    String value,
+    int rowNum,
+    int column)
+    throws Exception {
     OWLAnnotationProperty property = getAnnotationProperty(checker, template, "^^");
     String typeName = template.substring(template.indexOf("^^") + 2).trim();
     OWLDatatype datatype = getDatatype(tableName, checker, typeName, rowNum, column);
@@ -903,11 +896,11 @@ public class TemplateHelper {
       String[] values = value.split(Pattern.quote(split));
       for (String v : values) {
         annotations.add(
-            dataFactory.getOWLAnnotation(property, dataFactory.getOWLLiteral(v, datatype)));
+          dataFactory.getOWLAnnotation(property, dataFactory.getOWLLiteral(v, datatype)));
       }
     } else {
       annotations.add(
-          dataFactory.getOWLAnnotation(property, dataFactory.getOWLLiteral(value, datatype)));
+        dataFactory.getOWLAnnotation(property, dataFactory.getOWLLiteral(value, datatype)));
     }
 
     return annotations;
@@ -1038,7 +1031,7 @@ public class TemplateHelper {
       return true;
     } else if (template.equals("LABEL")) {
       return true;
-    } else if (template.equals("TYPE")) {
+    } else if (template.matches("^TYPE( SPLIT=.+)?$")) {
       return true;
     } else if (template.equals("CLASS_TYPE")) {
       return true;
@@ -1052,9 +1045,7 @@ public class TemplateHelper {
       // CHARACTERISTIC can have a split
       // Should only be followed by SPLIT, nothing else
       return true;
-    } else if (template.matches("^INDIVIDUAL_TYPE( SPLIT=.+)?$")) {
-      // INDIVIDUAL_TYPE can have a split
-      // Should only be followed by SPLIT, nothing else
+    } else if (template.matches("^INDIVIDUAL_TYPE")) {
       return true;
     } else if (template.matches("^>{0,2}A[LTI]? .*")) {
       // Annotations can have one or two > (nested)
@@ -1069,9 +1060,56 @@ public class TemplateHelper {
       return true;
     } else
       // Individuals can be I, II (does not need to be followed by space), SI, or DI
-      return template.matches("^(I .*|II.?|[SD]I .*)");
+      return template.matches("^(I .*|II.?|[TSD]I .*)");
 
     // TODO - future support for DT datatype axioms
+  }
+
+  /**
+   * @param path
+   * @param rows
+   * @throws IOException
+   */
+  public static void writeTable(String path, List<List<String>> rows) throws IOException {
+    File file = new File(path);
+    String extension = FilenameUtils.getExtension(file.getName());
+    switch (extension) {
+      case "csv":
+        writeXSV(new FileWriter(path), ',', rows);
+        break;
+      case "tsv":
+      case "tab":
+        writeXSV(new FileWriter(path), '\t', rows);
+        break;
+      default:
+        throw new IOException(String.format(fileTypeError, path));
+    }
+  }
+
+  /**
+   * Given a tempalte string, return the split character if it exists.
+   *
+   * @param template template string
+   * @return split character or null
+   */
+  protected static String getSplit(String template) {
+    if (template.contains("SPLIT=")) {
+      return template.substring(template.indexOf("SPLIT=") + 6).trim();
+    }
+    return null;
+  }
+
+  /**
+   * Given a template string, return the template without a split (if it exists).
+   *
+   * @param template template string
+   * @return template string, maybe without SPLIT
+   */
+  protected static String getTemplate(String template) {
+    if (template.contains("SPLIT=")) {
+      return template.substring(0, template.indexOf("SPLIT=")).trim();
+    }
+    return template.trim();
   }
 
   /**
@@ -1087,12 +1125,12 @@ public class TemplateHelper {
    * @throws RowParseException if string cannot be parsed for any reason
    */
   protected static OWLClassExpression tryParse(
-      String tableName,
-      ManchesterOWLSyntaxClassExpressionParser parser,
-      String content,
-      int rowNum,
-      int column)
-      throws RowParseException {
+    String tableName,
+    ManchesterOWLSyntaxClassExpressionParser parser,
+    String content,
+    int rowNum,
+    int column)
+    throws RowParseException {
     OWLClassExpression expr;
     content = content.trim();
     logger.info(String.format("Parsing expression: %s", content));
@@ -1101,7 +1139,7 @@ public class TemplateHelper {
     } catch (OWLParserException e) {
       String cause = getManchesterErrorCause(e);
       throw new RowParseException(
-          String.format(manchesterParseError, content, rowNum, column + 1, tableName, cause));
+        String.format(manchesterParseError, content, rowNum, column + 1, tableName, cause));
     }
     return expr;
   }
@@ -1161,7 +1199,7 @@ public class TemplateHelper {
    * @throws RowParseException on issue resolving property
    */
   private static OWLAnnotationProperty getAnnotationProperty(
-      QuotedEntityChecker checker, String template, String chr) throws Exception {
+    QuotedEntityChecker checker, String template, String chr) throws Exception {
     template = template.substring(2).trim();
     String name = template.substring(0, template.indexOf(chr)).trim();
     return getAnnotationProperty(checker, name);
@@ -1180,14 +1218,16 @@ public class TemplateHelper {
    * @return OWLClassExpression from template
    * @throws RowParseException on issue resolving names
    */
-  private static OWLClassExpression getClassExpression(
-      String tableName,
-      String template,
-      String value,
-      ManchesterOWLSyntaxClassExpressionParser parser,
-      int rowNum,
-      int col)
-      throws RowParseException {
+  protected static OWLClassExpression getClassExpression(
+    String tableName,
+    String template,
+    String value,
+    ManchesterOWLSyntaxClassExpressionParser parser,
+    int rowNum,
+    int col)
+    throws RowParseException {
+    System.out.println(template);
+    System.out.println(value);
     String content = QuotedEntityChecker.wrap(value);
     // Get the template without identifier by breaking on the first space
     String sub;
@@ -1196,33 +1236,9 @@ public class TemplateHelper {
     } else {
       sub = content;
     }
-    return tryParse(tableName, parser, sub, rowNum, col);
-  }
-
-  /**
-   * Given a tempalte string, return the split character if it exists.
-   *
-   * @param template template string
-   * @return split character or null
-   */
-  private static String getSplit(String template) {
-    if (template.contains("SPLIT=")) {
-      return template.substring(template.indexOf("SPLIT=") + 6).trim();
-    }
-    return null;
-  }
-
-  /**
-   * Given a template string, return the template without a split (if it exists).
-   *
-   * @param template template string
-   * @return template string, maybe without SPLIT
-   */
-  private static String getTemplate(String template) {
-    if (template.contains("SPLIT=")) {
-      return template.substring(0, template.indexOf("SPLIT=")).trim();
-    }
-    return template.trim();
+    OWLClassExpression ce = tryParse(tableName, parser, sub, rowNum, col);
+    System.out.println(ce);
+    return ce;
   }
 
   /**
@@ -1238,13 +1254,13 @@ public class TemplateHelper {
    * @throws RowParseException if entities cannot be resolved
    */
   private static OWLAnnotation maybeGetIRIAnnotation(
-      String tableName,
-      QuotedEntityChecker checker,
-      String template,
-      String value,
-      int rowNum,
-      int column)
-      throws Exception {
+    String tableName,
+    QuotedEntityChecker checker,
+    String template,
+    String value,
+    int rowNum,
+    int column)
+    throws Exception {
     IRI iri = checker.getIRI(value, true);
     if (iri != null) {
       return getIRIAnnotation(checker, template, iri);
@@ -1263,15 +1279,39 @@ public class TemplateHelper {
    */
   private static List<List<String>> readXSV(Reader reader, char separator) throws IOException {
     CSVReader csv =
-        new CSVReaderBuilder(reader)
-            .withCSVParser(new CSVParserBuilder().withSeparator(separator).build())
-            .build();
+      new CSVReaderBuilder(reader)
+        .withCSVParser(new CSVParserBuilder().withSeparator(separator).build())
+        .build();
     List<List<String>> rows = new ArrayList<>();
     for (String[] nextLine : csv) {
       rows.add(new ArrayList<>(Arrays.asList(nextLine)));
     }
     csv.close();
     return rows;
+  }
+
+  /**
+   * @param writer
+   * @param separator
+   * @param rows
+   * @throws IOException
+   */
+  private static void writeXSV(FileWriter writer, char separator, List<List<String>> rows)
+    throws IOException {
+    ICSVWriter csv =
+      new CSVWriterBuilder(writer)
+        .withSeparator(separator)
+        .withLineEnd("\n")
+        .withQuoteChar('"')
+        .build();
+
+    List<String[]> writerRows = new ArrayList<>();
+    for (List<String> row : rows) {
+      String[] array = row.toArray(new String[0]);
+      writerRows.add(array);
+    }
+    csv.writeAll(writerRows);
+    csv.close();
   }
 
   /**
@@ -1287,9 +1327,9 @@ public class TemplateHelper {
    */
   @Deprecated
   public static Set<OWLAnnotationAssertionAxiom> getAnnotationAxioms(
-      OWLEntity entity,
-      Set<OWLAnnotation> annotations,
-      Map<OWLAnnotation, Map<OWLAnnotation, Set<OWLAnnotation>>> nested) {
+    OWLEntity entity,
+    Set<OWLAnnotation> annotations,
+    Map<OWLAnnotation, Map<OWLAnnotation, Set<OWLAnnotation>>> nested) {
     Set<OWLAnnotationAssertionAxiom> axioms = new HashSet<>();
     // Create basic annotations
     for (OWLAnnotation annotation : annotations) {
@@ -1297,12 +1337,12 @@ public class TemplateHelper {
     }
     // Create annotations with axiom annotations
     for (Entry<OWLAnnotation, Map<OWLAnnotation, Set<OWLAnnotation>>> annotationPlusAxioms :
-        nested.entrySet()) {
+      nested.entrySet()) {
       OWLAnnotation annotation = annotationPlusAxioms.getKey();
       Set<OWLAnnotation> axiomAnnotations = new HashSet<>();
       // For each annotation with its axiom annotations ...
       for (Entry<OWLAnnotation, Set<OWLAnnotation>> nestedSet :
-          annotationPlusAxioms.getValue().entrySet()) {
+        annotationPlusAxioms.getValue().entrySet()) {
         OWLAnnotation axiomAnnotation = nestedSet.getKey();
         // Check if there are annotations on the axiom annotations, and add those
         Set<OWLAnnotation> axiomAnnotationAnnotations = nestedSet.getValue();
@@ -1312,12 +1352,12 @@ public class TemplateHelper {
           OWLAnnotationProperty property = axiomAnnotation.getProperty();
           OWLAnnotationValue value = axiomAnnotation.getValue();
           axiomAnnotations.add(
-              dataFactory.getOWLAnnotation(property, value, axiomAnnotationAnnotations));
+            dataFactory.getOWLAnnotation(property, value, axiomAnnotationAnnotations));
         }
       }
       axioms.add(
-          dataFactory.getOWLAnnotationAssertionAxiom(
-              entity.getIRI(), annotation, axiomAnnotations));
+        dataFactory.getOWLAnnotationAssertionAxiom(
+          entity.getIRI(), annotation, axiomAnnotations));
     }
     return axioms;
   }
@@ -1361,7 +1401,7 @@ public class TemplateHelper {
    */
   @Deprecated
   public static OWLEntity getEntity(
-      QuotedEntityChecker checker, IRI type, String id, String label) {
+    QuotedEntityChecker checker, IRI type, String id, String label) {
 
     IOHelper ioHelper = checker.getIOHelper();
 
@@ -1425,11 +1465,11 @@ public class TemplateHelper {
    */
   @Deprecated
   public static Set<OWLAxiom> getLogicalAxioms(
-      OWLClass cls,
-      String classType,
-      Set<OWLClassExpression> classExpressions,
-      Map<OWLClassExpression, Set<OWLAnnotation>> annotatedExpressions)
-      throws Exception {
+    OWLClass cls,
+    String classType,
+    Set<OWLClassExpression> classExpressions,
+    Map<OWLClassExpression, Set<OWLAnnotation>> annotatedExpressions)
+    throws Exception {
     Set<OWLAxiom> axioms = new HashSet<>();
     switch (classType) {
       case "subclass":
@@ -1437,21 +1477,21 @@ public class TemplateHelper {
           axioms.add(dataFactory.getOWLSubClassOfAxiom(cls, expression));
         }
         for (Entry<OWLClassExpression, Set<OWLAnnotation>> annotatedEx :
-            annotatedExpressions.entrySet()) {
+          annotatedExpressions.entrySet()) {
           axioms.add(
-              dataFactory.getOWLSubClassOfAxiom(cls, annotatedEx.getKey(), annotatedEx.getValue()));
+            dataFactory.getOWLSubClassOfAxiom(cls, annotatedEx.getKey(), annotatedEx.getValue()));
         }
         return axioms;
       case "equivalent":
         // Since it's an intersection, all annotations will be added to the same axiom
         Set<OWLAnnotation> annotations = new HashSet<>();
         for (Entry<OWLClassExpression, Set<OWLAnnotation>> annotatedEx :
-            annotatedExpressions.entrySet()) {
+          annotatedExpressions.entrySet()) {
           classExpressions.add(annotatedEx.getKey());
           annotations.addAll(annotatedEx.getValue());
         }
         OWLObjectIntersectionOf intersection =
-            dataFactory.getOWLObjectIntersectionOf(classExpressions);
+          dataFactory.getOWLObjectIntersectionOf(classExpressions);
         OWLAxiom axiom;
         if (!annotations.isEmpty()) {
           axiom = dataFactory.getOWLEquivalentClassesAxiom(cls, intersection, annotations);


### PR DESCRIPTION
### Individual Template Strings

If the `TYPE` is a defined class, `owl:Individual`, or `owl:NamedIndividual`, an instance will be created. If the `TYPE` does not include a defined class, that instance will have no class assertions (unless you use the `TI` template string to add an anonymous type). You may include a `SPLIT=` in `TYPE` if you wish to provide more than one class assertion for an individual.

- **class assertion**:
    - `TI %`: the individual will be asserted to be a type of the *class expression* in the column
- **individual assertion**:
    - `I <property>`: when creating an individual, replace property with an object property or data property to add assertions (either by label or CURIE). The value of each axiom will be the value of the cell in this column. For object property assertions, this is another individual. For data property assertions, this is a literal value. If using a property label here, **do not** wrap the label in single quotes.
    - `SI %`: the individual in the column will be asserted to be the same individual
    - `DI %`: the individual in the column will be asserted to be a different individual

#### Example of Individual Template Strings

| Label        | Entity Type | Individual Role      |Property Assertions | Different Individuals | 
| ------------ | ----------- | -------------------- |------------------- | --------------------- |
| LABEL        | TYPE        | TI 'has role' some % |I part_of           | DI %                  |
| Individual 1 | Class 1     | Role Class 1         |Individual 2        |                       |
| Individual 2 | Class 1     | Role Class 2         |                    | Individual 1          |

---

In this PR, it looks like there's a lot of noise in `Template.java` because of the formatter.