### PR TITLE
Fix sorting in export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix filtering axioms with multiple axiom selectors [#644]
+- Fix comparator method for sorting empty strings with [`export`] in [#654]
 
 ## [1.6.0] - 2020-03-04
 
@@ -177,6 +178,7 @@ First official release of ROBOT!
 [`report`]: http://robot.obolibrary.org/report
 [`template`]: http://robot.obolibrary.org/template
 
+[#654]: https://github.com/ontodev/robot/issues/654
 [#646]: https://github.com/ontodev/robot/issues/646
 [#645]: https://github.com/ontodev/robot/issues/645
 [#644]: https://github.com/ontodev/robot/issues/644

--- a/robot-core/src/main/java/org/obolibrary/robot/export/Table.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/export/Table.java
@@ -8,9 +8,13 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** @author <a href="mailto@rbca.jackson@gmail.com">Becky Jackson</a> */
 public class Table {
+  /** Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(Table.class);
 
   private String format;
 
@@ -164,15 +168,15 @@ public class Table {
     for (Column sc : sortColumns) {
       // Sort name is used to get the value
       String sortName = sc.getDisplayName();
+      logger.info("Sorting on column " + sortName);
       Comparator<Row> rowComparator =
           (r1, r2) -> {
-            String v1 = r1.getSortValueString(sortName);
-            String v2 = r2.getSortValueString(sortName);
-
-            // Make sure empty strings end up last
-            if (v1.isEmpty()) return Integer.MAX_VALUE;
-            else if (v2.isEmpty()) return Integer.MIN_VALUE;
-            else return v1.compareTo(v2);
+            String o1 = r1.getSortValueString(sortName);
+            String o2 = r2.getSortValueString(sortName);
+            if (o1.trim().isEmpty() && o2.trim().isEmpty()) return 0;
+            else if (o1.trim().isEmpty()) return 1;
+            else if (o2.trim().isEmpty()) return -1;
+            else return o1.compareTo(o2);
           };
       if (sc.isReverseSort()) {
         rows.sort(Collections.reverseOrder(rowComparator));


### PR DESCRIPTION
- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

Ran into a minor problem with comparing empty strings:
```
Comparison method violates its general contract!
```
Apparently there was a transitivity issue in the comparator method.