### PR TITLE
Fix equivalent class rendering in template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix referencing properties by CURIE in [`export`] in [#722]
 - Fix [`validate`] `--write-all true` in [#726]
 - Fix reported row number in [`validate`] error tables in [#727]
+- Fix equivalent class rendering for [`template`] in [#728]
 
 ## [1.7.0] - 2020-07-31
 
@@ -202,7 +203,8 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
-[#726]: https://github.com/ontodev/robot/pull/727
+[#728]: https://github.com/ontodev/robot/pull/728
+[#727]: https://github.com/ontodev/robot/pull/727
 [#726]: https://github.com/ontodev/robot/pull/726
 [#722]: https://github.com/ontodev/robot/pull/722
 [#719]: https://github.com/ontodev/robot/pull/716

--- a/robot-core/src/main/java/org/obolibrary/robot/Template.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/Template.java
@@ -926,7 +926,11 @@ public class Template {
     if (!intersectionEquivalentExpressionColumns.isEmpty()) {
       // Special case to support legacy "C"/"equivalent" class type
       // Which is the intersection of all C columns
-      addIntersectionEquivalentClassesAxioms(cls, intersectionEquivalentExpressionColumns, row);
+      if (intersectionEquivalentExpressionColumns.size() == 1) {
+        addEquivalentClassesAxioms(cls, intersectionEquivalentExpressionColumns, row);
+      } else {
+        addIntersectionEquivalentClassesAxioms(cls, intersectionEquivalentExpressionColumns, row);
+      }
     }
     if (!disjointExpressionColumns.isEmpty()) {
       addDisjointClassAxioms(cls, disjointExpressionColumns, row);


### PR DESCRIPTION
- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

If a row only has one entry with `CLASS_TYPE` of `equivalent`, this should not be an intersection. Right now, `template` generates an intersection with only one entry. This looks OK in Protege, but if you look at the raw OWL, it's weird and can cause issues with `query`.