### PR TITLE
Always render full ontology IRI in report outputs

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -565,7 +565,6 @@ public class ReportOperation {
 
         case "tsv":
         default:
-          System.out.print("tsv!");
           rows = reportTable.toList("");
           if (outputPath != null) {
             if (print > 0) {

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
@@ -357,7 +357,8 @@ public class Report {
       for (Violation v : vs.getValue()) {
         // Subject of the violation for the following rows
         String subject;
-        if (!v.entity.isAnonymous()
+        if (ontologyIRI != null
+            && !v.entity.isAnonymous()
             && v.entity.getIRI().toString().equals(ontologyIRI.toString())) {
           // If the IRI is the ontology IRI, keep this as the full string
           subject = ontologyIRI.toString();

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
@@ -69,6 +69,8 @@ public class Report {
   private final List<String> header =
       Lists.newArrayList("Level", "Rule Name", "Subject", "Property", "Value");
 
+  private IRI ontologyIRI = null;
+
   /**
    * Create a new report object without an ontology or predefined IOHelper.
    *
@@ -88,6 +90,7 @@ public class Report {
   public Report(OWLOntology ontology, boolean useLabels) throws IOException {
     if (ontology != null) {
       manager = ontology.getOWLOntologyManager();
+      ontologyIRI = ontology.getOntologyID().getOntologyIRI().orNull();
     } else {
       manager = OWLManager.createOWLOntologyManager();
     }
@@ -140,6 +143,7 @@ public class Report {
   public Report(OWLOntology ontology, IOHelper ioHelper, boolean useLabels) {
     if (ontology != null) {
       manager = ontology.getOWLOntologyManager();
+      ontologyIRI = ontology.getOntologyID().getOntologyIRI().orNull();
     } else {
       manager = OWLManager.createOWLOntologyManager();
     }
@@ -352,7 +356,16 @@ public class Report {
       Cell ruleCell = new Cell(columns.get(1), ruleName);
       for (Violation v : vs.getValue()) {
         // Subject of the violation for the following rows
-        String subject = OntologyHelper.renderManchester(v.entity, provider, displayRenderer);
+        String subject;
+        if (!v.entity.isAnonymous()
+            && v.entity.getIRI().toString().equals(ontologyIRI.toString())) {
+          // If the IRI is the ontology IRI, keep this as the full string
+          subject = ontologyIRI.toString();
+        } else {
+          // Otherwise, render the subject based on the display renderer
+          subject = OntologyHelper.renderManchester(v.entity, provider, displayRenderer);
+        }
+
         Cell subjectCell = new Cell(columns.get(2), subject);
         for (Entry<OWLEntity, List<OWLObject>> statement : v.entityStatements.entrySet()) {
           // Property of the violation for the following rows


### PR DESCRIPTION
- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

See #737 - I found that ontology IRIs were shortened to CURIEs when rendering reports. I think that ontology IRIs should *always* be rendered as the full IRI, but I could be wrong. I also removed a bad print statement.
