### PR TITLE
WIP: Add RDFXML extract method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add [`export`] command [#481]
 - Add JSON format to [`export`] in [#645]
 - Add Excel format to [`export`] in [#646]
+- Add `RDFXML` method to [`extract`] in [#650]
 
 ### Fixed
 - Fix filtering axioms with multiple axiom selectors [#644]
@@ -177,6 +178,7 @@ First official release of ROBOT!
 [`report`]: http://robot.obolibrary.org/report
 [`template`]: http://robot.obolibrary.org/template
 
+[#650]: https://github.com/ontodev/robot/issues/650
 [#646]: https://github.com/ontodev/robot/issues/646
 [#645]: https://github.com/ontodev/robot/issues/645
 [#644]: https://github.com/ontodev/robot/issues/644

--- a/docs/examples/uberon_simple.owl
+++ b/docs/examples/uberon_simple.owl
@@ -1,0 +1,1059 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/uberon.owl#"
+     xml:base="http://purl.obolibrary.org/obo/uberon.owl"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/uberon.owl"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000232 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000232"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBPROP_0000001 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000001"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBPROP_0000003 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000003"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBPROP_0000007 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000007"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBPROP_0000008 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000008"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBPROP_0000009 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000009"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBPROP_0000012 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/UBPROP_0000012"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#date_retrieved -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#date_retrieved"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#external_class -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#external_class"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasAlternativeId -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasAlternativeId"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasDbXref -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasExactSynonym -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasOBONamespace -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasOBONamespace"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasSynonymType -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasSynonymType"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#id -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#id"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#ontology -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#ontology"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#source -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#source"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Datatypes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://en.wikipedia.org/wiki/Ductless_gland -->
+
+    <rdfs:Datatype rdf:about="http://en.wikipedia.org/wiki/Ductless_gland"/>
+    
+
+
+    <!-- http://en.wikipedia.org/wiki/Endocrine_gland -->
+
+    <rdfs:Datatype rdf:about="http://en.wikipedia.org/wiki/Endocrine_gland"/>
+    
+
+
+    <!-- http://orcid.org/0000-0002-6601-2165 -->
+
+    <rdfs:Datatype rdf:about="http://orcid.org/0000-0002-6601-2165"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/uberon/core#LATIN -->
+
+    <rdfs:Datatype rdf:about="http://purl.obolibrary.org/obo/uberon/core#LATIN"/>
+    
+
+
+    <!-- https://orcid.org/0000-0002-6601-2165 -->
+
+    <rdfs:Datatype rdf:about="https://orcid.org/0000-0002-6601-2165"/>
+    
+
+
+    <!-- https://sourceforge.net/p/geneontology/ontology-requests/11422/ -->
+
+    <rdfs:Datatype rdf:about="https://sourceforge.net/p/geneontology/ontology-requests/11422/"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000061 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000061">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000465"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Material anatomical entity that has inherent 3D shape and is generated by coordinated expression of the organism</obo:IAO_0000115>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Material anatomical entity that has inherent 3D shape and is generated by coordinated expression of the organism&apos;s own genome.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO:0010825</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AEO:0000003</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BILA:0000003</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:0000003</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EHDAA2:0003003</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EMAPA:0</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007001</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:67135</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GAID:781</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HAO:0000003</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MA:0003000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MESH:A13</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TAO:0000037</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TGMA:0001823</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0001759</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">WBbt:0000100</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">XAO:0003000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ZFA:0000037</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">biological structure</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000061</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anatomical structure</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Material anatomical entity that has inherent 3D shape and is generated by coordinated expression of the organism&apos;s own genome.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:0000003</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000062 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000062">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomical structure that performs a specific function or group of functions [WP].</obo:IAO_0000115>
+        <obo:UBPROP_0000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Organs are commonly observed as visibly distinct structures, but may also exist as loosely associated clusters of cells that work together to perform a specific function or functions.</obo:UBPROP_0000001>
+        <obo:UBPROP_0000012 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO v1 does not include a generic &apos;organ&apos; class, only simple and compound organ. CARO v2 may include organ, see https://github.com/obophenotype/caro/issues/4</obo:UBPROP_0000012>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EFO:0000634</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EMAPA:35949</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ENVO:01000162</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:67498</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MA:0003001</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OpenCyc:Mx4rv5XMb5wpEbGdrcN5Y29ycA</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OpenCyc:Mx4rwP3iWpwpEbGdrcN5Y29ycA</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C0178784</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">WBbt:0003760</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anatomical unit</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">body organ</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">element</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000062</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">organ</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000062"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/UBPROP_0000001"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Organs are commonly observed as visibly distinct structures, but may also exist as loosely associated clusters of cells that work together to perform a specific function or functions.</owl:annotatedTarget>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0048513</oboInOwl:source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000062"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C0178784</owl:annotatedTarget>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ncithesaurus:Organ</oboInOwl:source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000062"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">element</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:cjm</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000465 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000465">
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomical entity that has mass.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO:0010264</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AEO:0000006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BILA:0000006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:0000006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:MAH</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EHDAA2:0003006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007016</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:67165</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HAO:0000006</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TAO:0001836</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TGMA:0001826</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0001721</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000465</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">material anatomical entity</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000465"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomical entity that has mass.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:MAH</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000477 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000477">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000480"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomical group that has its parts adjacent to one another.</obo:IAO_0000115>
+        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Will be obsoleted in CARO v2 [https://github.com/obophenotype/caro/issues/3]</obo:IAO_0000116>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO:0010009</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AEO:0000041</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BILA:0000041</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:0000041</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EHDAA2:0003041</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007277</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:49443</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HAO:0000041</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TADS:0000605</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TAO:0001478</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TGMA:0001842</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0001737</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">XAO:0003160</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ZFA:0001478</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000477</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anatomical cluster</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000477"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomical group that has its parts adjacent to one another.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:MAH</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0000480 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0000480">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomical structure consisting of at least two non-overlapping organs, multi-tissue aggregates or portion of tissues or cells of different types that does not constitute an organism, organ, multi-tissue aggregate, or portion of tissue.</obo:IAO_0000115>
+        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Will be obsoleted in v2 of CARO [https://github.com/obophenotype/caro/issues/2]</obo:IAO_0000116>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO:0010008</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AEO:0000054</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BILA:0000054</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:0000054</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EHDAA2:0003054</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HAO:0000054</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TAO:0001512</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TGMA:0001846</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0001724</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">XAO:0003001</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ZFA:0001512</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0000480</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anatomical group</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000480"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomical structure consisting of at least two non-overlapping organs, multi-tissue aggregates or portion of tissues or cells of different types that does not constitute an organism, organ, multi-tissue aggregate, or portion of tissue.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:0000054</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:MAH</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0001017 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0001017">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004121"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0011216"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The central nervous system is the core nervous system that serves an integrating and coordinating function. In vertebrates it consists of the neural tube derivatives: the brain and spinal cord. In invertebrates it includes central ganglia plus nerve cord.</obo:IAO_0000115>
+        <obo:UBPROP_0000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Part of the nervous system which includes the brain and spinal cord.[AAO]</obo:UBPROP_0000001>
+        <obo:UBPROP_0000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The brain and spinal cord. Kimmel et al, 1995.[TAO]</obo:UBPROP_0000001>
+        <obo:UBPROP_0000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The central nervous system (CNS) is the part of the nervous system which includes the brain, spinal cord, and nerve cell layer of the retina (CUMBO).</obo:UBPROP_0000001>
+        <obo:UBPROP_0000003 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(...) at some stage of its development, every chordate exhibits five uniquely derived characters or synapomorphies of the group: (...) (4) a single, tubular nerve cord that is located dorsal to the notochord (...) (reference 1); The</obo:UBPROP_0000003>
+        <obo:UBPROP_0000003 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(...) at some stage of its development, every chordate exhibits five uniquely derived characters or synapomorphies of the group: (...) (4) a single, tubular nerve cord that is located dorsal to the notochord (...) (reference 1); The neural tube is destined to differentiate into the brain and spinal cord (the central nervous system) (reference 2); Taken together, our data make a very strong case that the complex molecular mediolateral architecture of the developing trunk CNS (central nervous system), as shared between Platynereis and vertebrates, was already present in their last common ancestor, Urbilateria. The concept of bilaterian nervous system centralization implies that neuron types concentrate on one side of the trunk, as is the case in vertebrates and many invertebrates including Platynereis, where they segregate and become spatially organized (as opposed to a diffuse nerve net). Our data reveal that a large part of the spatial organization of the annelid and vertebrate CNS was already present in their last common ancestor, which implies that Urbilateria had already possessed a CNS (reference 3).[well established][VHOG]</obo:UBPROP_0000003>
+        <oboInOwl:date_retrieved rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2012-06-20</oboInOwl:date_retrieved>
+        <oboInOwl:date_retrieved rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2012-08-14</oboInOwl:date_retrieved>
+        <oboInOwl:date_retrieved rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2012-09-17</oboInOwl:date_retrieved>
+        <oboInOwl:external_class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO:0000090</oboInOwl:external_class>
+        <oboInOwl:external_class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TAO:0000012</oboInOwl:external_class>
+        <oboInOwl:external_class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0000293</oboInOwl:external_class>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO:0000090</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BAMS:CNS</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BILA:0000080</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTO:0000227</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CALOHA:TS-0150</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EFO:0000908</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EHDAA2:0000225</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EHDAA:828</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EMAPA:16470</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EMAPA:16754</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EV:0100163</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005094</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:55675</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:TA</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GAID:570</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0021551</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MA:0000167</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MAT:0000457</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MESH:A08.186</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NeuroNames:246</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OpenCyc:Mx4rvzYt3pwpEbGdrcN5Y29ycA</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TAO:0000012</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C0927232</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0000293</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">XAO:0000215</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ZFA:0000012</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://braininfo.rprc.washington.edu/centraldirectory.aspx?ID=246</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CNS</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">systema nervosum centrale</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cerebrospinal axis</oboInOwl:hasNarrowSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">basal nucleus of the amygdala</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">basolateral nucleus of amygdala</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">basolateral nucleus of the amygdala</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">neuraxis</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nucleus amygdalae basalis</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nucleus amygdaloideus basalis</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nucleus amygdaloideus basolateralis</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nucleus basalis amygdalae</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0001017</oboInOwl:id>
+        <oboInOwl:ontology rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO</oboInOwl:ontology>
+        <oboInOwl:ontology rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TAO</oboInOwl:ontology>
+        <oboInOwl:ontology rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG</oboInOwl:ontology>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO:BJB</oboInOwl:source>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ISBN:978-0030223693 Liem KF, Bemis WE, Walker WF, Grande L, Functional Anatomy of the Vertebrates: An Evolutionary Perspective (2001) p.28 (reference 1), ISBN:978-0072528305 Kardong KV, Vertebrates: Comparative Anatomy, Function, Evolution (2006) p.165 (reference 2), DOI:10.1016/j.cell.2007.02.040 Denes AS, Jekely G, Steinmetz PRH, Raible F, Snyman H, Prud</oboInOwl:source>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NIFSTD:birnlex_1099</oboInOwl:source>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ZFIN:curator</oboInOwl:source>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ncithesaurus:Central_Nervous_System</oboInOwl:source>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">central nervous system</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/UBPROP_0000001"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The brain and spinal cord. Kimmel et al, 1995.[TAO]</owl:annotatedTarget>
+        <oboInOwl:date_retrieved rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2012-08-14</oboInOwl:date_retrieved>
+        <oboInOwl:external_class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TAO:0000012</oboInOwl:external_class>
+        <oboInOwl:ontology rdf:datatype="http://www.w3.org/2001/XMLSchema#string">TAO</oboInOwl:ontology>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ZFIN:curator</oboInOwl:source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/UBPROP_0000001"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The central nervous system (CNS) is the part of the nervous system which includes the brain, spinal cord, and nerve cell layer of the retina (CUMBO).</owl:annotatedTarget>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NIFSTD:birnlex_1099</oboInOwl:source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/UBPROP_0000003"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(...) at some stage of its development, every chordate exhibits five uniquely derived characters or synapomorphies of the group: (...) (4) a single, tubular nerve cord that is located dorsal to the notochord (...) (reference 1); The neural tube is destined to differentiate into the brain and spinal cord (the central nervous system) (reference 2); Taken together, our data make a very strong case that the complex molecular mediolateral architecture of the developing trunk CNS (central nervous system), as shared between Platynereis and vertebrates, was already present in their last common ancestor, Urbilateria. The concept of bilaterian nervous system centralization implies that neuron types concentrate on one side of the trunk, as is the case in vertebrates and many invertebrates including Platynereis, where they segregate and become spatially organized (as opposed to a diffuse nerve net). Our data reveal that a large part of the spatial organization of the annelid and vertebrate CNS was already present in their last common ancestor, which implies that Urbilateria had already possessed a CNS (reference 3).[well established][VHOG]</owl:annotatedTarget>
+        <oboInOwl:date_retrieved rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2012-09-17</oboInOwl:date_retrieved>
+        <oboInOwl:external_class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0000293</oboInOwl:external_class>
+        <oboInOwl:ontology rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG</oboInOwl:ontology>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ISBN:978-0030223693 Liem KF, Bemis WE, Walker WF, Grande L, Functional Anatomy of the Vertebrates: An Evolutionary Perspective (2001) p.28 (reference 1), ISBN:978-0072528305 Kardong KV, Vertebrates: Comparative Anatomy, Function, Evolution (2006) p.165 (reference 2), DOI:10.1016/j.cell.2007.02.040 Denes AS, Jekely G, Steinmetz PRH, Raible F, Snyman H, Prud&apos;homme B, Ferrier DEK, Balavoine G and Arendt D, Molecular architecture of annelid nerve cord supports common origin of nervous system centralization in Bilateria. Cell (2007) (reference 3)</oboInOwl:source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C0927232</owl:annotatedTarget>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NIFSTD:birnlex_1099</oboInOwl:source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C0927232</owl:annotatedTarget>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ncithesaurus:Central_Nervous_System</oboInOwl:source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://braininfo.rprc.washington.edu/centraldirectory.aspx?ID=246</owl:annotatedTarget>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NIFSTD:birnlex_1099</oboInOwl:source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">systema nervosum centrale</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:55675</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:TA</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cerebrospinal axis</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:55675</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">basal nucleus of the amygdala</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NeuroNames:246</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">basolateral nucleus of amygdala</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NeuroNames:246</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">basolateral nucleus of the amygdala</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NeuroNames:246</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">neuraxis</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:55675</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nucleus amygdalae basalis</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NeuroNames:246</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nucleus amygdaloideus basalis</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NeuroNames:246</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nucleus amygdaloideus basolateralis</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NeuroNames:246</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">nucleus basalis amygdalae</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">NeuroNames:246</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The central nervous system is the core nervous system that serves an integrating and coordinating function. In vertebrates it consists of the neural tube derivatives: the brain and spinal cord. In invertebrates it includes central ganglia plus nerve cord.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="https://sourceforge.net/p/geneontology/ontology-requests/11422/"></oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0021551</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0001017"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/UBPROP_0000001"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Part of the nervous system which includes the brain and spinal cord.[AAO]</owl:annotatedTarget>
+        <oboInOwl:date_retrieved rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2012-06-20</oboInOwl:date_retrieved>
+        <oboInOwl:external_class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO:0000090</oboInOwl:external_class>
+        <oboInOwl:ontology rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO</oboInOwl:ontology>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO:BJB</oboInOwl:source>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002368 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002368">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002530"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Endocrine glands are glands of the endocrine system that secrete their products directly into the circulatory system rather than through a duct.[WP, modified].</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AEO:0000098</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTO:0001488</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CALOHA:TS-1300</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EHDAA2:0003098</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EMAPA:35999</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:9602</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GAID:335</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MA:0002563</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MESH:A06.407</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OpenCyc:Mx4rvbkiRZwpEbGdrcN5Y29ycA</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C0014133</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ductless gland</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glandula endocrina</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ductless gland</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glandulae endocrinae</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002368</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">endocrine gland</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002368"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C0014133</owl:annotatedTarget>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ncithesaurus:Endocrine_Gland</oboInOwl:source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002368"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ductless gland</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AEO:0000098</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002368"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ductless gland</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://en.wikipedia.org/wiki/Ductless_gland"></oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002368"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glandulae endocrinae</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://en.wikipedia.org/wiki/Endocrine_gland"></oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002369 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002369">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006858"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0015212"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Either of a pair of complex endocrine organs near the anterior medial border of the kidney consisting of a mesodermal cortex that produces glucocorticoid, mineralocorticoid, and androgenic hormones and an ectodermal medulla that produces epinephrine and norepinephrine[BTO].</obo:IAO_0000115>
+        <obo:UBPROP_0000001 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomical structure which is found on the surface of the kidney and secretes various hormones including epinephrine, norephinephrine, aldosterone, corticosterone, and cortisol.[AAO]</obo:UBPROP_0000001>
+        <obo:UBPROP_0000003 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">All craniates have groups of cells homologous to the mammalian adrenocortical and chromaffin tissues, but they are scattered in and near the kidneys in fishes. (...) The cortical and chromaffin tissues come together to form adrenal glands in tetrapods.[well established][VHOG]</obo:UBPROP_0000003>
+        <obo:UBPROP_0000008 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The origin of the adrenal gland is still controversial. It is thought to share the same origin as the kidney and gonads, derived from coelomic epithelium of the urogenital ridge and/or the underlying mesenchyme (Keegan and Hammer, 2002; Morohashi, 1997). We follow Kardong and state homology at the level of the cortex and medulla rather than gland as a whole</obo:UBPROP_0000008>
+        <obo:UBPROP_0000009 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">suprarenal cortex manufactures corticosteroids; suprarenal medulla manufactures epinephrine and norepinephrine; suprarenal medulla receives preganglionic sympathetic innervation from the greater thoracic splanchnic n.</obo:UBPROP_0000009>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO:0010551</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTO:0000047</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CALOHA:TS-0016</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EFO:0000238</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EMAPA:18426</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EV:0100135</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:9604</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GAID:446</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MA:0000116</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MAT:0000071</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MESH:A06.407.071</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIAA:0000071</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OpenCyc:Mx4rvXYiz5wpEbGdrcN5Y29ycA</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C0001625</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0001141</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">XAO:0000164</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">galen:AdrenalGland</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glandula adrenalis</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glandula suprarenalis</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adrenal</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adrenal capsule</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adrenal medulla cell</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">atrabiliary capsule</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">epinephric gland</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">epinephros</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glandula suprarenalis</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">interrenal gland</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">suprarenal capsule</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">suprarenal gland</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002369</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adrenal gland</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002369"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Either of a pair of complex endocrine organs near the anterior medial border of the kidney consisting of a mesodermal cortex that produces glucocorticoid, mineralocorticoid, and androgenic hormones and an ectodermal medulla that produces epinephrine and norepinephrine[BTO].</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTO:0000047</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002369"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/UBPROP_0000001"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomical structure which is found on the surface of the kidney and secretes various hormones including epinephrine, norephinephrine, aldosterone, corticosterone, and cortisol.[AAO]</owl:annotatedTarget>
+        <oboInOwl:date_retrieved rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2012-06-20</oboInOwl:date_retrieved>
+        <oboInOwl:external_class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO:0010551</oboInOwl:external_class>
+        <oboInOwl:ontology rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO</oboInOwl:ontology>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO:BJB</oboInOwl:source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002369"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/UBPROP_0000003"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">All craniates have groups of cells homologous to the mammalian adrenocortical and chromaffin tissues, but they are scattered in and near the kidneys in fishes. (...) The cortical and chromaffin tissues come together to form adrenal glands in tetrapods.[well established][VHOG]</owl:annotatedTarget>
+        <oboInOwl:date_retrieved rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2012-09-17</oboInOwl:date_retrieved>
+        <oboInOwl:external_class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0001141</oboInOwl:external_class>
+        <oboInOwl:ontology rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG</oboInOwl:ontology>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ISBN:978-0030223693 Liem KF, Bemis WE, Walker WF, Grande L, Functional Anatomy of the Vertebrates: An Evolutionary Perspective (2001) p.518 and Figure 15-9</oboInOwl:source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002369"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C0001625</owl:annotatedTarget>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ncithesaurus:Adrenal_Gland</oboInOwl:source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002369"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glandula adrenalis</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:datatype="http://purl.obolibrary.org/obo/uberon/core#LATIN"></oboInOwl:hasSynonymType>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002369"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glandula suprarenalis</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:datatype="http://purl.obolibrary.org/obo/uberon/core#LATIN"></oboInOwl:hasSynonymType>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002369"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adrenal</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTO:0000047</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002369"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adrenal capsule</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTO:0000047</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002369"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">atrabiliary capsule</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTO:0000047</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002369"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">epinephros</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTO:0000047</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002369"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glandula suprarenalis</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTO:0000047</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002369"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">interrenal gland</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0030325</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002369"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">suprarenal capsule</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTO:0000047</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0002530 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0002530">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000062"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">an organ that functions as a secretory or excretory organ</obo:IAO_0000115>
+        <obo:UBPROP_0000007 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glandular</obo:UBPROP_0000007>
+        <oboInOwl:hasAlternativeId rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:MIAA_0000021</oboInOwl:hasAlternativeId>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AAO:0000212</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AEO:0000096</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTO:0000522</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EFO:0000797</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EHDAA2:0003096</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EHDAA:2161</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EHDAA:4475</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EHDAA:6522</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">EMAPA:18425</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00100317</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:86294</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">HAO:0000375</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MA:0003038</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MAT:0000021</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MIAA:0000021</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OpenCyc:Mx4rwP3vyJwpEbGdrcN5Y29ycA</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C1285092</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">WikipediaCategory:Glands</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">galen:Gland</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Druese</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glandula</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0002530</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gland</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002530"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">an organ that functions as a secretory or excretory organ</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MP:0002163,MGI:csmith</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002530"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasDbXref"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UMLS:C1285092</owl:annotatedTarget>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ncithesaurus:Gland</oboInOwl:source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002530"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Druese</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTO:0000522</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002530"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glandula</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BTO:0000522</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002530"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">glandula</owl:annotatedTarget>
+        <oboInOwl:hasSynonymType rdf:datatype="http://purl.obolibrary.org/obo/uberon/core#LATIN"></oboInOwl:hasSynonymType>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0004120 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0004120">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An anatomical structure that develops (entirely or partially) from the mesoderm.</obo:IAO_0000115>
+        <obo:IAO_0000232 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Grouping term for query purposes</obo:IAO_0000232>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0004120</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">mesoderm-derived structure</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004120"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An anatomical structure that develops (entirely or partially) from the mesoderm.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="https://orcid.org/0000-0002-6601-2165"></oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0004121 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0004121">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An anatomical structure that develops (entirely or partially) from the ectoderm.</obo:IAO_0000115>
+        <obo:IAO_0000232 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Grouping term for query purposes</obo:IAO_0000232>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0004121</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ectoderm-derived structure</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0005172 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0005172">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005173"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An organ or element that is in the abdomen. Examples: spleen, intestine, kidney, abdominal mammary gland.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MA:0000522</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abdomen organ</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0005172</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abdomen element</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005172"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abdomen organ</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MA:0000522</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0005173 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0005173">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005177"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An organ or element that is part of the adbominal segment of the organism. This region can be further subdivided into the abdominal cavity and the pelvic region.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MA:0000529</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abdominal segment organ</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0005173</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abdominal segment element</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005173"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An organ or element that is part of the adbominal segment of the organism. This region can be further subdivided into the abdominal cavity and the pelvic region.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://orcid.org/0000-0002-6601-2165"></oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005173"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">abdominal segment organ</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MA:0000529</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0005177 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0005177">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000062"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An organ or element that part of the trunk region. The trunk region can be further subdividied into thoracic (including chest and thoracic cavity) and abdominal (including abdomen and pelbis) regions.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MA:0000516</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">trunk organ</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0005177</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">trunk region element</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005177"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">trunk organ</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">MA:0000516</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0006858 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0006858">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0002368"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0004120"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0005172"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010314"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This gland can either be a discrete structure located bilaterally above each kidney, or a cluster of cells in the head kidney that perform the functions of the adrenal gland. In either case, this organ consists of two cells types, aminergic chromaffin cells and steroidogenic cortical cells[GO]</obo:IAO_0000115>
+        <obo:IAO_0000116 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">keep this grouping class so long as it is required for GO</obo:IAO_0000116>
+        <obo:UBPROP_0000003 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">All craniates have groups of cells homologous to the mammalian adrenocortical and chromaffin tissues, but they are scattered in and near the kidneys in fishes. (...) The cortical and chromaffin tissues come together to form adrenal glands in tetrapods.[well established][VHOG]</obo:UBPROP_0000003>
+        <oboInOwl:date_retrieved rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2012-09-17</oboInOwl:date_retrieved>
+        <oboInOwl:external_class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0001141</oboInOwl:external_class>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0030325</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0001141</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adrenal gland - interrenal gland</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adrenal gland/interrenal tissue</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adrenal - interrenal gland</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">suprarenal gland - interrenal gland</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0006858</oboInOwl:id>
+        <oboInOwl:ontology rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG</oboInOwl:ontology>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ISBN:978-0030223693 Liem KF, Bemis WE, Walker WF, Grande L, Functional Anatomy of the Vertebrates: An Evolutionary Perspective (2001) p.518 and Figure 15-9</oboInOwl:source>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adrenal/interrenal gland</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006858"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This gland can either be a discrete structure located bilaterally above each kidney, or a cluster of cells in the head kidney that perform the functions of the adrenal gland. In either case, this organ consists of two cells types, aminergic chromaffin cells and steroidogenic cortical cells[GO]</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">GO:0030325</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006858"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/UBPROP_0000003"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">All craniates have groups of cells homologous to the mammalian adrenocortical and chromaffin tissues, but they are scattered in and near the kidneys in fishes. (...) The cortical and chromaffin tissues come together to form adrenal glands in tetrapods.[well established][VHOG]</owl:annotatedTarget>
+        <oboInOwl:date_retrieved rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2012-09-17</oboInOwl:date_retrieved>
+        <oboInOwl:external_class rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0001141</oboInOwl:external_class>
+        <oboInOwl:ontology rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG</oboInOwl:ontology>
+        <oboInOwl:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ISBN:978-0030223693 Liem KF, Bemis WE, Walker WF, Grande L, Functional Anatomy of the Vertebrates: An Evolutionary Perspective (2001) p.518 and Figure 15-9</oboInOwl:source>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006858"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adrenal gland - interrenal gland</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0001141</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006858"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">adrenal - interrenal gland</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0001141</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0006858"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">suprarenal gland - interrenal gland</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">VHOG:0001141</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0010000 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0010000">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An anatomical structure that has more than one cell as a part.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:0010000</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00100313</oboInOwl:hasDbXref>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">multicellular structure</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0010000</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">multicellular anatomical structure</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An anatomical structure that has more than one cell as a part.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">CARO:0010000</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010000"/>
+        <owl:annotatedProperty rdf:resource="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">multicellular structure</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00100313</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0010314 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0010314">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An anatomical structure that has some part that develops from the neural crest.</obo:IAO_0000115>
+        <obo:IAO_0000232 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Grouping term for query purposes</obo:IAO_0000232>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0010314</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">structure with developmental contribution from neural crest</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0010314"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An anatomical structure that has some part that develops from the neural crest.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="https://orcid.org/0000-0002-6601-2165"></oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0011216 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0011216">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000477"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomical structure, which consists of a specific set of the members of (predominantly) one organ or organ part subclass interconnected by zones of continuity or body substances; is demarcated from other subdivisions of the same organ system by one or more zones of continuity or anatomical lines; together with other subdivisions of the same organ system, it constitutes an organ system. Examples: rib cage, facial skeleton, portal system, central nervous system, upper respiratory tract, muscle group of back.</obo:IAO_0000115>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007330</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:67509</oboInOwl:hasDbXref>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0011216</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">organ system subdivision</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/UBERON_0011216"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Anatomical structure, which consists of a specific set of the members of (predominantly) one organ or organ part subclass interconnected by zones of continuity or body substances; is demarcated from other subdivisions of the same organ system by one or more zones of continuity or anatomical lines; together with other subdivisions of the same organ system, it constitutes an organ system. Examples: rib cage, facial skeleton, portal system, central nervous system, upper respiratory tract, muscle group of back.</owl:annotatedTarget>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FMA:67509</oboInOwl:hasDbXref>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UBERON_0015212 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UBERON_0015212">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/UBERON_0000061"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Any structure that is placed on one side of the left-right axis of a bilaterian.</obo:IAO_0000115>
+        <obo:IAO_0000232 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This class is primarily to implement taxon constraints. It may be removed in the future.</obo:IAO_0000232>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
+        <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">UBERON:0015212</oboInOwl:id>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lateral structure</rdfs:label>
+    </owl:Class>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.6) https://github.com/owlcs/owlapi -->
+

--- a/docs/extract.md
+++ b/docs/extract.md
@@ -68,7 +68,29 @@ To specify upper and lower term files, use `--upper-terms` and `--lower-terms`. 
 
 To only include all descendants of a term or set of terms, use `--branch-from-term` or `--branch-from-terms`, respectively. `--lower-term` or `--lower-terms` are not required when using this option.
 
+You may specify which annotation properties to include with `--annotation-property`, or `--annotation-properties` for a text file of annotation properties. These should be referenced by CURIE or IRI.
+
+If neither `--annotation-property` nor `--annotation-properties` is specified, all annotation properties will be included in the output.
+
 For more details see the [MIREOT paper](http://dx.doi.org/10.3233/AO-2011-0087).
+
+## RDFXML
+
+Loading very large ontologies into ROBOT can require a lot of time and memory. Because of this, it can be easier to parse large RDF/XML files using a streaming XML processor instead of fully loading them into memory.
+
+**Please note** that this method can only be used on files in RDF/XML format.
+
+    robot extract --method RDFXML \
+        --input uberon_fragment.owl \
+        --term UBERON:0000465 \
+        --term UBERON:0001017 \
+        --term UBERON:0002369 \
+        --output uberon_simple.owl
+        
+For this method, one or more `--annotation-property` options can be provided in order to add annotations to the entities. If not included, all annotations will be included in the output. To provide a text file of annotation properties, use `--annotation-properties`.
+
+The `RDFXML` method is similar to MIREOT in that no anonymous class expressions or equivalent classes are included.
+
 
 ### Intermediates
 

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
@@ -57,7 +57,8 @@ public class CommandLineHelper {
   private static final String missingRequirementError = NS + "MISSING REQUIREMENT ERROR %s";
 
   /** Error message when no input ontology is provided. */
-  protected static final String missingInputError = NS + "MISSING INPUT ERROR an --input is required";
+  protected static final String missingInputError =
+      NS + "MISSING INPUT ERROR an --input is required";
 
   /** Error message when no input ontology is provided for methods that accept multiple inputs. */
   private static final String missingInputsError =

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
@@ -57,7 +57,7 @@ public class CommandLineHelper {
   private static final String missingRequirementError = NS + "MISSING REQUIREMENT ERROR %s";
 
   /** Error message when no input ontology is provided. */
-  private static final String missingInputError = NS + "MISSING INPUT ERROR an --input is required";
+  protected static final String missingInputError = NS + "MISSING INPUT ERROR an --input is required";
 
   /** Error message when no input ontology is provided for methods that accept multiple inputs. */
   private static final String missingInputsError =

--- a/robot-command/src/main/java/org/obolibrary/robot/ExtractCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ExtractCommand.java
@@ -6,7 +6,6 @@ import com.opencsv.CSVReaderBuilder;
 import java.io.*;
 import java.util.*;
 import java.util.stream.Collectors;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.semanticweb.owlapi.apibinding.OWLManager;
@@ -87,15 +86,12 @@ public class ExtractCommand implements Command {
     o.addOption("M", "imports", true, "handle imports (default: include)");
     o.addOption("N", "intermediates", true, "specify how to handle intermediate entities");
     o.addOption(
-      null,
-      "annotation-property",
-      true,
-      "annotation property to include (MIREOT and RDFXML)");
+        null, "annotation-property", true, "annotation property to include (MIREOT and RDFXML)");
     o.addOption(
-      null,
-      "annotation-properties",
-      true,
-      "annotation properties to include (MIREOT and RDFXML)");
+        null,
+        "annotation-properties",
+        true,
+        "annotation properties to include (MIREOT and RDFXML)");
     options = o;
   }
 
@@ -180,12 +176,12 @@ public class ExtractCommand implements Command {
 
     // Get method, make sure it has been specified
     String method =
-      CommandLineHelper.getRequiredValue(line, "method", "method of extraction must be specified")
-        .trim()
-        .toLowerCase();
+        CommandLineHelper.getRequiredValue(line, "method", "method of extraction must be specified")
+            .trim()
+            .toLowerCase();
 
     // RDFXML method never loads OWLOntology object
-    if (method.equals("RDFXML")) {
+    if (method.equals("rdfxml")) {
       outputOntology = rdfxmlExtract(ioHelper, line, extractOptions);
       CommandLineHelper.maybeSaveOutput(line, outputOntology);
       state.setOntology(outputOntology);
@@ -292,23 +288,29 @@ public class ExtractCommand implements Command {
       // If this isn't included, all annotation properties are included
       OWLDataFactory df = OWLManager.getOWLDataFactory();
       Set<IRI> annotationPropertyIRIs =
-        CommandLineHelper.getTerms(ioHelper, line, "annotation-property", "annotation-properties");
+          CommandLineHelper.getTerms(
+              ioHelper, line, "annotation-property", "annotation-properties");
       Set<OWLAnnotationProperty> annotationProperties;
       if (annotationPropertyIRIs.isEmpty()) {
         annotationProperties = null;
       } else {
         annotationProperties =
-          annotationPropertyIRIs
-            .stream()
-            .map(df::getOWLAnnotationProperty)
-            .collect(Collectors.toSet());
+            annotationPropertyIRIs
+                .stream()
+                .map(df::getOWLAnnotationProperty)
+                .collect(Collectors.toSet());
       }
 
       // First check for lower IRIs, upper IRIs can be null or not
       if (lowerIRIs != null) {
         outputOntologies.add(
             MireotOperation.getAncestors(
-                inputOntology, upperIRIs, lowerIRIs, annotationProperties, extractOptions, sourceMap));
+                inputOntology,
+                upperIRIs,
+                lowerIRIs,
+                annotationProperties,
+                extractOptions,
+                sourceMap));
         // If there are no lower IRIs, there shouldn't be any upper IRIs
       } else if (upperIRIs != null) {
         throw new IllegalArgumentException(missingLowerTermError);
@@ -342,7 +344,7 @@ public class ExtractCommand implements Command {
    * @throws Exception on any problem
    */
   private static OWLOntology rdfxmlExtract(
-    IOHelper ioHelper, CommandLine line, Map<String, String> extractOptions) throws Exception {
+      IOHelper ioHelper, CommandLine line, Map<String, String> extractOptions) throws Exception {
     String fileName = CommandLineHelper.getOptionalValue(line, "input");
     String iriString = CommandLineHelper.getOptionalValue(line, "input-iri");
     if (fileName == null && iriString == null) {
@@ -352,7 +354,7 @@ public class ExtractCommand implements Command {
 
     Set<IRI> terms = CommandLineHelper.getTerms(ioHelper, line, "term", "term-file");
     Set<IRI> annotationProperties =
-      CommandLineHelper.getTerms(ioHelper, line, "annotation-property", "annotation-properties");
+        CommandLineHelper.getTerms(ioHelper, line, "annotation-property", "annotation-properties");
 
     XMLHelper xmlHelper;
     if (fileName != null) {

--- a/robot-core/src/main/java/org/obolibrary/robot/XMLHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/XMLHelper.java
@@ -1,0 +1,915 @@
+package org.obolibrary.robot;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import java.io.*;
+import java.util.*;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.XMLEvent;
+import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.LaxRedirectStrategy;
+import org.codehaus.stax2.XMLInputFactory2;
+import org.codehaus.stax2.XMLStreamReader2;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides convenience methods for working with RDF/XML ontologies with a streaming XML processor.
+ *
+ * @author <a href="mailto:rbca.jackson@gmail.com">Becky Jackson</a>
+ */
+public class XMLHelper {
+
+  /** Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(XMLHelper.class);
+
+  // Entity types
+  private final String ANNOTATION_PROPERTY_TAG =
+    "{http://www.w3.org/2002/07/owl#}AnnotationProperty";
+  private final String CLASS_TAG = "{http://www.w3.org/2002/07/owl#}Class";
+  private final String DATA_PROPERTY_TAG = "{http://www.w3.org/2002/07/owl#}DatatypeProperty";
+  private final String OWL_DATATYPE_TAG = "{http://www.w3.org/2002/07/owl#}Datatype";
+  private final String NAMED_INDIVIDUAL_TAG = "{http://www.w3.org/2002/07/owl#}NamedIndividual";
+  private final String OBJECT_PROPERTY_TAG = "{http://www.w3.org/2002/07/owl#}ObjectProperty";
+  private final String AXIOM_TAG = "{http://www.w3.org/2002/07/owl#}Axiom";
+
+  // Other tags
+  private final String ONTOLOGY_TAG = "{http://www.w3.org/2002/07/owl#}Ontology";
+  private final String LABEL_TAG = "{http://www.w3.org/2000/01/rdf-schema#}label";
+  private final String LANG_TAG = "{http://www.w3.org/XML/1998/namespace}lang";
+  private final String RDFS_DATATYPE_TAG = "{http://www.w3.org/1999/02/22-rdf-syntax-ns#}datatype";
+  private final String SUBCLASS_OF_TAG = "{http://www.w3.org/2000/01/rdf-schema#}subClassOf";
+  private final String ANNOTATED_TARGET_TAG = "{http://www.w3.org/2002/07/owl#}annotatedTarget";
+  private final String ANNOTATED_SOURCE_TAG = "{http://www.w3.org/2002/07/owl#}annotatedSource";
+  private final String ANNOTATED_PROPERTY_TAG = "{http://www.w3.org/2002/07/owl#}annotatedProperty";
+
+  // Shared data factory & manager
+  private final OWLDataFactory dataFactory = OWLManager.getOWLDataFactory();
+  private final OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+
+  // Extracted module
+  private OWLOntology outputOntology;
+
+  // User parameters
+  private String fileName;
+  private IRI outputIRI;
+
+  // Maps to resolve labels, relationships, and types from IRIs
+  private BiMap<IRI, String> labelMap = HashBiMap.create();
+  private Map<IRI, Set<IRI>> childParentMap = new HashMap<>();
+  private Map<IRI, EntityType> typeMap = new HashMap<>();
+
+  // Tracking added targets (if intermediates = all or minimal)
+  private Set<IRI> allTargets = new HashSet<>();
+
+  // Tracking all annotation properties, if none are specified
+  private Set<IRI> allAnnotationProperties = new HashSet<>();
+
+  // TODO - change to use XML writer instead of OWLAPI
+  // Keep root element with all prefixes etc
+  // If you see an element that you want, copy it in output stream as XML
+  // Maybe method for cloning an element?
+
+  /**
+   * Create a new XMLHelper for parsing an ontology in a local file.
+   *
+   * @param fileName path to XML file
+   * @throws IOException if file does not exist or XML cannot be parsed
+   * @throws OWLOntologyCreationException if empty ontology cannot be created
+   */
+  public XMLHelper(String fileName, IRI outputIRI)
+    throws IOException, OWLOntologyCreationException {
+    this.fileName = fileName;
+    // Create an empty ontology
+    outputOntology = manager.createOntology();
+    if (outputIRI != null) {
+      this.outputIRI = outputIRI;
+    }
+
+    // Create maps: IRI -> label, child -> parents
+    try (FileInputStream fis = new FileInputStream(this.fileName)) {
+      getBasicDetails(fis);
+    } catch (XMLStreamException e) {
+      throw new IOException("Unable to parse XML from " + fileName, e);
+    }
+  }
+
+  /**
+   * Create a new XMLHelper for parsing an ontology from an IRI. This will create a temporary file,
+   * which will be deleted on exit.
+   *
+   * @param iri IRI of XML file
+   * @throws IOException if temp file cannot be created or downloaded, or if XML cannot be parsed
+   * @throws OWLOntologyCreationException if empty ontology cannot be created
+   */
+  public XMLHelper(IRI iri, IRI outputIRI) throws IOException, OWLOntologyCreationException {
+    // We will create a temporary file
+    String fileName = iri.toString().substring(iri.toString().lastIndexOf("/"));
+    String ext = fileName.substring(fileName.lastIndexOf("."));
+    String fn = fileName.substring(0, fileName.lastIndexOf("."));
+    File temp = File.createTempFile(fn, ext);
+
+    // Make sure this file is removed on exit
+    temp.deleteOnExit();
+    this.fileName = temp.getAbsolutePath();
+
+    // Download ontology, following redirects
+    logger.info(String.format("Starting download from <%s>", iri.toString()));
+    CloseableHttpClient httpclient =
+      HttpClients.custom().setRedirectStrategy(new LaxRedirectStrategy()).build();
+    try {
+      HttpGet get = new HttpGet(iri.toURI());
+      HttpResponse r = httpclient.execute(get);
+      InputStream source = r.getEntity().getContent();
+      FileUtils.copyInputStreamToFile(source, temp);
+    } catch (Exception e) {
+      throw new IOException("Unable to download content from " + iri, e);
+    } finally {
+      IOUtils.closeQuietly(httpclient);
+    }
+
+    logger.info("Temporary file created for input ontology: " + this.fileName);
+
+    // Create an empty ontology
+    outputOntology = manager.createOntology();
+    if (outputIRI != null) {
+      this.outputIRI = outputIRI;
+    }
+
+    // Create map of IRI -> label
+    try (FileInputStream fis = new FileInputStream(this.fileName)) {
+      getBasicDetails(fis);
+    } catch (XMLStreamException e) {
+      throw new IOException("Unable to parse XML from " + this.fileName, e);
+    }
+  }
+
+  /**
+   * Perform an extraction to create a subset containing the target IRIs with their target
+   * annotation properties.
+   *
+   * @param targets IRIs to extract
+   * @param annotationProperties IRIs of annotation properties to include
+   * @param options Map of extract options
+   * @return extracted subset
+   * @throws IOException on problem parsing XML
+   * @throws OWLOntologyCreationException on problem creating empty ontology
+   */
+  public OWLOntology extract(
+    Set<IRI> targets, Set<IRI> annotationProperties, Map<String, String> options)
+    throws IOException, OWLOntologyCreationException {
+    String intermediates = OptionsHelper.getOption(options, "intermediates", "all");
+    boolean annotateSource = OptionsHelper.optionIsTrue(options, "annotate-with-source");
+
+    // Add declarations and hierarchy structure
+    initOntology(targets, intermediates);
+
+    // Add desired annotations on targets
+    // If 'all' or 'minimal' intermediates, more targets have been added
+    // If 'none' intermediates, targets are the same as the provided targets
+    try (FileInputStream fis = new FileInputStream(this.fileName)) {
+      addAnnotations(fis, annotationProperties);
+    } catch (XMLStreamException e) {
+      throw new IOException("Unable to parse XML from " + this.fileName, e);
+    }
+
+    try (FileInputStream fis = new FileInputStream(this.fileName)) {
+      addOWLAxioms(fis, annotationProperties);
+    } catch (XMLStreamException e) {
+      throw new IOException("unable to parse XML");
+    }
+
+    // Maybe add source annotations
+    if (annotateSource && outputIRI != null) {
+      OWLAnnotationProperty isDefinedBy = dataFactory.getRDFSIsDefinedBy();
+      for (IRI iri : allTargets) {
+        manager.addAxiom(
+          outputOntology,
+          dataFactory.getOWLAnnotationAssertionAxiom(isDefinedBy, iri, outputIRI));
+      }
+    }
+
+    // This is a stupid way to set the IRI
+    // But manager.setOntologyDocumentIRI(...) does not copy over to the output
+    if (outputIRI == null) {
+      return outputOntology;
+    }
+    OWLOntologyManager manager = outputOntology.getOWLOntologyManager();
+    Set<OWLOntology> ont = new HashSet<>();
+    ont.add(outputOntology);
+    return manager.createOntology(outputIRI, ont);
+  }
+
+  /**
+   * Get the entity type of an entity by its IRI
+   *
+   * @param iri IRI of entity
+   * @return EntityType or null
+   */
+  public EntityType getEntityType(IRI iri) {
+    return typeMap.getOrDefault(iri, null);
+  }
+
+  /**
+   * Get the IRI of an entity by its label.
+   *
+   * @param label String label of entity to get IRI of
+   * @return IRI or null
+   */
+  public IRI getIRI(String label) {
+    return labelMap.inverse().getOrDefault(label, null);
+  }
+
+  /**
+   * Get the set of parent IRIs for a child entity.
+   *
+   * @param child IRI to get parents of
+   * @return set of IRIs (maybe empty if no parents), or null if child IRI does not exist
+   */
+  public Set<IRI> getParents(IRI child) {
+    if (typeMap.containsKey(child)) {
+      return childParentMap.getOrDefault(child, new HashSet<>());
+    } else {
+      // Entity does not exist in input ontology
+      return null;
+    }
+  }
+
+  /**
+   * Get the basic details for all entities in an ontology. This includes parent-child
+   * relationships, entity types, and labels.
+   *
+   * @param fis FileInputStream of XML
+   * @throws XMLStreamException on issue parsing XML
+   */
+  private void getBasicDetails(FileInputStream fis) throws XMLStreamException {
+    XMLInputFactory2 inf = (XMLInputFactory2) XMLInputFactory2.newInstance();
+    XMLStreamReader2 sr = (XMLStreamReader2) inf.createXMLStreamReader(fileName, fis);
+
+    // XML event integer
+    int e;
+
+    // Name of current node tag
+    String node = null;
+
+    // Ignore anonymous closing events
+    boolean anonymous = false;
+
+    // Track long strings over multiple CHARACTER events for labels
+    StringBuilder currentContent = null;
+
+    // Add label to set of annotation properties
+    allAnnotationProperties.add(dataFactory.getRDFSLabel().getIRI());
+
+    // Track current entity by IRI
+    IRI iri = null;
+    try {
+      while (sr.hasNext()) {
+        e = sr.next();
+        switch (e) {
+          case XMLEvent.START_ELEMENT:
+            node = sr.getName().toString();
+
+            // Maybe add child -> parents
+            if (node.equals(SUBCLASS_OF_TAG) && iri != null) {
+              // We only care about named classes right now
+              if (sr.getAttributeCount() == 0) {
+                continue;
+              }
+              IRI parentIRI = IRI.create(sr.getAttributeValue(0));
+              Set<IRI> parents = childParentMap.getOrDefault(iri, new HashSet<>());
+              parents.add(parentIRI);
+              childParentMap.put(iri, parents);
+              continue;
+            }
+
+            // Check if the node is for an entity declaration
+            // Add the IRI
+            switch (node) {
+              case ONTOLOGY_TAG:
+                // Maybe get an ontology IRI
+                if (sr.getAttributeCount() == 0) {
+                  continue;
+                }
+                if (outputIRI == null) {
+                  String ontologyIRI = sr.getAttributeValue(0);
+                  outputIRI = IRI.create(ontologyIRI);
+                }
+                break;
+
+              case CLASS_TAG:
+              case OBJECT_PROPERTY_TAG:
+                if (sr.getAttributeCount() == 0) {
+                  // anonymous
+                  anonymous = true;
+                  continue;
+                }
+                iri = IRI.create(sr.getAttributeValue(0));
+                if (node.equals(CLASS_TAG)) {
+                  typeMap.put(iri, EntityType.CLASS);
+                } else {
+                  typeMap.put(iri, EntityType.OBJECT_PROPERTY);
+                }
+                break;
+              case ANNOTATION_PROPERTY_TAG:
+              case DATA_PROPERTY_TAG:
+              case OWL_DATATYPE_TAG:
+              case NAMED_INDIVIDUAL_TAG:
+                iri = IRI.create(sr.getAttributeValue(0));
+                switch (node) {
+                  case ANNOTATION_PROPERTY_TAG:
+                    typeMap.put(iri, EntityType.ANNOTATION_PROPERTY);
+                    allAnnotationProperties.add(iri);
+                    break;
+                  case DATA_PROPERTY_TAG:
+                    typeMap.put(iri, EntityType.DATA_PROPERTY);
+                    break;
+                  case OWL_DATATYPE_TAG:
+                    typeMap.put(iri, EntityType.DATATYPE);
+                    break;
+                  default:
+                    typeMap.put(iri, EntityType.NAMED_INDIVIDUAL);
+                    break;
+                }
+                break;
+            }
+
+            break;
+          case XMLEvent.CHARACTERS:
+            if (node == null || iri == null) {
+              // Node should never be null here
+              continue;
+            }
+            if (node.equals(LABEL_TAG)) {
+              String content = sr.getText();
+              if (content.trim().equals("")) {
+                continue;
+              }
+              if (currentContent != null) {
+                currentContent.append(content);
+              } else {
+                currentContent = new StringBuilder(content);
+              }
+            }
+            break;
+          case XMLEvent.END_ELEMENT:
+            node = sr.getName().toString();
+            // Check if the node is for an entity declaration
+            switch (node) {
+              case ANNOTATION_PROPERTY_TAG:
+              case CLASS_TAG:
+              case DATA_PROPERTY_TAG:
+              case OWL_DATATYPE_TAG:
+              case NAMED_INDIVIDUAL_TAG:
+              case OBJECT_PROPERTY_TAG:
+                if (!anonymous) {
+                  iri = null;
+                } else {
+                  anonymous = false;
+                }
+                continue;
+            }
+            if (node.equals(LABEL_TAG) && currentContent != null) {
+              String content = currentContent.toString();
+
+              if (labelMap.containsValue(content)) {
+                logger.debug(String.format("Duplicate label '%s' - appending IRI!", content));
+                IRI dupIRI = labelMap.inverse().get(content);
+                content = String.format("%s <%s>", content, iri);
+                String dupContent = String.format("%s <%s>", content, dupIRI);
+                labelMap.put(dupIRI, dupContent);
+                labelMap.put(iri, content);
+              } else {
+                labelMap.put(iri, content);
+              }
+              currentContent = null;
+            }
+            break;
+        }
+      }
+    } finally {
+      sr.closeCompletely();
+    }
+  }
+
+  /**
+   * Create a new ontology by extracting target IRIs. This ontology only includes the declarations
+   * and the hierarchy.
+   *
+   * @param targets set of IRIs to include in output ontology
+   * @param intermediates 'none', 'all', or 'minimal'
+   * @throws OWLOntologyCreationException on issue creating empty ontology
+   */
+  private void initOntology(Set<IRI> targets, String intermediates)
+    throws OWLOntologyCreationException {
+    for (IRI iri : targets) {
+      EntityType<?> et = getEntityType(iri);
+      if (et == null) {
+        System.out.println(String.format("Unable to create entity from <%s>", iri.toString()));
+        continue;
+      }
+      // Add declaration
+      OWLEntity e = dataFactory.getOWLEntity(et, iri);
+      manager.addAxiom(outputOntology, dataFactory.getOWLDeclarationAxiom(e));
+    }
+
+    // Handle parents
+    for (IRI iri : targets) {
+      if (intermediates.equals("none")) {
+        // Assert what relationships we can between existing terms
+        addAncestorsNoIntermediates(targets, iri, iri);
+      } else if (intermediates.equals("all") || intermediates.equals("minimal")) {
+        // Add all terms between existing terms
+        addAncestorsAllIntermediates(targets, iri);
+      } else {
+        throw new IllegalArgumentException("Unknown intermediates option: " + intermediates);
+      }
+    }
+
+    if (intermediates.equals("minimal")) {
+      // Minimal intermediates, collapse ontology
+      OntologyHelper.collapseOntology(outputOntology, targets);
+    }
+
+    // Add all entities referenced in ontology to targets for annotations
+    OntologyHelper.getEntities(outputOntology).forEach(e -> allTargets.add(e.getIRI()));
+  }
+
+  private void addOWLAxiomsToSource(
+    Set<OWLAnnotation> annotations,
+    String source,
+    String property,
+    String target,
+    String targetContent) {
+    if (!annotations.isEmpty() && source != null && property != null) {
+      // We must have a source, a property, and annotations
+      // Target (resource) might be null - requires target content
+      // Target content might be null - requires target (resource)
+      // If both target content and target are not null, target is an IRI for a datatype
+
+      IRI sourceIRI = IRI.create(source.replace("{", "").replace("}", ""));
+      if (!allTargets.contains(sourceIRI)) {
+        // Only add if the source of axiom is in the targets we are extracting
+        return;
+      }
+
+      // Target property - potentially an annotation property, or a logical property
+      IRI propertyIRI = IRI.create(property.replace("{", "").replace("}", ""));
+
+      // This is either an IRI, a datatype, or null
+      IRI targetIRI = null;
+      if (target != null) {
+        targetIRI = IRI.create(target);
+      }
+
+      if (targetContent != null && !targetContent.trim().equals("")) {
+        // Create a parent annotation axiom using IRI as a datatype
+        OWLAnnotationProperty ap = dataFactory.getOWLAnnotationProperty(propertyIRI);
+        OWLLiteral lit;
+        if (targetIRI != null) {
+          lit = dataFactory.getOWLLiteral(targetContent, dataFactory.getOWLDatatype(targetIRI));
+        } else {
+          lit = dataFactory.getOWLLiteral(targetContent);
+        }
+        OWLAnnotation parentAnnotation = dataFactory.getOWLAnnotation(ap, lit);
+        OWLAxiom ax =
+          dataFactory.getOWLAnnotationAssertionAxiom(sourceIRI, parentAnnotation, annotations);
+        manager.addAxiom(outputOntology, ax);
+
+      } else if (targetIRI != null) {
+        // Target is an IRI which means the axiom is targeting a logical axiom
+        OWLClass sourceClass = dataFactory.getOWLClass(sourceIRI);
+        OWLClass targetClass = dataFactory.getOWLClass(targetIRI);
+        Set<OWLClass> cls = new HashSet<>();
+        cls.add(sourceClass);
+        cls.add(targetClass);
+
+        if (propertyIRI
+          .toString()
+          .equalsIgnoreCase("http://www.w3.org/2000/01/rdf-schema#subClassOf")) {
+          OWLSubClassOfAxiom subClassOfAxiom =
+            dataFactory.getOWLSubClassOfAxiom(sourceClass, targetClass, annotations);
+          manager.addAxiom(outputOntology, subClassOfAxiom);
+        } else if (propertyIRI
+          .toString()
+          .equalsIgnoreCase("http://www.w3.org/2002/07/owl#equivalentClasses")) {
+          OWLDisjointClassesAxiom disjointClassesAxiom =
+            dataFactory.getOWLDisjointClassesAxiom(cls, annotations);
+          manager.addAxiom(outputOntology, disjointClassesAxiom);
+        } else if (propertyIRI
+          .toString()
+          .equalsIgnoreCase("http://www.w3.org/2002/07/owl#disjointClasses")) {
+          OWLEquivalentClassesAxiom eqClassesAxiom =
+            dataFactory.getOWLEquivalentClassesAxiom(cls, annotations);
+          manager.addAxiom(outputOntology, eqClassesAxiom);
+        }
+      }
+    }
+  }
+
+  /**
+   * Add OWLAxiom objects to output ontology for all targets that are sources of OWLAxioms.
+   *
+   * @param fis FileInputStream of XML
+   * @param annotationProperties set of IRIs for annotation properties to include
+   * @throws XMLStreamException on issue parsing XML
+   */
+  private void addOWLAxioms(FileInputStream fis, Set<IRI> annotationProperties)
+    throws XMLStreamException {
+    if (annotationProperties == null || annotationProperties.isEmpty()) {
+      // Add all annotation properties if they were not provided
+      annotationProperties = allAnnotationProperties;
+    }
+    XMLInputFactory2 inf = (XMLInputFactory2) XMLInputFactory2.newInstance();
+    XMLStreamReader2 sr = (XMLStreamReader2) inf.createXMLStreamReader(fileName, fis);
+
+    int e;
+    String node = null;
+
+    // Parts of the OWLAxiom
+    String source = null;
+    String property = null;
+    String target = null;
+    String annotationNode = null;
+
+    // Annotation content
+    StringBuilder targetContentBuilder = null;
+    String targetContent = null;
+    StringBuilder annotationContentBuilder = null;
+
+    Set<OWLAnnotation> annotations = new HashSet<>();
+
+    // Datatype of annotation
+    String annotationDt = null;
+
+    try {
+      while (sr.hasNext()) {
+        e = sr.next();
+        if (e == XMLEvent.START_ELEMENT && sr.getName().toString().equalsIgnoreCase(AXIOM_TAG)) {
+          // Start of OWLAxiom - the only element we care about
+          boolean inAx = true;
+          while (inAx) {
+            // Loop through elements until we hit end of AXIOM_TAG
+            // When we do, break out of this while loop
+            if (sr.hasNext()) {
+              e = sr.next();
+              if (e == XMLEvent.END_ELEMENT) {
+                node = sr.getName().toString();
+                if (!node.equalsIgnoreCase(AXIOM_TAG)) {
+                  // End of OWL Axiom, reset all values and break
+                  if (node.equalsIgnoreCase(ANNOTATED_TARGET_TAG) && targetContentBuilder != null) {
+                    // End of target with content
+                    targetContent = targetContentBuilder.toString();
+                    targetContentBuilder = null;
+
+                  } else if (node.equalsIgnoreCase(annotationNode)
+                    && annotationContentBuilder != null) {
+                    // End of annotation with content
+                    String annotationContent = annotationContentBuilder.toString();
+
+                    // Create annotation and add to set, as there may be more than one
+                    OWLLiteral literal;
+                    if (annotationDt != null) {
+                      OWLDatatype dt = dataFactory.getOWLDatatype(IRI.create(annotationDt));
+                      literal = dataFactory.getOWLLiteral(annotationContent, dt);
+                    } else {
+                      literal = dataFactory.getOWLLiteral(annotationContent);
+                    }
+
+                    IRI annotationIRI =
+                      IRI.create(annotationNode.replace("{", "").replace("}", ""));
+                    if (annotationProperties.contains(annotationIRI)) {
+                      // Only include the annotation if the annotation property is in our set
+                      OWLAnnotationProperty ap =
+                        dataFactory.getOWLAnnotationProperty(annotationIRI);
+                      OWLAnnotation a = dataFactory.getOWLAnnotation(ap, literal);
+                      annotations.add(a);
+                      annotationContentBuilder = null;
+                      annotationNode = null;
+                    }
+                  }
+                } else {
+                  // End of OWL Axiom
+                  // Add the annotations
+                  addOWLAxiomsToSource(annotations, source, property, target, targetContent);
+                  inAx = false;
+                  annotations = new HashSet<>();
+                }
+
+              } else if (e == XMLEvent.START_ELEMENT) {
+                node = sr.getName().toString();
+                switch (node) {
+                  case ANNOTATED_SOURCE_TAG:
+                    if (sr.getAttributeCount() > 0) {
+                      // Source should always have a resource
+                      source = sr.getAttributeValue(0);
+                    }
+                    break;
+
+                  case ANNOTATED_PROPERTY_TAG:
+                    if (sr.getAttributeCount() > 0) {
+                      // Property should always have a resource
+                      property = sr.getAttributeValue(0);
+                    }
+                    break;
+
+                  case ANNOTATED_TARGET_TAG:
+                    if (sr.getAttributeCount() > 0) {
+                      // This may or may not have a resource
+                      // This is either a datatype or another entity IRI
+                      target = sr.getAttributeValue(0);
+                    }
+                    break;
+
+                  default:
+                    // The node is the annotation property
+                    annotationNode = node;
+                    if (sr.getAttributeCount() > 0) {
+                      // This might have a datatype
+                      annotationDt = sr.getAttributeValue(0);
+                    }
+                }
+
+              } else if (e == XMLEvent.CHARACTERS) {
+                if (node == null) {
+                  // node should never be null here
+                  // but just in case, continue to next element
+                  continue;
+                }
+
+                String content = sr.getText();
+                if (node.equalsIgnoreCase(ANNOTATED_TARGET_TAG)) {
+                  // Target content (if the OWLAxiom is targeting another annotation)
+                  if (targetContentBuilder == null) {
+                    targetContentBuilder = new StringBuilder();
+                  }
+                  if (!content.trim().isEmpty()) {
+                    targetContentBuilder.append(content);
+                  }
+
+                } else if (annotationNode != null) {
+                  // Annotation content
+                  if (annotationContentBuilder == null) {
+                    annotationContentBuilder = new StringBuilder();
+                  }
+                  if (!content.trim().isEmpty()) {
+                    annotationContentBuilder.append(content);
+                  }
+                }
+              }
+            } else {
+              // End of OWL Axiom
+              // Add the annotations
+              addOWLAxiomsToSource(annotations, source, property, target, targetContent);
+              inAx = false;
+              annotations = new HashSet<>();
+            }
+          }
+        }
+      }
+    } finally {
+      sr.closeCompletely();
+    }
+  }
+
+  /**
+   * Add annotations to output ontology for all targets.
+   *
+   * @param fis FileInputStream of XML
+   * @param annotationProperties set of IRIs for annotation properties to include
+   * @throws XMLStreamException on issue parsing XML
+   */
+  private void addAnnotations(FileInputStream fis, Set<IRI> annotationProperties)
+    throws XMLStreamException {
+    if (annotationProperties == null || annotationProperties.isEmpty()) {
+      // Add all annotation properties if they were not provided
+      annotationProperties = allAnnotationProperties;
+    }
+    XMLInputFactory2 inf = (XMLInputFactory2) XMLInputFactory2.newInstance();
+    XMLStreamReader2 sr = (XMLStreamReader2) inf.createXMLStreamReader(fileName, fis);
+
+    // XML Event int
+    int e;
+
+    // Current XML node
+    String node = null;
+
+    // Ignore anonymous nodes
+    boolean anonymous = false;
+
+    // Current entity IRI
+    IRI iri = null;
+
+    // Current annotation property IRI
+    IRI apIRI = null;
+
+    // Current content of annotation
+    StringBuilder currentContent = null;
+
+    // Maybe track a datatype
+    OWLDatatype annotationDatatype = null;
+
+    // Maybe track a language
+    String lang = null;
+
+    try {
+      while (sr.hasNext()) {
+        e = sr.next();
+        switch (e) {
+          case XMLEvent.START_ELEMENT:
+            // Start of an XML tag
+            node = sr.getName().toString();
+            boolean isEntity = false;
+
+            // Check if the node is for an entity declaration
+            switch (node) {
+              case ANNOTATION_PROPERTY_TAG:
+              case DATA_PROPERTY_TAG:
+              case OWL_DATATYPE_TAG:
+              case NAMED_INDIVIDUAL_TAG:
+                iri = IRI.create(sr.getAttributeValue(0));
+                isEntity = true;
+                break;
+              case CLASS_TAG:
+              case OBJECT_PROPERTY_TAG:
+                if (sr.getAttributeCount() == 0) {
+                  // Skip anonymous for now
+                  anonymous = true;
+                  continue;
+                }
+                iri = IRI.create(sr.getAttributeValue(0));
+                isEntity = true;
+                break;
+            }
+
+            // IRI = null for entities we don't care about
+            if (!allTargets.contains(iri) && isEntity) {
+              iri = null;
+              continue;
+            }
+
+            // Could be an annotation with a datatype or language
+            if (sr.getAttributeCount() > 0 && !isEntity) {
+              String attr = sr.getAttributeName(0).toString();
+              if (attr.equals(RDFS_DATATYPE_TAG)) {
+                IRI dtIRI = IRI.create(sr.getAttributeValue(0));
+                annotationDatatype = dataFactory.getOWLDatatype(dtIRI);
+              } else if (attr.equals(LANG_TAG)) {
+                lang = sr.getAttributeValue(0);
+              }
+            }
+            break;
+
+          case XMLEvent.CHARACTERS:
+            // Content inside of XML tags
+            if (node == null || iri == null) {
+              // Node should never be null here
+              // If IRI is null, we don't care about this entity
+              continue;
+            }
+            String content = sr.getText();
+            if (content.trim().equals("")) {
+              // Skip empty content
+              continue;
+            }
+
+            // Create an IRI from the node and check if it's in the desired APs
+            node = node.replace("{", "").replace("}", "");
+            IRI maybeIRI = IRI.create(node);
+            if (annotationProperties.contains(maybeIRI) && apIRI == null) {
+              // Set AP IRI to track and init content builder
+              apIRI = maybeIRI;
+              currentContent = new StringBuilder(content);
+            } else if (maybeIRI == apIRI) {
+              // Continue to add to content builder
+              currentContent.append(content);
+            }
+            break;
+
+          case XMLEvent.END_ELEMENT:
+            // XML closing tag
+            if (iri == null) {
+              continue;
+            }
+            node = sr.getName().toString();
+
+            // Check if the node is for an entity declaration
+            switch (node) {
+              case ANNOTATION_PROPERTY_TAG:
+              case CLASS_TAG:
+              case DATA_PROPERTY_TAG:
+              case OWL_DATATYPE_TAG:
+              case NAMED_INDIVIDUAL_TAG:
+              case OBJECT_PROPERTY_TAG:
+                if (!anonymous) {
+                  iri = null;
+                } else {
+                  anonymous = false;
+                }
+                continue;
+            }
+
+            // If not entity, it might be closing of an annotation
+            node = node.replace("{", "").replace("}", "");
+            if (apIRI != null && node.equals(apIRI.toString())) {
+              // Closing of an annotation property
+              // Add the content to the ontology
+              content = currentContent.toString();
+              OWLAnnotationProperty ap = dataFactory.getOWLAnnotationProperty(apIRI);
+              OWLLiteral lit;
+              if (annotationDatatype != null) {
+                lit = dataFactory.getOWLLiteral(content, annotationDatatype);
+              } else if (lang != null) {
+                lit = dataFactory.getOWLLiteral(content, lang);
+              } else {
+                lit = dataFactory.getOWLLiteral(content);
+              }
+              manager.addAxiom(
+                outputOntology, dataFactory.getOWLAnnotationAssertionAxiom(ap, iri, lit));
+
+              // Reset tracking variables
+              apIRI = null;
+              currentContent = null;
+              annotationDatatype = null;
+              lang = null;
+            }
+            break;
+        }
+      }
+    } finally {
+      sr.closeCompletely();
+    }
+  }
+
+  /**
+   * Create a hiearchy within the output ontology with all intermediates. Terms not included in
+   * target set will be used to fill in gaps. Update the set of targets to include added entities.
+   *
+   * @param targets set of target IRIs
+   * @param childIRI IRI for current term to be asserted as child of something else
+   */
+  private void addAncestorsAllIntermediates(Set<IRI> targets, IRI childIRI) {
+    Set<IRI> parents = getParents(childIRI);
+    for (IRI piri : parents) {
+      addSubXOfAxiom(childIRI, piri);
+      if (!targets.contains(piri)) {
+        addAncestorsAllIntermediates(targets, piri);
+      }
+    }
+  }
+
+  /**
+   * Create a hierarchy within the output ontology with no intermediates. Only terms within the
+   * target set will be included, and relationships will be made between ancestors an descendants to
+   * fill in gaps.
+   *
+   * @param targets set of target IRIs
+   * @param bottomIRI bottom-level IRI
+   * @param currentIRI current-level IRI
+   */
+  private void addAncestorsNoIntermediates(Set<IRI> targets, IRI bottomIRI, IRI currentIRI) {
+    Set<IRI> parents = getParents(currentIRI);
+    for (IRI piri : parents) {
+      if (targets.contains(piri)) {
+        addSubXOfAxiom(bottomIRI, piri);
+      } else {
+        addAncestorsNoIntermediates(targets, bottomIRI, piri);
+      }
+    }
+  }
+
+  /**
+   * Add a 'subXOf' axiom (subClass, subProperty) to the output ontology.
+   *
+   * @param childIRI child in SubX axiom
+   * @param parentIRI parent in SubX axiom
+   */
+  private void addSubXOfAxiom(IRI childIRI, IRI parentIRI) {
+    EntityType<?> et = getEntityType(childIRI);
+    if (et == EntityType.CLASS) {
+      OWLClass child = dataFactory.getOWLClass(childIRI);
+      OWLClass parent = dataFactory.getOWLClass(parentIRI);
+      manager.addAxiom(outputOntology, dataFactory.getOWLSubClassOfAxiom(child, parent));
+    } else if (et == EntityType.ANNOTATION_PROPERTY) {
+      OWLAnnotationProperty child = dataFactory.getOWLAnnotationProperty(childIRI);
+      OWLAnnotationProperty parent = dataFactory.getOWLAnnotationProperty(parentIRI);
+      manager.addAxiom(
+        outputOntology, dataFactory.getOWLSubAnnotationPropertyOfAxiom(child, parent));
+    } else if (et == EntityType.DATA_PROPERTY) {
+      OWLDataProperty child = dataFactory.getOWLDataProperty(childIRI);
+      OWLDataProperty parent = dataFactory.getOWLDataProperty(parentIRI);
+      manager.addAxiom(outputOntology, dataFactory.getOWLSubDataPropertyOfAxiom(child, parent));
+    } else if (et == EntityType.OBJECT_PROPERTY) {
+      OWLObjectProperty child = dataFactory.getOWLObjectProperty(childIRI);
+      OWLObjectProperty parent = dataFactory.getOWLObjectProperty(parentIRI);
+      manager.addAxiom(outputOntology, dataFactory.getOWLSubObjectPropertyOfAxiom(child, parent));
+    }
+  }
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/XMLHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/XMLHelper.java
@@ -32,7 +32,7 @@ public class XMLHelper {
 
   // Entity types
   private final String ANNOTATION_PROPERTY_TAG =
-    "{http://www.w3.org/2002/07/owl#}AnnotationProperty";
+      "{http://www.w3.org/2002/07/owl#}AnnotationProperty";
   private final String CLASS_TAG = "{http://www.w3.org/2002/07/owl#}Class";
   private final String DATA_PROPERTY_TAG = "{http://www.w3.org/2002/07/owl#}DatatypeProperty";
   private final String OWL_DATATYPE_TAG = "{http://www.w3.org/2002/07/owl#}Datatype";
@@ -85,7 +85,7 @@ public class XMLHelper {
    * @throws OWLOntologyCreationException if empty ontology cannot be created
    */
   public XMLHelper(String fileName, IRI outputIRI)
-    throws IOException, OWLOntologyCreationException {
+      throws IOException, OWLOntologyCreationException {
     this.fileName = fileName;
     // Create an empty ontology
     outputOntology = manager.createOntology();
@@ -123,7 +123,7 @@ public class XMLHelper {
     // Download ontology, following redirects
     logger.info(String.format("Starting download from <%s>", iri.toString()));
     CloseableHttpClient httpclient =
-      HttpClients.custom().setRedirectStrategy(new LaxRedirectStrategy()).build();
+        HttpClients.custom().setRedirectStrategy(new LaxRedirectStrategy()).build();
     try {
       HttpGet get = new HttpGet(iri.toURI());
       HttpResponse r = httpclient.execute(get);
@@ -163,8 +163,8 @@ public class XMLHelper {
    * @throws OWLOntologyCreationException on problem creating empty ontology
    */
   public OWLOntology extract(
-    Set<IRI> targets, Set<IRI> annotationProperties, Map<String, String> options)
-    throws IOException, OWLOntologyCreationException {
+      Set<IRI> targets, Set<IRI> annotationProperties, Map<String, String> options)
+      throws IOException, OWLOntologyCreationException {
     String intermediates = OptionsHelper.getOption(options, "intermediates", "all");
     boolean annotateSource = OptionsHelper.optionIsTrue(options, "annotate-with-source");
 
@@ -191,8 +191,8 @@ public class XMLHelper {
       OWLAnnotationProperty isDefinedBy = dataFactory.getRDFSIsDefinedBy();
       for (IRI iri : allTargets) {
         manager.addAxiom(
-          outputOntology,
-          dataFactory.getOWLAnnotationAssertionAxiom(isDefinedBy, iri, outputIRI));
+            outputOntology,
+            dataFactory.getOWLAnnotationAssertionAxiom(isDefinedBy, iri, outputIRI));
       }
     }
 
@@ -408,7 +408,7 @@ public class XMLHelper {
    * @throws OWLOntologyCreationException on issue creating empty ontology
    */
   private void initOntology(Set<IRI> targets, String intermediates)
-    throws OWLOntologyCreationException {
+      throws OWLOntologyCreationException {
     for (IRI iri : targets) {
       EntityType<?> et = getEntityType(iri);
       if (et == null) {
@@ -443,11 +443,11 @@ public class XMLHelper {
   }
 
   private void addOWLAxiomsToSource(
-    Set<OWLAnnotation> annotations,
-    String source,
-    String property,
-    String target,
-    String targetContent) {
+      Set<OWLAnnotation> annotations,
+      String source,
+      String property,
+      String target,
+      String targetContent) {
     if (!annotations.isEmpty() && source != null && property != null) {
       // We must have a source, a property, and annotations
       // Target (resource) might be null - requires target content
@@ -480,7 +480,7 @@ public class XMLHelper {
         }
         OWLAnnotation parentAnnotation = dataFactory.getOWLAnnotation(ap, lit);
         OWLAxiom ax =
-          dataFactory.getOWLAnnotationAssertionAxiom(sourceIRI, parentAnnotation, annotations);
+            dataFactory.getOWLAnnotationAssertionAxiom(sourceIRI, parentAnnotation, annotations);
         manager.addAxiom(outputOntology, ax);
 
       } else if (targetIRI != null) {
@@ -492,22 +492,22 @@ public class XMLHelper {
         cls.add(targetClass);
 
         if (propertyIRI
-          .toString()
-          .equalsIgnoreCase("http://www.w3.org/2000/01/rdf-schema#subClassOf")) {
+            .toString()
+            .equalsIgnoreCase("http://www.w3.org/2000/01/rdf-schema#subClassOf")) {
           OWLSubClassOfAxiom subClassOfAxiom =
-            dataFactory.getOWLSubClassOfAxiom(sourceClass, targetClass, annotations);
+              dataFactory.getOWLSubClassOfAxiom(sourceClass, targetClass, annotations);
           manager.addAxiom(outputOntology, subClassOfAxiom);
         } else if (propertyIRI
-          .toString()
-          .equalsIgnoreCase("http://www.w3.org/2002/07/owl#equivalentClasses")) {
+            .toString()
+            .equalsIgnoreCase("http://www.w3.org/2002/07/owl#equivalentClasses")) {
           OWLDisjointClassesAxiom disjointClassesAxiom =
-            dataFactory.getOWLDisjointClassesAxiom(cls, annotations);
+              dataFactory.getOWLDisjointClassesAxiom(cls, annotations);
           manager.addAxiom(outputOntology, disjointClassesAxiom);
         } else if (propertyIRI
-          .toString()
-          .equalsIgnoreCase("http://www.w3.org/2002/07/owl#disjointClasses")) {
+            .toString()
+            .equalsIgnoreCase("http://www.w3.org/2002/07/owl#disjointClasses")) {
           OWLEquivalentClassesAxiom eqClassesAxiom =
-            dataFactory.getOWLEquivalentClassesAxiom(cls, annotations);
+              dataFactory.getOWLEquivalentClassesAxiom(cls, annotations);
           manager.addAxiom(outputOntology, eqClassesAxiom);
         }
       }
@@ -522,7 +522,7 @@ public class XMLHelper {
    * @throws XMLStreamException on issue parsing XML
    */
   private void addOWLAxioms(FileInputStream fis, Set<IRI> annotationProperties)
-    throws XMLStreamException {
+      throws XMLStreamException {
     if (annotationProperties == null || annotationProperties.isEmpty()) {
       // Add all annotation properties if they were not provided
       annotationProperties = allAnnotationProperties;
@@ -570,7 +570,7 @@ public class XMLHelper {
                     targetContentBuilder = null;
 
                   } else if (node.equalsIgnoreCase(annotationNode)
-                    && annotationContentBuilder != null) {
+                      && annotationContentBuilder != null) {
                     // End of annotation with content
                     String annotationContent = annotationContentBuilder.toString();
 
@@ -584,11 +584,11 @@ public class XMLHelper {
                     }
 
                     IRI annotationIRI =
-                      IRI.create(annotationNode.replace("{", "").replace("}", ""));
+                        IRI.create(annotationNode.replace("{", "").replace("}", ""));
                     if (annotationProperties.contains(annotationIRI)) {
                       // Only include the annotation if the annotation property is in our set
                       OWLAnnotationProperty ap =
-                        dataFactory.getOWLAnnotationProperty(annotationIRI);
+                          dataFactory.getOWLAnnotationProperty(annotationIRI);
                       OWLAnnotation a = dataFactory.getOWLAnnotation(ap, literal);
                       annotations.add(a);
                       annotationContentBuilder = null;
@@ -687,7 +687,7 @@ public class XMLHelper {
    * @throws XMLStreamException on issue parsing XML
    */
   private void addAnnotations(FileInputStream fis, Set<IRI> annotationProperties)
-    throws XMLStreamException {
+      throws XMLStreamException {
     if (annotationProperties == null || annotationProperties.isEmpty()) {
       // Add all annotation properties if they were not provided
       annotationProperties = allAnnotationProperties;
@@ -832,7 +832,7 @@ public class XMLHelper {
                 lit = dataFactory.getOWLLiteral(content);
               }
               manager.addAxiom(
-                outputOntology, dataFactory.getOWLAnnotationAssertionAxiom(ap, iri, lit));
+                  outputOntology, dataFactory.getOWLAnnotationAssertionAxiom(ap, iri, lit));
 
               // Reset tracking variables
               apIRI = null;
@@ -901,7 +901,7 @@ public class XMLHelper {
       OWLAnnotationProperty child = dataFactory.getOWLAnnotationProperty(childIRI);
       OWLAnnotationProperty parent = dataFactory.getOWLAnnotationProperty(parentIRI);
       manager.addAxiom(
-        outputOntology, dataFactory.getOWLSubAnnotationPropertyOfAxiom(child, parent));
+          outputOntology, dataFactory.getOWLSubAnnotationPropertyOfAxiom(child, parent));
     } else if (et == EntityType.DATA_PROPERTY) {
       OWLDataProperty child = dataFactory.getOWLDataProperty(childIRI);
       OWLDataProperty parent = dataFactory.getOWLDataProperty(parentIRI);

--- a/robot-core/src/main/java/org/obolibrary/robot/XMLHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/XMLHelper.java
@@ -763,11 +763,16 @@ public class XMLHelper {
             // IRI = null for entities we don't care about
             if (!allTargets.contains(iri) && isEntity) {
               iri = null;
+              apIRI = null;
+              currentContent = null;
+              annotationDatatype = null;
+              lang = null;
               continue;
             }
 
             // Could be an annotation with a datatype or language
-            if (sr.getAttributeCount() > 0 && !isEntity) {
+            // We only care about the annotations on target IRIs
+            if (sr.getAttributeCount() > 0 && !isEntity && iri != null) {
               String attr = sr.getAttributeName(0).toString();
               if (attr.equals(RDFS_DATATYPE_TAG)) {
                 IRI dtIRI = IRI.create(sr.getAttributeValue(0));

--- a/robot-core/src/main/java/org/obolibrary/robot/XMLHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/XMLHelper.java
@@ -452,7 +452,7 @@ public class XMLHelper {
       EntityType<?> et = getEntityType(iri);
       if (et == null) {
         // Entity does not exist in the target ontology
-        logger.error(String.format("<%s> does not exist in input ontology", iri.toString()));
+        logger.warn(String.format("<%s> does not exist in input ontology", iri.toString()));
         doesNotExist.add(iri);
         continue;
       }


### PR DESCRIPTION
Create an `RDFXML` extraction method for big ontologies. This uses XML parsing instead of loading the ontology as an `OWLOntology` object.

- [x] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

Previously this was `mireot-rdfxml` but I changed it to `RDFXML` (or `rdfxml`). If people prefer the former, I'll revert it.
