### PR TITLE
Solve issue #716: empty characteristics for properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Now handles empty characteristics [#716]
 
 ## [1.7.0] - 2020-07-31
 

--- a/robot-core/src/main/java/org/obolibrary/robot/Template.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/Template.java
@@ -1029,6 +1029,8 @@ public class Template {
         case "transitive":
           axioms.add(dataFactory.getOWLTransitiveObjectPropertyAxiom(property));
           break;
+        case "":
+          break;
         default:
           throw new Exception(
               String.format(
@@ -2185,11 +2187,15 @@ public class Template {
    */
   private List<String> getCharacteristics(List<String> row) {
     if (characteristicColumn != -1) {
-      String characteristicString = row.get(characteristicColumn);
-      if (characteristicSplit != null && characteristicString.contains(characteristicSplit)) {
-        return Arrays.asList(characteristicString.split(Pattern.quote(characteristicSplit)));
-      } else {
-        return Collections.singletonList(characteristicString.trim());
+      // If characteristics is the last column and there are no characteristics for
+      // this entry, the list will be one element short.
+      if (characteristicColumn <= (row.size() - 1)) {
+        String characteristicString = row.get(characteristicColumn);
+        if (characteristicSplit != null && characteristicString.contains(characteristicSplit)) {
+          return Arrays.asList(characteristicString.split(Pattern.quote(characteristicSplit)));
+        } else {
+          return Collections.singletonList(characteristicString.trim());
+        }
       }
     }
     return new ArrayList<>();


### PR DESCRIPTION
Resolves [#716 ]

- [NOT APPLICABLE] `docs/` have been added/updated
- [NO] tests have been added/updated : Not done, there doesn't seem to be much tested for templates yet, will revisit if necessary
- [PROBLEM] `mvn verify` says all tests pass : but was there before this modification

````
  [ERROR] Number of foreign imports: 1
  [ERROR] import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
  [ERROR] 
  [ERROR] ------------
````

- [PROBLEM] `mvn site` says all JavaDocs correct  : Failure missing javadoc.
- [X] `CHANGELOG.md` has been updated

This handle the two cases raised by the issue #716 :
- we need to allow empty characteristics
- in the case of characteristics being the last	column,
  the list of elements in the row is one element short
  when the characteristic is empty, handling that case

