### PR TITLE
Stream JSON format output to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix filtering axioms with multiple axiom selectors [#644]
 - Fix comparator method for sorting empty strings with [`export`] in [#654]
 - Fix releasing dataset after exception when running [`report`] with `--tdb true` [#659]
+- Fix writing JSON format to use `OutputStream` with ['convert'] in [#670]
 
 ## [1.6.0] - 2020-03-04
 

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -1,5 +1,8 @@
 package org.obolibrary.robot;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.github.jsonldjava.core.Context;
 import com.github.jsonldjava.core.JsonLdApi;
 import com.github.jsonldjava.core.JsonLdError;
@@ -1406,9 +1409,11 @@ public class IOHelper {
     if (format instanceof OboGraphJsonDocumentFormat) {
       FromOwl fromOwl = new FromOwl();
       GraphDocument gd = fromOwl.generateGraphDocument(ontology);
-      String doc = OgJsonGenerator.render(gd);
       File outfile = new File(ontologyIRI.toURI());
-      FileUtils.writeStringToFile(outfile, doc);
+      ObjectMapper mapper = new ObjectMapper();
+      mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+      ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();
+      writer.writeValue(new FileOutputStream(outfile), gd);
     } else if (format instanceof OBODocumentFormat && !checkOBO) {
       // only use this method when ignoring OBO checking, otherwise use native save
       OWLAPIOwl2Obo bridge = new OWLAPIOwl2Obo(ontology.getOWLOntologyManager());


### PR DESCRIPTION
Resolves #670 

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

Fixes an error encountered when converting `go-lego.owl` to `go-lego.json` as covered in issue #670. I pretty much transplanted code from [obographs/OgJsonGenerator.prettyJsonString](https://github.com/geneontology/obographs/blob/55b8000c9026fe90c0c9d94b71d68849ca04861e/src/main/java/org/geneontology/obographs/io/OgJsonGenerator.java#L15-L17) along with @julesjacobsen's [suggestion](https://github.com/ontodev/robot/issues/670#issuecomment-613477081) to stream the output.