### PR TITLE
Filter blank nodes in report queries

### DIFF
--- a/robot-core/src/main/resources/report_queries/annotation_whitespace.rq
+++ b/robot-core/src/main/resources/report_queries/annotation_whitespace.rq
@@ -10,10 +10,12 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT DISTINCT ?entity ?property ?value WHERE {
   {?property a owl:AnnotationProperty .
    ?entity ?property ?value .
-   FILTER REGEX(str(?value), "[\\s\r\n]+$")}
+   FILTER REGEX(str(?value), "[\\s\r\n]+$")
+   FILTER (!isBlank(?entity))}
   UNION
   {?property a owl:AnnotationProperty .
    ?entity ?property ?value .
-   FILTER REGEX(str(?value), "^[\\s\r\n]+")}
+   FILTER REGEX(str(?value), "^[\\s\r\n]+")
+   FILTER (!isBlank(?entity))}
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/duplicate_exact_synonym.rq
+++ b/robot-core/src/main/resources/report_queries/duplicate_exact_synonym.rq
@@ -19,5 +19,7 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   FILTER NOT EXISTS { ?entity owl:deprecated true }
   FILTER NOT EXISTS { ?entity2 owl:deprecated true }
   FILTER (?entity != ?entity2)
+  FILTER (!isBlank(?entity))
+  FILTER (!isBlank(?entity2))
 }
 ORDER BY DESC(UCASE(str(?value)))

--- a/robot-core/src/main/resources/report_queries/duplicate_label_synonym.rq
+++ b/robot-core/src/main/resources/report_queries/duplicate_label_synonym.rq
@@ -21,5 +21,6 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   FILTER NOT EXISTS { ?entity2 owl:deprecated true }
   ?entity rdfs:label ?value .
   ?entity ?property ?value .
+  FILTER (!isBlank(?entity))
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/duplicate_scoped_synonym.rq
+++ b/robot-core/src/main/resources/report_queries/duplicate_scoped_synonym.rq
@@ -26,5 +26,6 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   ?entity ?property ?value .
   ?entity ?property2 ?value .
   FILTER (?property != ?property2)
+  FILTER (!isBlank(?entity))
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/label_formatting.rq
+++ b/robot-core/src/main/resources/report_queries/label_formatting.rq
@@ -12,12 +12,14 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
    VALUES ?property {rdfs:label}
    ?entity ?property ?value .
    FILTER regex(?value, "\n")
+   FILTER (!isBlank(?entity))
   }
   UNION
   {
    VALUES ?property {rdfs:label}
    ?entity ?property ?value .
    FILTER regex(?value, "\t")
+   FILTER (!isBlank(?entity))
   }
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/label_whitespace.rq
+++ b/robot-core/src/main/resources/report_queries/label_whitespace.rq
@@ -12,12 +12,14 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
    VALUES ?property {rdfs:label}
    ?entity ?property ?value .
    FILTER REGEX(str(?value), "[\\s\r\n]+$")
+   FILTER (!isBlank(?entity))
   }
   UNION
   {
    VALUES ?property {rdfs:label}
    ?entity ?property ?value .
    FILTER REGEX(str(?value), "^[\\s\r\n]+")
+   FILTER (!isBlank(?entity))
   }
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/lowercase_definition.rq
+++ b/robot-core/src/main/resources/report_queries/lowercase_definition.rq
@@ -13,5 +13,6 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
                      obo:IAO_0000600 }
   ?entity ?property ?value .
   FILTER (!regex(?value, "^[A-Z]"))
+  FILTER (!isBlank(?entity))
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/misused_obsolete_label.rq
+++ b/robot-core/src/main/resources/report_queries/misused_obsolete_label.rq
@@ -14,5 +14,6 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   FILTER NOT EXISTS { ?entity owl:deprecated true }
   FILTER (?entity != oboInOwl:ObsoleteClass)
   FILTER regex(?value, "^obsolete", "i")
+  FILTER (!isBlank(?entity))
 }
 ORDER BY ?entity


### PR DESCRIPTION
See discussion in #737

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

Sometimes some annotation properties such as "definition" are used in axiom annotations. These have no IRI to reference, so this causes the queries to fail. Some of the queries already filter out the blank nodes, this juse updates the rest of them;.
