### PR TITLE
Fix referencing properties by CURIE in export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Handle empty [`template`] property charactersitics in [#719]
+- Fix referencing properties by CURIE in [`export`] in [#722]
 
 ## [1.7.0] - 2020-07-31
 
@@ -198,6 +199,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#722]: https://github.com/ontodev/robot/pull/722
 [#719]: https://github.com/ontodev/robot/pull/716
 [#715]: https://github.com/ontodev/robot/pull/715
 [#710]: https://github.com/ontodev/robot/pull/710

--- a/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
@@ -220,7 +220,7 @@ public class ExportOperation {
       OWLAnnotationProperty ap = null;
 
       // Handle rdfs:label defaults
-      if (iri != null && iri.toString().equals(dataFactory.getRDFSLabel().getIRI().toString())) {
+      if (iri != null && iri.equals(dataFactory.getRDFSLabel().getIRI())) {
         currentEntityFormat = "LABEL";
         currentEntitySelect = "NAMED";
         ap = dataFactory.getRDFSLabel();
@@ -575,7 +575,7 @@ public class ExportOperation {
     List<String> values = new ArrayList<>();
     for (OWLAnnotationAssertionAxiom a :
         EntitySearcher.getAnnotationAssertionAxioms(entity, ontology)) {
-      if (a.getProperty().getIRI().toString().equals(ap.getIRI().toString())) {
+      if (a.getProperty().getIRI().equals(ap.getIRI())) {
         if (a.getValue().isIRI()) {
           IRI iri = a.getValue().asIRI().orNull();
           if (iri != null) {
@@ -743,7 +743,7 @@ public class ExportOperation {
           pe = avf.getProperty();
           if (!pe.isAnonymous()) {
             OWLDataProperty prop = pe.asOWLDataProperty();
-            if (prop.getIRI().toString().equals(dp.getIRI().toString())) {
+            if (prop.getIRI().equals(dp.getIRI())) {
               if ((!f.isAnonymous() && includeNamed) || (f.isAnonymous() && includeAnonymous)) {
                 fillers.add(renderRestrictionString(rt, provider, f, null));
               }
@@ -756,7 +756,7 @@ public class ExportOperation {
           pe = svf.getProperty();
           if (!pe.isAnonymous()) {
             OWLDataProperty prop = pe.asOWLDataProperty();
-            if (prop.getIRI().toString().equals(dp.getIRI().toString())) {
+            if (prop.getIRI().equals(dp.getIRI())) {
               if ((!f.isAnonymous() && includeNamed) || (f.isAnonymous() && includeAnonymous)) {
                 fillers.add(renderRestrictionString(rt, provider, f, null));
               }
@@ -770,7 +770,7 @@ public class ExportOperation {
           n = ec.getCardinality();
           if (!pe.isAnonymous()) {
             OWLDataProperty prop = pe.asOWLDataProperty();
-            if (prop.getIRI().toString().equals(dp.getIRI().toString())) {
+            if (prop.getIRI().equals(dp.getIRI())) {
               if ((!f.isAnonymous() && includeNamed) || (f.isAnonymous() && includeAnonymous)) {
                 fillers.add(renderRestrictionString(rt, provider, f, n));
               }
@@ -784,7 +784,7 @@ public class ExportOperation {
           n = minc.getCardinality();
           if (!pe.isAnonymous()) {
             OWLDataProperty prop = pe.asOWLDataProperty();
-            if (prop.getIRI().toString().equals(dp.getIRI().toString())) {
+            if (prop.getIRI().equals(dp.getIRI())) {
               if ((!f.isAnonymous() && includeNamed) || (f.isAnonymous() && includeAnonymous)) {
                 fillers.add(renderRestrictionString(rt, provider, f, n));
               }
@@ -798,7 +798,7 @@ public class ExportOperation {
           n = maxc.getCardinality();
           if (!pe.isAnonymous()) {
             OWLDataProperty prop = pe.asOWLDataProperty();
-            if (prop.getIRI().toString().equals(dp.getIRI().toString())) {
+            if (prop.getIRI().equals(dp.getIRI())) {
               if ((!f.isAnonymous() && includeNamed) || (f.isAnonymous() && includeAnonymous)) {
                 fillers.add(renderRestrictionString(rt, provider, f, n));
               }
@@ -846,7 +846,7 @@ public class ExportOperation {
           f = avf.getFiller();
           if (!pe.isAnonymous()) {
             OWLObjectProperty prop = pe.asOWLObjectProperty();
-            if (prop.getIRI().toString().equals(op.getIRI().toString())) {
+            if (prop.getIRI().equals(op.getIRI())) {
               if ((f.isAnonymous() && includeAnonymous) || (!f.isAnonymous() && includeNamed)) {
                 fillers.add(renderRestrictionString(rt, provider, f, null));
               }
@@ -860,7 +860,7 @@ public class ExportOperation {
           f = svf.getFiller();
           if (!pe.isAnonymous()) {
             OWLObjectProperty prop = pe.asOWLObjectProperty();
-            if (prop.getIRI().toString().equals(op.getIRI().toString())) {
+            if (prop.getIRI().equals(op.getIRI())) {
               if ((f.isAnonymous() && includeAnonymous) || (!f.isAnonymous() && includeNamed)) {
                 fillers.add(renderRestrictionString(rt, provider, f, null));
               }
@@ -875,7 +875,7 @@ public class ExportOperation {
           n = ec.getCardinality();
           if (!pe.isAnonymous()) {
             OWLObjectProperty prop = pe.asOWLObjectProperty();
-            if (prop.getIRI().toString().equals(op.getIRI().toString())) {
+            if (prop.getIRI().equals(op.getIRI())) {
               if ((f.isAnonymous() && includeAnonymous) || (!f.isAnonymous() && includeNamed)) {
                 fillers.add(renderRestrictionString(rt, provider, f, n));
               }
@@ -890,7 +890,7 @@ public class ExportOperation {
           n = minc.getCardinality();
           if (!pe.isAnonymous()) {
             OWLObjectProperty prop = pe.asOWLObjectProperty();
-            if (prop.getIRI().toString().equals(op.getIRI().toString())) {
+            if (prop.getIRI().equals(op.getIRI())) {
               if ((f.isAnonymous() && includeAnonymous) || (!f.isAnonymous() && includeNamed)) {
                 fillers.add(renderRestrictionString(rt, provider, f, n));
               }
@@ -905,7 +905,7 @@ public class ExportOperation {
           n = maxc.getCardinality();
           if (!pe.isAnonymous()) {
             OWLObjectProperty prop = pe.asOWLObjectProperty();
-            if (prop.getIRI().toString().equals(op.getIRI().toString())) {
+            if (prop.getIRI().equals(op.getIRI())) {
               if ((f.isAnonymous() && includeAnonymous) || (!f.isAnonymous() && includeNamed)) {
                 fillers.add(renderRestrictionString(rt, provider, f, n));
               }

--- a/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
@@ -217,20 +217,47 @@ public class ExportOperation {
         currentEntitySelect = "NAMED";
       }
 
-      // Maybe get a property
-      OWLAnnotationProperty ap = checker.getOWLAnnotationProperty(colName, false);
+      OWLAnnotationProperty ap = null;
 
-      // Handle some defaults
-      IRI colIRI = ioHelper.createIRI(colName);
-      if (colIRI != null
-          && colIRI.toString().equals(dataFactory.getRDFSLabel().getIRI().toString())) {
+      // Handle rdfs:label defaults
+      if (iri != null && iri.toString().equals(dataFactory.getRDFSLabel().getIRI().toString())) {
         currentEntityFormat = "LABEL";
         currentEntitySelect = "NAMED";
         ap = dataFactory.getRDFSLabel();
       }
 
-      OWLDataProperty dp = checker.getOWLDataProperty(colName);
-      OWLObjectProperty op = checker.getOWLObjectProperty(colName);
+      // checker only resolves labels, so try with IRI
+      if (ap == null && iri != null && ontology.containsAnnotationPropertyInSignature(iri)) {
+        ap = dataFactory.getOWLAnnotationProperty(iri);
+      } else {
+        // Try by label
+        ap = checker.getOWLAnnotationProperty(colName);
+      }
+
+      // Check for object/data properties if not an annotation property
+      OWLDataProperty dp = null;
+      OWLObjectProperty op = null;
+      if (ap == null) {
+        // annotation property not found
+        if (iri != null && ontology.containsDataPropertyInSignature(iri)) {
+          // Use IRI to create data property
+          dp = dataFactory.getOWLDataProperty(iri);
+        } else {
+          // Try by label
+          dp = checker.getOWLDataProperty(colName);
+        }
+
+        if (dp == null) {
+          // data property not found
+          if (iri != null && ontology.containsObjectPropertyInSignature(iri)) {
+            // Use IRI to create object property
+            op = dataFactory.getOWLObjectProperty(iri);
+          } else {
+            // Try by label
+            op = checker.getOWLObjectProperty(colName);
+          }
+        }
+      }
 
       // Maybe get a short form provider
       ShortFormProvider provider;
@@ -342,8 +369,8 @@ public class ExportOperation {
    * @param rt RendererType to use to render Manchester
    * @param provider ShortFormProvider to resolve entities
    * @param classes Set of class expressions to convert to string
-   * @param includeNamed
-   * @param includeAnonymous
+   * @param includeNamed if true, include named classes in output
+   * @param includeAnonymous if true, include anonymous classes in output
    * @return String of class expressions or null
    */
   private static List<String> classExpressionsToString(
@@ -374,8 +401,8 @@ public class ExportOperation {
    * @param displayRendererType RendererType for display value
    * @param sortRendererType RendererType for sort value
    * @param provider ShortFormProvider to resolve entities
-   * @param includeNamed
-   * @param includeAnonymous
+   * @param includeNamed if true, include named classes in output
+   * @param includeAnonymous if true, include anonymous classes in output
    * @return Cell for this Column containing class expressions
    */
   private static Cell getClassCell(
@@ -502,8 +529,8 @@ public class ExportOperation {
    * @param displayRendererType RendererType for display value
    * @param sortRendererType RendererType for sort value
    * @param provider ShortFormProvider to resolve entities
-   * @param includeNamed
-   * @param includeAnonymous
+   * @param includeNamed if true, include named classes in output
+   * @param includeAnonymous if true, include anonymous classes in output
    * @return Cell for this Column containing property expressions
    */
   private static Cell getPropertyCell(
@@ -548,7 +575,7 @@ public class ExportOperation {
     List<String> values = new ArrayList<>();
     for (OWLAnnotationAssertionAxiom a :
         EntitySearcher.getAnnotationAssertionAxioms(entity, ontology)) {
-      if (a.getProperty().getIRI() == ap.getIRI()) {
+      if (a.getProperty().getIRI().toString().equals(ap.getIRI().toString())) {
         if (a.getValue().isIRI()) {
           IRI iri = a.getValue().asIRI().orNull();
           if (iri != null) {
@@ -575,8 +602,8 @@ public class ExportOperation {
    * @param provider ShortFormProvider to resolve entities
    * @param entity OWLEntity to get relations of
    * @param dp OWLDataProperty to get the value(s) of
-   * @param includeNamed
-   * @param includeAnonymous
+   * @param includeNamed if true, include named classes in output
+   * @param includeAnonymous if true, include anonymous classes in output
    * @return String of values or null
    */
   private static List<String> getPropertyValues(
@@ -631,8 +658,8 @@ public class ExportOperation {
    * @param provider ShortFormProvider to resolve entities
    * @param entity OWLEntity to get annotations on
    * @param op OWLObjectProperty to get the value(s) of
-   * @param includeNamed
-   * @param includeAnonymous
+   * @param includeNamed if true, include named classes in output
+   * @param includeAnonymous if true, include anonymous classes in output
    * @return String of values or null
    */
   private static List<String> getPropertyValues(
@@ -691,8 +718,8 @@ public class ExportOperation {
    * @param dp OWLDataProperty to look for
    * @param rt RendererType to use to render Manchester
    * @param provider ShortFormProvider to resolve entities
-   * @param includeNamed
-   * @param includeAnonymous
+   * @param includeNamed if true, include named classes in output
+   * @param includeAnonymous if true, include anonymous classes in output
    * @return set of fillers that are 'values' of the data property
    */
   private static Set<String> getRestrictionFillers(
@@ -716,7 +743,7 @@ public class ExportOperation {
           pe = avf.getProperty();
           if (!pe.isAnonymous()) {
             OWLDataProperty prop = pe.asOWLDataProperty();
-            if (prop.getIRI() == dp.getIRI()) {
+            if (prop.getIRI().toString().equals(dp.getIRI().toString())) {
               if ((!f.isAnonymous() && includeNamed) || (f.isAnonymous() && includeAnonymous)) {
                 fillers.add(renderRestrictionString(rt, provider, f, null));
               }
@@ -729,7 +756,7 @@ public class ExportOperation {
           pe = svf.getProperty();
           if (!pe.isAnonymous()) {
             OWLDataProperty prop = pe.asOWLDataProperty();
-            if (prop.getIRI() == dp.getIRI()) {
+            if (prop.getIRI().toString().equals(dp.getIRI().toString())) {
               if ((!f.isAnonymous() && includeNamed) || (f.isAnonymous() && includeAnonymous)) {
                 fillers.add(renderRestrictionString(rt, provider, f, null));
               }
@@ -743,7 +770,7 @@ public class ExportOperation {
           n = ec.getCardinality();
           if (!pe.isAnonymous()) {
             OWLDataProperty prop = pe.asOWLDataProperty();
-            if (prop.getIRI() == dp.getIRI()) {
+            if (prop.getIRI().toString().equals(dp.getIRI().toString())) {
               if ((!f.isAnonymous() && includeNamed) || (f.isAnonymous() && includeAnonymous)) {
                 fillers.add(renderRestrictionString(rt, provider, f, n));
               }
@@ -757,7 +784,7 @@ public class ExportOperation {
           n = minc.getCardinality();
           if (!pe.isAnonymous()) {
             OWLDataProperty prop = pe.asOWLDataProperty();
-            if (prop.getIRI() == dp.getIRI()) {
+            if (prop.getIRI().toString().equals(dp.getIRI().toString())) {
               if ((!f.isAnonymous() && includeNamed) || (f.isAnonymous() && includeAnonymous)) {
                 fillers.add(renderRestrictionString(rt, provider, f, n));
               }
@@ -771,7 +798,7 @@ public class ExportOperation {
           n = maxc.getCardinality();
           if (!pe.isAnonymous()) {
             OWLDataProperty prop = pe.asOWLDataProperty();
-            if (prop.getIRI() == dp.getIRI()) {
+            if (prop.getIRI().toString().equals(dp.getIRI().toString())) {
               if ((!f.isAnonymous() && includeNamed) || (f.isAnonymous() && includeAnonymous)) {
                 fillers.add(renderRestrictionString(rt, provider, f, n));
               }
@@ -793,8 +820,8 @@ public class ExportOperation {
    * @param op OWLObjectProperty to look for
    * @param rt RendererType to use to render Manchester
    * @param provider ShortFormProvider to resolve entities
-   * @param includeNamed
-   * @param includeAnonymous
+   * @param includeNamed if true, include named classes in output
+   * @param includeAnonymous if true, include anonymous classes in output
    * @return set of fillers that are 'values' of the object property
    */
   private static Set<String> getRestrictionFillers(
@@ -819,7 +846,7 @@ public class ExportOperation {
           f = avf.getFiller();
           if (!pe.isAnonymous()) {
             OWLObjectProperty prop = pe.asOWLObjectProperty();
-            if (prop.getIRI() == op.getIRI()) {
+            if (prop.getIRI().toString().equals(op.getIRI().toString())) {
               if ((f.isAnonymous() && includeAnonymous) || (!f.isAnonymous() && includeNamed)) {
                 fillers.add(renderRestrictionString(rt, provider, f, null));
               }
@@ -833,7 +860,7 @@ public class ExportOperation {
           f = svf.getFiller();
           if (!pe.isAnonymous()) {
             OWLObjectProperty prop = pe.asOWLObjectProperty();
-            if (prop.getIRI() == op.getIRI()) {
+            if (prop.getIRI().toString().equals(op.getIRI().toString())) {
               if ((f.isAnonymous() && includeAnonymous) || (!f.isAnonymous() && includeNamed)) {
                 fillers.add(renderRestrictionString(rt, provider, f, null));
               }
@@ -848,7 +875,7 @@ public class ExportOperation {
           n = ec.getCardinality();
           if (!pe.isAnonymous()) {
             OWLObjectProperty prop = pe.asOWLObjectProperty();
-            if (prop.getIRI() == op.getIRI()) {
+            if (prop.getIRI().toString().equals(op.getIRI().toString())) {
               if ((f.isAnonymous() && includeAnonymous) || (!f.isAnonymous() && includeNamed)) {
                 fillers.add(renderRestrictionString(rt, provider, f, n));
               }
@@ -863,7 +890,7 @@ public class ExportOperation {
           n = minc.getCardinality();
           if (!pe.isAnonymous()) {
             OWLObjectProperty prop = pe.asOWLObjectProperty();
-            if (prop.getIRI() == op.getIRI()) {
+            if (prop.getIRI().toString().equals(op.getIRI().toString())) {
               if ((f.isAnonymous() && includeAnonymous) || (!f.isAnonymous() && includeNamed)) {
                 fillers.add(renderRestrictionString(rt, provider, f, n));
               }
@@ -878,7 +905,7 @@ public class ExportOperation {
           n = maxc.getCardinality();
           if (!pe.isAnonymous()) {
             OWLObjectProperty prop = pe.asOWLObjectProperty();
-            if (prop.getIRI() == op.getIRI()) {
+            if (prop.getIRI().toString().equals(op.getIRI().toString())) {
               if ((f.isAnonymous() && includeAnonymous) || (!f.isAnonymous() && includeNamed)) {
                 fillers.add(renderRestrictionString(rt, provider, f, n));
               }
@@ -927,9 +954,9 @@ public class ExportOperation {
       boolean includeAnonymous = col.getIncludeAnonymous();
 
       String colName = col.getName();
-      OWLProperty maybeAnnotation = col.getProperty();
-      if (maybeAnnotation instanceof OWLAnnotationProperty) {
-        OWLAnnotationProperty maybeLabel = (OWLAnnotationProperty) maybeAnnotation;
+      OWLProperty colProperty = col.getProperty();
+      if (colProperty instanceof OWLAnnotationProperty) {
+        OWLAnnotationProperty maybeLabel = (OWLAnnotationProperty) colProperty;
         if (maybeLabel.isLabel()) {
           // Handle like we do default LABEL columns
           colName = "LABEL";
@@ -982,7 +1009,6 @@ public class ExportOperation {
       }
 
       // If a property exists, use this property to get values
-      OWLProperty colProperty = col.getProperty();
       if (colProperty != null) {
         if (colProperty instanceof OWLAnnotationProperty) {
           OWLAnnotationProperty ap = (OWLAnnotationProperty) colProperty;
@@ -1306,8 +1332,8 @@ public class ExportOperation {
    * @param rt RendererType to use to render Manchester
    * @param provider ShortFormProvider to resolve entities
    * @param props Set of property expressions to convert to string
-   * @param includeNamed
-   * @param includeAnonymous
+   * @param includeNamed if true, include named classes in output
+   * @param includeAnonymous if true, include anonymous classes in output
    * @return String of property expressions or null
    */
   private static List<String> propertyExpressionsToString(


### PR DESCRIPTION
Resolves #721

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

Change to compare IRI with `equals()` instead of `==` in `export` in order to allow both CURIEs and labels in `export` headers. I have no idea why two properties with the same IRI would be considered different IRI objects when we pass CURIEs but not labels, but if we change to this comparison, it's resolved.

Previously:

```
prop1.getIRI() == prop2.getIRI()
```

Now:

```
prop1.getIRI().equals(prop2.getIRI())
```

I also made the process to get the IRI of a header a little bit smarter.