### PR TITLE
Add support for anonymous class assertions in templates

### DIFF
--- a/docs/template.md
+++ b/docs/template.md
@@ -132,8 +132,10 @@ In this template, Class 5 would be a subclass of `part_of some 'Class 4'`.
 
 ### Individual Template Strings
 
-If the `TYPE` is a defined class, `owl:Individual`, or `owl:NamedIndividual`, an instance will be created. If the `TYPE` does not include a defined class, that instance will have no class assertions. You may include a `SPLIT=` in `TYPE` if you wish to provide more than one class assertion for an individual.
+If the `TYPE` is a defined class, `owl:Individual`, or `owl:NamedIndividual`, an instance will be created. If the `TYPE` does not include a defined class, that instance will have no class assertions (unless you use the `TI` template string to add an anonymous type). You may include a `SPLIT=` in `TYPE` if you wish to provide more than one class assertion for an individual.
 
+- **class assertion**:
+    - `TI %`: the individual will be asserted to be a type of the *class expression* in the column
 - **individual assertion**:
     - `I <property>`: when creating an individual, replace property with an object property or data property to add assertions (either by label or CURIE). The value of each axiom will be the value of the cell in this column. For object property assertions, this is another individual. For data property assertions, this is a literal value. If using a property label here, **do not** wrap the label in single quotes.
     - `SI %`: the individual in the column will be asserted to be the same individual
@@ -141,11 +143,11 @@ If the `TYPE` is a defined class, `owl:Individual`, or `owl:NamedIndividual`, an
 
 #### Example of Individual Template Strings
 
-| Label        | Entity Type | Property Assertions | Different Individuals |
-| ------------ | ----------- | ------------------- | --------------------- |
-| LABEL        | TYPE        | I part_of           | DI %                  |
-| Individual 1 | Class 1     | Individual 2        |                       |
-| Individual 2 | Class 1     |                     | Individual 1          |
+| Label        | Entity Type | Individual Role      | Property Assertions | Different Individuals | 
+| ------------ | ----------- | -------------------- | ------------------- | --------------------- |
+| LABEL        | TYPE        | TI 'has role' some % | I part_of           | DI %                  |
+| Individual 1 | Class 1     | Role Class 1         | Individual 2        |                       |
+| Individual 2 | Class 1     | Role Class 2         |                     | Individual 1          |
 
 <!-- ### Datatype Template Strings -->
 

--- a/robot-core/src/main/java/org/obolibrary/robot/Template.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/Template.java
@@ -1798,6 +1798,16 @@ public class Template {
         if (!differentIndividuals.isEmpty()) {
           addDifferentIndividualsAxioms(individual, differentIndividuals, row, column);
         }
+      } else if (template.startsWith("TI ")) {
+        if (split != null) {
+          // Add the split back on for getClassExpressions
+          template = template + " SPLIT=" + split;
+        }
+        Set<OWLClassExpression> typeExpressions =
+            TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column + 1);
+        for (OWLClassExpression ce : typeExpressions) {
+          axioms.add(dataFactory.getOWLClassAssertionAxiom(ce, individual));
+        }
       } else if (template.startsWith("I") && !template.startsWith("INDIVIDUAL_TYPE")) {
         // Use individual type to determine how to handle expressions
         switch (individualType) {

--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
@@ -443,7 +443,6 @@ public class TemplateHelper {
         // Get the template without identifier by breaking on the first space
         String sub = template.substring(template.indexOf(" ")).trim().replaceAll("%", content);
         parser.setStringToParse(sub);
-        logger.info("Parsing expression '%s'", sub);
         try {
           expressions.addAll(parser.parseDataPropertyList());
         } catch (OWLParserException e) {
@@ -784,7 +783,6 @@ public class TemplateHelper {
         // Get the template without identifier by breaking on the first space
         String sub = template.substring(template.indexOf(" ")).trim().replaceAll("%", content);
         parser.setStringToParse(sub);
-        logger.info("Parsing expression '%s'", sub);
         try {
           expressions.addAll(parser.parseObjectPropertyList());
         } catch (OWLParserException e) {
@@ -1038,8 +1036,6 @@ public class TemplateHelper {
       return true;
     } else if (template.equals("LABEL")) {
       return true;
-    } else if (template.equals("TYPE")) {
-      return true;
     } else if (template.equals("CLASS_TYPE")) {
       return true;
     } else if (template.equals("PROPERTY_TYPE")) {
@@ -1048,12 +1044,13 @@ public class TemplateHelper {
       return true;
     } else if (template.equals("RANGE")) {
       return true;
+    } else if (template.equals("INDIVIDUAL_TYPE")) {
+      return true;
+    } else if (template.matches("^TYPE( SPLIT=.+)?$")) {
+      // TYPE can be followed by a split for individuals
+      return true;
     } else if (template.matches("^CHARACTERISTIC( SPLIT=.+)?$")) {
       // CHARACTERISTIC can have a split
-      // Should only be followed by SPLIT, nothing else
-      return true;
-    } else if (template.matches("^INDIVIDUAL_TYPE( SPLIT=.+)?$")) {
-      // INDIVIDUAL_TYPE can have a split
       // Should only be followed by SPLIT, nothing else
       return true;
     } else if (template.matches("^>{0,2}A[LTI]? .*")) {

--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
@@ -1066,7 +1066,7 @@ public class TemplateHelper {
       return true;
     } else
       // Individuals can be I, II (does not need to be followed by space), SI, or DI
-      return template.matches("^(I .*|II.?|[SD]I .*)");
+      return template.matches("^(I .*|II.?|[TSD]I .*)");
 
     // TODO - future support for DT datatype axioms
   }

--- a/robot-maven-plugin/src/main/java/org/obolibrary/robot/UpdateContextMojo.java
+++ b/robot-maven-plugin/src/main/java/org/obolibrary/robot/UpdateContextMojo.java
@@ -20,9 +20,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 @Mojo(name = "UpdateContext")
 public class UpdateContextMojo extends AbstractMojo {
 
-  /**
-   * Execute updating the OBO context file.
-   */
+  /** Execute updating the OBO context file. */
   public void execute() {
     getLog().info("Updating OBO context...");
     File robotMvn = new File(System.getProperty("user.dir"));


### PR DESCRIPTION
### Individual Template Strings

If the `TYPE` is a defined class, `owl:Individual`, or `owl:NamedIndividual`, an instance will be created. If the `TYPE` does not include a defined class, that instance will have no class assertions (unless you use the `TI` template string to add an anonymous type). You may include a `SPLIT=` in `TYPE` if you wish to provide more than one class assertion for an individual.

- **class assertion**:
    - `TI %`: the individual will be asserted to be a type of the *class expression* in the column
- **individual assertion**:
    - `I <property>`: when creating an individual, replace property with an object property or data property to add assertions (either by label or CURIE). The value of each axiom will be the value of the cell in this column. For object property assertions, this is another individual. For data property assertions, this is a literal value. If using a property label here, **do not** wrap the label in single quotes.
    - `SI %`: the individual in the column will be asserted to be the same individual
    - `DI %`: the individual in the column will be asserted to be a different individual

#### Example of Individual Template Strings

| Label        | Entity Type | Individual Role      | Property Assertions | Different Individuals | 
| ------------ | ----------- | -------------------- | ------------------- | --------------------- |
| LABEL        | TYPE        | TI 'has role' some % | I part_of           | DI %                  |
| Individual 1 | Class 1     | Role Class 1         | Individual 2        |                       |
| Individual 2 | Class 1     | Role Class 2         |                     | Individual 1          |