### PR TITLE
Update to whelk 1.0.4.

### DIFF
--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -175,7 +175,7 @@
     <dependency>
       <groupId>org.geneontology</groupId>
       <artifactId>whelk-owlapi_${scala.version}</artifactId>
-      <version>1.0.3</version>
+      <version>1.0.4</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
This whelk release fixes some quirks in handling owl:Nothing when responding to OWLReasoner methods.