### PR TITLE
Rework handling of IRI creation based on CURIE/label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix releasing dataset after exception when running [`report`] with `--tdb true` [#659]
 - Reduced time spent loading datasets for [`query`] in [#666]
 - Fix writing JSON format to use `OutputStream` with ['convert'] in [#671]
+- Fix IRI resolution for `template` in [#689]
 
 
 ## [1.6.0] - 2020-03-04
@@ -186,6 +187,7 @@ First official release of ROBOT!
 [`report`]: http://robot.obolibrary.org/report
 [`template`]: http://robot.obolibrary.org/template
 
+[#689]: https://github.com/ontodev/robot/pull/689
 [#685]: https://github.com/ontodev/robot/pull/685
 [#671]: https://github.com/ontodev/robot/pull/671
 [#666]: https://github.com/ontodev/robot/pull/666

--- a/docs/template.md
+++ b/docs/template.md
@@ -229,6 +229,9 @@ Annotation properties should not have any value in the `CHARACTERISTIC` column, 
 ### Annotation Property Error
 
 The annotation property provided could not be resolved. Check your template to ensure the provided annotation property is in a correct IRI or CURIE format. For legibility, using CURIEs is recommended, but you must ensure that the prefix is defined.
+
+If you are using a label, make sure that the label is defined either in the template or input ontology.
+
 ```
 A rdfs:label
 A http://www.w3.org/2000/01/rdf-schema#label

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -23,6 +23,7 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.system.IRIResolver;
 import org.apache.jena.shared.JenaException;
 import org.apache.jena.tdb.TDBFactory;
 import org.apache.jena.util.FileManager;
@@ -37,6 +38,7 @@ import org.obolibrary.oboformat.writer.OBOFormatWriter;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.formats.*;
 import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.rdf.rdfxml.renderer.IllegalElementNameException;
 import org.semanticweb.owlapi.rdf.rdfxml.renderer.XMLWriterPreferences;
 import org.semanticweb.owlapi.util.DefaultPrefixManager;
 import org.slf4j.Logger;
@@ -748,9 +750,22 @@ public class IOHelper {
    */
   @SuppressWarnings("unchecked")
   public IRI createIRI(String term) {
+    return createIRI(term, false);
+  }
+
+  /**
+   * Given a term string, use the current prefixes to create an IRI.
+   *
+   * @param term the term to convert to an IRI
+   * @param qName if true, check that the expanded IRI is a valid QName (if not, return null)
+   * @return the new IRI or null
+   */
+  @SuppressWarnings("unchecked")
+  public IRI createIRI(String term, boolean qName) {
     if (term == null) {
       return null;
     }
+    IRI iri;
 
     try {
       // This is stupid, because better methods aren't public.
@@ -764,15 +779,26 @@ public class IOHelper {
       Object expanded = new JsonLdApi().expand(context, jsonMap);
       String result = ((Map<String, Object>) expanded).keySet().iterator().next();
       if (result != null) {
-        return IRI.create(result);
+        iri = IRI.create(result);
       } else {
-        return IRI.create(term);
+        // Validate that this is an IRI and not a CURIE
+        if (IRIResolver.checkIRI(term)) {
+          iri = IRI.create(term);
+        } else {
+          return null;
+        }
       }
     } catch (Exception e) {
       logger.warn("Could not create IRI for {}", term);
       logger.warn(e.getMessage());
+      return null;
     }
-    return null;
+
+    // Check that this is a valid QName
+    if (qName && !iri.getRemainder().isPresent()) {
+      return null;
+    }
+    return iri;
   }
 
   /**
@@ -1434,6 +1460,8 @@ public class IOHelper {
       // use native save functionality
       try {
         ontology.getOWLOntologyManager().saveOntology(ontology, format, ontologyIRI);
+      } catch (IllegalElementNameException e) {
+        throw new IOException("ELEMENT NAME EXCEPTION " + e.getCause().getMessage());
       } catch (OWLOntologyStorageException e) {
         // Determine if its caused by an OBO Format error
         if (format instanceof OBODocumentFormat

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -23,7 +23,6 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.riot.system.IRIResolver;
 import org.apache.jena.shared.JenaException;
 import org.apache.jena.tdb.TDBFactory;
 import org.apache.jena.util.FileManager;
@@ -781,12 +780,7 @@ public class IOHelper {
       if (result != null) {
         iri = IRI.create(result);
       } else {
-        // Validate that this is an IRI and not a CURIE
-        if (IRIResolver.checkIRI(term)) {
-          iri = IRI.create(term);
-        } else {
-          return null;
-        }
+        iri = IRI.create(term);
       }
     } catch (Exception e) {
       logger.warn("Could not create IRI for {}", term);

--- a/robot-core/src/main/java/org/obolibrary/robot/QuotedEntityChecker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/QuotedEntityChecker.java
@@ -293,7 +293,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
   public IRI getIRI(String name, boolean create) {
     IRI iri = iris.getOrDefault(name, null);
     if (iri == null && ioHelper != null && create) {
-      iri = ioHelper.createIRI(name);
+      iri = ioHelper.createIRI(name, true);
     }
     return iri;
   }
@@ -337,7 +337,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
       return dataFactory.getOWLAnnotationProperty(iri);
     }
     if (create && ioHelper != null) {
-      iri = ioHelper.createIRI(name);
+      iri = ioHelper.createIRI(name, true);
       if (iri != null) {
         return dataFactory.getOWLAnnotationProperty(iri);
       }
@@ -358,7 +358,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
       return dataFactory.getOWLClass(iri);
     }
     if (ioHelper != null) {
-      iri = ioHelper.createIRI(name);
+      iri = ioHelper.createIRI(name, true);
       if (iri != null) {
         return dataFactory.getOWLClass(iri);
       }
@@ -379,7 +379,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
       return dataFactory.getOWLDataProperty(iri);
     }
     if (ioHelper != null) {
-      iri = ioHelper.createIRI(name);
+      iri = ioHelper.createIRI(name, true);
       if (iri != null) {
         return dataFactory.getOWLDataProperty(iri);
       }
@@ -413,7 +413,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
       return dataFactory.getOWLDatatype(iri);
     }
     if (create && ioHelper != null) {
-      iri = ioHelper.createIRI(name);
+      iri = ioHelper.createIRI(name, true);
       if (iri != null) {
         return dataFactory.getOWLDatatype(iri);
       }
@@ -434,7 +434,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
       return dataFactory.getOWLNamedIndividual(iri);
     }
     if (ioHelper != null) {
-      iri = ioHelper.createIRI(name);
+      iri = ioHelper.createIRI(name, true);
       if (iri != null) {
         return dataFactory.getOWLNamedIndividual(iri);
       }
@@ -455,7 +455,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
       return dataFactory.getOWLObjectProperty(iri);
     }
     if (ioHelper != null) {
-      iri = ioHelper.createIRI(name);
+      iri = ioHelper.createIRI(name, true);
       if (iri != null) {
         return dataFactory.getOWLObjectProperty(iri);
       }

--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
@@ -328,10 +328,10 @@ public class TemplateHelper {
       if (split != null) {
         String[] values = value.split(Pattern.quote(split));
         for (String v : values) {
-          annotations.add(maybeGetIRIAnnotation(tableName, checker, template, v, rowNum, column));
+          annotations.add(maybeGetIRIAnnotation(checker, template, v));
         }
       } else {
-        annotations.add(maybeGetIRIAnnotation(tableName, checker, template, value, rowNum, column));
+        annotations.add(maybeGetIRIAnnotation(checker, template, value));
       }
       return annotations;
     } else if (template.equals("LABEL")) {
@@ -640,7 +640,7 @@ public class TemplateHelper {
       if (id == null || id.trim().isEmpty()) {
         continue;
       }
-      IRI iri = ioHelper.createIRI(id);
+      IRI iri = ioHelper.createIRI(id, true);
       if (iri == null) {
         continue;
       }
@@ -1225,29 +1225,19 @@ public class TemplateHelper {
   /**
    * Given a checker, a template string, and a value for the template, return an IRI annotation.
    *
-   * @param tableName name of table
    * @param checker QuotedEntityChecker to resolve entities
    * @param template template string
    * @param value value to use with the template string
-   * @param rowNum the row number for logging
-   * @param column the column number for logging
    * @return OWLAnnotation created from template and value
    * @throws RowParseException if entities cannot be resolved
    */
   private static OWLAnnotation maybeGetIRIAnnotation(
-      String tableName,
-      QuotedEntityChecker checker,
-      String template,
-      String value,
-      int rowNum,
-      int column)
-      throws Exception {
+      QuotedEntityChecker checker, String template, String value) throws Exception {
     IRI iri = checker.getIRI(value, true);
-    if (iri != null) {
-      return getIRIAnnotation(checker, template, iri);
-    } else {
-      throw new RowParseException(String.format(iriError, rowNum, column + 1, tableName, value));
+    if (iri == null) {
+      iri = IRI.create(value);
     }
+    return getIRIAnnotation(checker, template, iri);
   }
 
   /**

--- a/robot-core/src/test/java/org/obolibrary/robot/TemplateTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/TemplateTest.java
@@ -2,10 +2,10 @@ package org.obolibrary.robot;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.Lists;
 import java.util.*;
 import org.junit.Test;
 import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLOntology;
 
 /**
@@ -59,20 +59,20 @@ public class TemplateTest extends CoreTest {
     tables.put(path, TemplateHelper.readCSV(this.getClass().getResourceAsStream(path)));
     path = "/template-labels.csv";
     tables.put(path, TemplateHelper.readCSV(this.getClass().getResourceAsStream(path)));
-    path = "/template.csv";
+    path = "/template-logical.csv";
     tables.put(path, TemplateHelper.readCSV(this.getClass().getResourceAsStream(path)));
-    OWLOntology simpleParts = loadOntology("/simple_parts.owl");
+    OWLOntology in = loadOntology("/simple_parts.owl");
 
     List<OWLOntology> ontologies = new ArrayList<>();
+    OWLOntology out;
     for (String table : tables.keySet()) {
-      Template t = new Template(table, tables.get(table), simpleParts);
-      ontologies.add(t.generateOutputOntology());
+      Template t = new Template(table, tables.get(table), in);
+      out = t.generateOutputOntology();
+      ontologies.add(out);
+      in = MergeOperation.merge(Lists.newArrayList(in, out));
     }
 
     OWLOntology template = MergeOperation.merge(ontologies);
-    for (OWLAxiom cls : template.getAxioms()) {
-      System.out.println(cls);
-    }
     assertEquals("Count classes", 4, template.getClassesInSignature().size());
     assertEquals("Count logical axioms", 3, template.getLogicalAxiomCount());
     assertEquals("Count all axioms", 11, template.getAxiomCount());
@@ -88,22 +88,22 @@ public class TemplateTest extends CoreTest {
     Map<String, List<List<String>>> tables = new LinkedHashMap<>();
     String path = "/template-ids.csv";
     tables.put(path, TemplateHelper.readCSV(this.getClass().getResourceAsStream(path)));
-    path = "/legacy-template-labels.csv";
+    path = "/template-labels.csv";
     tables.put(path, TemplateHelper.readCSV(this.getClass().getResourceAsStream(path)));
-    path = "/legacy-template.csv";
+    path = "/legacy-template-logical.csv";
     tables.put(path, TemplateHelper.readCSV(this.getClass().getResourceAsStream(path)));
-    OWLOntology simpleParts = loadOntology("/simple_parts.owl");
+    OWLOntology in = loadOntology("/simple_parts.owl");
 
     List<OWLOntology> ontologies = new ArrayList<>();
+    OWLOntology out;
     for (String table : tables.keySet()) {
-      Template t = new Template(table, tables.get(table), simpleParts);
-      ontologies.add(t.generateOutputOntology());
+      Template t = new Template(table, tables.get(table), in);
+      out = t.generateOutputOntology();
+      ontologies.add(out);
+      in = MergeOperation.merge(Lists.newArrayList(in, out));
     }
 
     OWLOntology template = MergeOperation.merge(ontologies);
-    for (OWLAxiom cls : template.getAxioms()) {
-      System.out.println(cls);
-    }
     assertEquals("Count classes", 4, template.getClassesInSignature().size());
     assertEquals("Count logical axioms", 3, template.getLogicalAxiomCount());
     assertEquals("Count all axioms", 11, template.getAxiomCount());
@@ -115,7 +115,7 @@ public class TemplateTest extends CoreTest {
    * @throws Exception on any issue
    */
   @Test
-  public void testLegacyTemplate() throws Exception {
+  public void testLegacyDocsTemplate() throws Exception {
     Map<String, String> options = TemplateOperation.getDefaultOptions();
     IOHelper ioHelper = new IOHelper();
     ioHelper.addPrefix("ex", "http://example.com/");

--- a/robot-core/src/test/resources/legacy-template-labels.csv
+++ b/robot-core/src/test/resources/legacy-template-labels.csv
@@ -1,4 +1,0 @@
-Label,Synonyms,Type,Parent,Parts
-LABEL,A IAO:0000118 SPLIT=|,CLASS_TYPE,C % SPLIT=|,C part_of some %
-test 3,synonym 1|synonym 2,subclass,test one|test2,test one
-test 4,,equivalent,test one,(test2 and 'test 3')

--- a/robot-core/src/test/resources/legacy-template-logical.csv
+++ b/robot-core/src/test/resources/legacy-template-logical.csv
@@ -1,0 +1,5 @@
+Label,Label Comment,Nested Comment,See Also,Type,Parent,Parts,Parts Annotation
+A rdfs:label,>AL rdfs:comment@en,>>A rdfs:comment,>AI rdfs:seeAlso,CLASS_TYPE,C %,C part_of some %,>C rdfs:comment
+,skip this row,,,,,,
+test 3,test 3 comment,test 3 comment comment,http://robot.obolibrary.org/,subclass,test2,test one,test one comment
+test 4,test 4 comment,,,equivalent,test one,(test2 and 'test 3'),test2 and test 3 comment

--- a/robot-core/src/test/resources/template-labels.csv
+++ b/robot-core/src/test/resources/template-labels.csv
@@ -1,4 +1,3 @@
-Label,Synonyms,Parent,Subclass Parts,Equivalent,Equivalent Parts
-LABEL,A IAO:0000118 SPLIT=|,SC % SPLIT=|,SC part_of some %,EC %,EC part_of some %
-test 3,synonym 1|synonym 2,test one|test2,test one,,
-test 4,,,,test one,(test2 and 'test 3')
+Label,Synonyms
+LABEL,A IAO:0000118 SPLIT=|
+test 3,synonym 1|synonym 2

--- a/robot-core/src/test/resources/template-logical.csv
+++ b/robot-core/src/test/resources/template-logical.csv
@@ -1,0 +1,5 @@
+Label,Label Comment,Nested Comment,See Also,Parent,Parts,Parts Annotation,Equivalent,Eq Annotation
+A rdfs:label,>AL rdfs:comment@en,>>A rdfs:comment,>AI rdfs:seeAlso,SC %,SC part_of some %,>A rdfs:comment,EC %,>A rdfs:comment
+,skip this row,,,,,,,
+test 3,test 3 comment,test 3 comment comment,http://robot.obolibrary.org/,test2,test one,test one comment,,
+test 4,test 4 comment,,,,,,'test one' and (part_of some (test2 and 'test 3')),test2 and test 3 comment


### PR DESCRIPTION
Resolves #688

- [x] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

This PR is mainly to add better error-handling to IRI resolution in `template`. If a prefix was not defined, a CURIE could still get passed as an "IRI", but the ontology would fail to save because it wasn't a valid QName. All entities generated from templates should have IRIs that are valid QNames, otherwise `template` will fail at the very end with `IllegalElementNameException`.

The template tests had to be updated because it turned out that the third template we were testing for the "multiple templates" had everything in it (IDs from `template-ids.csv` and synonyms from `template-labels.csv`), so the first two didn't really matter. Additionally, we were never passing the previously generated ontology as input. For example, if you define labels and IDs in `template-ids.csv` and use *only* labels in `template.csv`, it would fail. It didn't fail in the past because we included an ID column in `template.csv`. This is just a minor rework of the test, not an issue with the template operation.
