### PR TITLE
Changed invalid reference violations to warnings.

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
@@ -581,7 +581,7 @@ public class ReasonOperation {
     }
 
     if (filteredViolations.size() > 0) {
-      logger.error(
+      logger.warn(
           "Reference violations found: "
               + filteredViolations.size()
               + " - reasoning may be incomplete");
@@ -591,10 +591,10 @@ public class ReasonOperation {
       for (InvalidReferenceViolation v : filteredViolations) {
         if (v.getCategory().equals(InvalidReferenceViolation.Category.DANGLING)
             && danglings < maxDanglings) {
-          logger.error("Reference violation: " + v);
+          logger.warn("Reference violation: " + v);
           danglings++;
         } else if (!v.getCategory().equals(InvalidReferenceViolation.Category.DANGLING)) {
-          logger.error("Reference violation: " + v);
+          logger.warn("Reference violation: " + v);
         }
       }
 


### PR DESCRIPTION
This is a tiny change to make invalid reference violation output logged as WARN instead of ERROR.  This is a frequent source of confusion (see #674). I think WARN is more accurate, because these messages are printed every time I use `robot reason`, and I still continue with the results.