### PR TITLE
Update owl-diff to version 1.2.1

### DIFF
--- a/docs/diff.md
+++ b/docs/diff.md
@@ -28,7 +28,7 @@ If your left and right ontologies have different catalog files (perhaps pointing
       --right-catalog catalog-right.xml \
       --output results/catalog-diff.txt
 
-See [release-diff.txt](/examples/release-diff.txt) for an example. In the output, 'Ontology 1' corresponds to your `--left` input and 'Ontology 2' corresponds to your `--right` input.
+See [release-diff.txt](/examples/release-diff.txt) for an example.
 
 The default "plain" output is in OWL Functional syntax with IRIs. You can include entity labels with `--labels true`. In addition, Markdown and HTML diff formats (based on Manchester syntax) are available. You can select the desired format using the `--format` (or `-f`) option, with possible values `plain`, `pretty` (text with labels and CURIEs), `html`, or `markdown`.
 

--- a/docs/examples/catalog-diff.txt
+++ b/docs/examples/catalog-diff.txt
@@ -1,5 +1,5 @@
-1 axioms in Ontology 1 but not in Ontology 2:
+1 axioms in left ontology but not in right ontology:
 - Import(<https://github.com/ontodev/robot/examples/edit.owl>)
 
-1 axioms in Ontology 2 but not in Ontology 1:
+1 axioms in right ontology but not in left ontology:
 + Import(<https://github.com/ontodev/robot/examples/foo.owl>)

--- a/docs/examples/release-diff.txt
+++ b/docs/examples/release-diff.txt
@@ -1,7 +1,7 @@
-1 axioms in Ontology 1 but not in Ontology 2:
+1 axioms in left ontology but not in right ontology:
 - OntologyID(OntologyIRI(<https://github.com/ontodev/robot/examples/edit.owl>) VersionIRI(<null>))
 
-15 axioms in Ontology 2 but not in Ontology 1:
+15 axioms in right ontology but not in left ontology:
 + AnnotationAssertion(rdfs:label <https://github.com/ontodev/robot/examples/release.owl#junk> "Junk")
 + Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasAlternativeId>))
 + Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym>))

--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -166,7 +166,7 @@
     <dependency>
       <groupId>org.geneontology</groupId>
       <artifactId>owl-diff_2.12</artifactId>
-      <version>1.1.2</version>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -166,7 +166,7 @@
     <dependency>
       <groupId>org.geneontology</groupId>
       <artifactId>owl-diff_2.12</artifactId>
-      <version>1.2</version>
+      <version>1.2.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/robot-core/src/test/resources/simple.diff
+++ b/robot-core/src/test/resources/simple.diff
@@ -1,4 +1,4 @@
-0 axioms in Ontology 1 but not in Ontology 2:
+0 axioms in left ontology but not in right ontology:
 
-1 axioms in Ontology 2 but not in Ontology 1:
+1 axioms in right ontology but not in left ontology:
 + SubClassOf(<https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl#test1>[Test 1] <owl:Thing>)

--- a/robot-core/src/test/resources/simple1.diff
+++ b/robot-core/src/test/resources/simple1.diff
@@ -1,6 +1,6 @@
-1 axioms in Ontology 1 but not in Ontology 2:
+1 axioms in left ontology but not in right ontology:
 - OntologyID(OntologyIRI(<https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl>) VersionIRI(<null>))
 
-2 axioms in Ontology 2 but not in Ontology 1:
+2 axioms in right ontology but not in left ontology:
 + AnnotationAssertion(rdfs:label <https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl#test1> "TEST #1"^^xsd:string)
 + OntologyID(OntologyIRI(<https://github.com/ontodev/robot/robot-core/src/test/resources/simple1.owl>) VersionIRI(<null>))


### PR DESCRIPTION
Resolves #614. Markdown and HTML diff output now use "left" and "right" instead of "old" and "new". This matches the command line arguments.

~Partially addresses~ Resolves #586. I ~did not update~ updated the plain text output, which refers to "ontology 1" and "ontology 2". Now it also refers to "left" and "right".

I updated four test files to match the new text.