### PR TITLE
Support `rdfs:label` in export

### DIFF
--- a/docs/examples/nucleus-iris.csv
+++ b/docs/examples/nucleus-iris.csv
@@ -1,4 +1,4 @@
-LABEL,SubClass Of [ID],SubClass Of [IRI]
+rdfs:label,SubClass Of [ID],SubClass Of [IRI]
 cell,GO:0005575,http://purl.obolibrary.org/obo/GO_0005575
 cell part,GO:0005575,http://purl.obolibrary.org/obo/GO_0005575
 cellular_component,,

--- a/docs/export.md
+++ b/docs/export.md
@@ -47,7 +47,7 @@ Various `--header` types are supported:
 * **Special Headers**:
 	* `IRI`: creates an "IRI" column based on the full unique identifier
 	* `ID`: creates an "ID" column based on the short form of the unique identifier (CURIE) - please note that all IRIs must have [defined prefixes](global/prefixes), or the full IRI will be returned.
-	* `LABEL`: creates a "Label" column based on `rdfs:label`
+	* `LABEL`: creates a "Label" column based on `rdfs:label` (`rdfs:label` can also be used in place of this column)
 	* `SYNONYMS`: creates a "SYNONYMS" column based on all synonyms (oboInOwl exact, broad, narrow, related, or IAO alternative term)
 	* `SubClass Of`: creates a "SubClass Of" column based on `rdfs:subClassOf`
 	* `SubClasses`: creates a "SubClasses" column based on direct children of a class
@@ -141,7 +141,7 @@ In the above example, all the "subclass of" values will be rendered by their sho
 You can also specify different rendering strategies for different columns by including the strategy name in a square-bracket-enclosed tag after the column name:
 
     robot export --input nucleus_part_of.owl \
-      --header "LABEL|SubClass Of [ID]|SubClass Of [IRI]" \
+      --header "rdfs:label|SubClass Of [ID]|SubClass Of [IRI]" \
       --exclude-anonymous true \
       --export results/nucleus-iris.csv
 

--- a/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
@@ -160,7 +160,6 @@ public class ExportOperation {
       IRI colIRI = ioHelper.createIRI(colName);
       if (colIRI != null
           && colIRI.toString().equals(dataFactory.getRDFSLabel().getIRI().toString())) {
-        System.out.println(colIRI);
         tag = "LABEL";
         ap = dataFactory.getRDFSLabel();
       }

--- a/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
@@ -155,6 +155,16 @@ public class ExportOperation {
 
       // Maybe get a property
       OWLAnnotationProperty ap = checker.getOWLAnnotationProperty(colName, false);
+
+      // Handle some defaults
+      IRI colIRI = ioHelper.createIRI(colName);
+      if (colIRI != null
+          && colIRI.toString().equals(dataFactory.getRDFSLabel().getIRI().toString())) {
+        System.out.println(colIRI);
+        tag = "LABEL";
+        ap = dataFactory.getRDFSLabel();
+      }
+
       OWLDataProperty dp = checker.getOWLDataProperty(colName);
       OWLObjectProperty op = checker.getOWLObjectProperty(colName);
 
@@ -766,13 +776,9 @@ public class ExportOperation {
           }
           break;
         case OBJECT_ONE_OF:
-          System.out.println("ONE OF " + ce);
-          break;
         case OBJECT_UNION_OF:
-          System.out.println("UNION OF " + ce);
-          break;
         case OBJECT_INTERSECTION_OF:
-          System.out.println("INTERSECTION OF " + ce);
+          // TODO
           break;
       }
     }
@@ -811,6 +817,14 @@ public class ExportOperation {
     for (Column col : table.getColumns()) {
 
       String colName = col.getName();
+      OWLProperty maybeAnnotation = col.getProperty();
+      if (maybeAnnotation instanceof OWLAnnotationProperty) {
+        OWLAnnotationProperty maybeLabel = (OWLAnnotationProperty) maybeAnnotation;
+        if (maybeLabel.isLabel()) {
+          // Handle like we do default LABEL columns
+          colName = "LABEL";
+        }
+      }
       ShortFormProvider provider = col.getShortFormProvider();
 
       Cell cell;


### PR DESCRIPTION
Resolves #677

- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct

Treat `rdfs:label` header like the default `LABEL` header in `export`
