### PR TITLE
Render annotation value IRIs correctly

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -147,6 +147,8 @@ You can also specify different rendering strategies for different columns by inc
 
 These tags should not be used with the following default columns: `LABEL`, `ID`, or `IRI` as they will not change the rendered values.
 
+These tags can be used for object and annotation property columns as well. When using these tags with annotation properties, the value in the cell will only change if the annotation value is an IRI. For literals, the annotation value will always be rendered the same, no matter what the tag is.
+
 ### Preparing the Ontology
 
 When exporting details on classes using object or data properties, we recommend running [reason](/reason), [relax](/relax), and [reduce](/reduce) first. You can also create a subset of entities using [remove](/remove) or [filter](/filter).

--- a/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
@@ -220,7 +220,7 @@ public class ExportOperation {
 
     // Get the cell values based on columns
     for (OWLEntity entity : entities) {
-      table.addRow(getRow(ontology, checker, table, entity, excludeAnonymous));
+      table.addRow(getRow(ontology, table, entity, excludeAnonymous));
     }
 
     // Sort the rows by sort column or columns
@@ -467,8 +467,7 @@ public class ExportOperation {
       RendererType rt,
       ShortFormProvider provider,
       OWLEntity entity,
-      OWLAnnotationProperty ap,
-      QuotedEntityChecker c) {
+      OWLAnnotationProperty ap) {
     List<String> values = new ArrayList<>();
     for (OWLAnnotationAssertionAxiom a :
         EntitySearcher.getAnnotationAssertionAxioms(entity, ontology)) {
@@ -837,11 +836,7 @@ public class ExportOperation {
    * @throws Exception on invalid column
    */
   private static Row getRow(
-      OWLOntology ontology,
-      QuotedEntityChecker c,
-      Table table,
-      OWLEntity entity,
-      boolean excludeAnonymous)
+      OWLOntology ontology, Table table, OWLEntity entity, boolean excludeAnonymous)
       throws Exception {
 
     String format = table.getFormat();
@@ -912,10 +907,10 @@ public class ExportOperation {
         if (colProperty instanceof OWLAnnotationProperty) {
           OWLAnnotationProperty ap = (OWLAnnotationProperty) colProperty;
           List<String> display =
-              getPropertyValues(ontology, displayRendererType, provider, entity, ap, c);
+              getPropertyValues(ontology, displayRendererType, provider, entity, ap);
           List<String> sort;
           if (sortRendererType != null) {
-            sort = getPropertyValues(ontology, sortRendererType, provider, entity, ap, c);
+            sort = getPropertyValues(ontology, sortRendererType, provider, entity, ap);
           } else {
             sort = display;
           }


### PR DESCRIPTION
- [x] `docs/` have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct

Minor problem found while using `export` on OBI. I would expect annotation value IRIs to render based on the tag in the header (`ID`, `LABEL`, etc.), but they always appear as IRIs because there is no check for `isIRI()` in parsing annotation values.

This fixes it so that entities can be rendered correctly when they appear as annotation values.

I don't think this requires updates to the changelog.
