### PR TITLE
Add fail-on-violation option to verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add [`validate`] command [#691]
 - Add `--errors <path>` option to [`template`] in [#713]
 - Add new formats to [`report`]: HTML, JSON, and XLSX [#699]
+- Add `--fail-on-violation <bool>` option to [`verify`] in [#738]
 
 ### Fixed
 - Handle empty [`template`] property charactersitics in [#719]
@@ -205,6 +206,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#738]: https://github.com/ontodev/robot/pull/738
 [#728]: https://github.com/ontodev/robot/pull/728
 [#727]: https://github.com/ontodev/robot/pull/727
 [#726]: https://github.com/ontodev/robot/pull/726

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -24,6 +24,16 @@ And the CSV file `results/equivalent.csv` should have:
     first,second,firstLabel,secondLabel
     http://purl.obolibrary.org/obo/TEST_A,http://purl.obolibrary.org/obo/TEST_B,,
 
+
+### Fail on Violation
+
+By default, this command will fail with a non-zero exit code when any violations are found. If you wish the command to succeed (e.g., for use for warnings in workflows), you can include `--fail-on-violation false`. Not that it will still log `FAIL Rule [rule name]` on the command line.
+
+	robot verify --input asserted-equiv.owl \
+	  --queries equivalent.sparql \
+	  --fail-on-violation false \
+	  --output-dir results/
+
 ---
 
 ## Error Messages

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -27,7 +27,7 @@ And the CSV file `results/equivalent.csv` should have:
 
 ### Fail on Violation
 
-By default, this command will fail with a non-zero exit code when any violations are found. If you wish the command to succeed (e.g., for use for warnings in workflows), you can include `--fail-on-violation false`. Not that it will still log `FAIL Rule [rule name]` on the command line.
+By default, this command will fail with a non-zero exit code when any violations are found. If you wish the command to succeed (e.g., for use for warnings in workflows), you can include `--fail-on-violation false`. Note that it will still log `FAIL Rule [rule name]` on the command line.
 
 	robot verify --input asserted-equiv.owl \
 	  --queries equivalent.sparql \

--- a/robot-command/src/main/java/org/obolibrary/robot/VerifyCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/VerifyCommand.java
@@ -36,13 +36,13 @@ public class VerifyCommand implements Command {
   /** Initialze the command. */
   public VerifyCommand() {
     Options o = CommandLineHelper.getCommonOptions();
+    o.addOption("F", "fail-on-violation", true, "logging level to fail on");
     o.addOption("i", "input", true, "Input Ontology");
+    o.addOption("O", "output-dir", true, "Directory to place reports in");
 
     Option queries = new Option("q", "queries", true, "verify one or more SPARQL queries");
     queries.setArgs(Option.UNLIMITED_VALUES);
     o.addOption(queries);
-
-    o.addOption("O", "output-dir", true, "Directory to place reports in");
 
     options = o;
   }
@@ -133,8 +133,9 @@ public class VerifyCommand implements Command {
       }
     }
 
-    if (!passing) {
-      throw new Exception(verificationFailed);
+    boolean failOnViolation = CommandLineHelper.getBooleanValue(line, "fail-on-violation", true);
+    if (!passing && failOnViolation) {
+      System.exit(1);
     }
 
     return state;


### PR DESCRIPTION
Resolves #731

- [x] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

Add `--fail-on-violation` option to `verify` (default = `true`, which is the current behaviour). I also changed the exception to just `System.exit(1)` but I can change this back if we prefer the exception.