### PR TITLE
Add option to just create a TDB directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add [`export`] command [#481]
 - Add JSON format to [`export`] in [#645]
 - Add Excel format to [`export`] in [#646]
+- Add `--create-tdb <true/false>` option to [`query`] in [#685]
 
 ### Changed
 - Updated `obographs` from 0.0.8 to 0.2.1 [#657]
@@ -185,6 +186,7 @@ First official release of ROBOT!
 [`report`]: http://robot.obolibrary.org/report
 [`template`]: http://robot.obolibrary.org/template
 
+[#685]: https://github.com/ontodev/robot/pull/685
 [#671]: https://github.com/ontodev/robot/pull/671
 [#666]: https://github.com/ontodev/robot/pull/666
 [#659]: https://github.com/ontodev/robot/issues/659

--- a/docs/query.md
+++ b/docs/query.md
@@ -83,6 +83,14 @@ Once the query operation is complete, ROBOT will remove the TDB directory. If yo
 
 The ontology is never loaded as an `OWLOntology` object, since doing so loads the whole ontology into memory. Therefore, TDB cannot be used while chaining commands or with the `--update` option.
 
+### Creating a TDB Directory
+
+You can also choose to just create a TDB directory without running a query using the `--create-tdb` option. This is useful for workflows were a TDB directory may need to be initiated in one step and queried mulitple times in another.
+
+```
+robot query --input nucleus.ttl --create-tdb true
+```
+
 ---
 
 ## Error Messages


### PR DESCRIPTION
- [x] `docs/` have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

Add `--create-tdb` option to `query` so that you can create a TDB directory without needing to provide a query.
