### PR TITLE
Suggestion to allow single quotes in C template values

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/DiffOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/DiffOperation.java
@@ -153,9 +153,7 @@ public class DiffOperation {
     return false;
   }
 
-  /**
-   * OWLOntologySetProvider for two (left and right) ontologies.
-   */
+  /** OWLOntologySetProvider for two (left and right) ontologies. */
   private static class DualOntologySetProvider implements OWLOntologySetProvider {
 
     private static final long serialVersionUID = -8942374248162307075L;

--- a/robot-core/src/main/java/org/obolibrary/robot/Template.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/Template.java
@@ -870,34 +870,40 @@ public class Template {
         // Subclass expression
         subclassExpressionColumns.put(
             column,
-            TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column));
+            TemplateHelper.getClassExpressions(
+                name, checker, parser, template, value, rowNum, column));
       } else if (template.startsWith("EC")) {
         // Equivalent expression
         equivalentExpressionColumns.put(
             column,
-            TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column));
+            TemplateHelper.getClassExpressions(
+                name, checker, parser, template, value, rowNum, column));
       } else if (template.startsWith("DC")) {
         // Disjoint expression
         disjointExpressionColumns.put(
             column,
-            TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column));
+            TemplateHelper.getClassExpressions(
+                name, checker, parser, template, value, rowNum, column));
       } else if (template.startsWith("C") && !template.startsWith("CLASS_TYPE")) {
         // Use class type to determine what to do with the expression
         switch (classType) {
           case "subclass":
             subclassExpressionColumns.put(
                 column,
-                TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column));
+                TemplateHelper.getClassExpressions(
+                    name, checker, parser, template, value, rowNum, column));
             break;
           case "equivalent":
             intersectionEquivalentExpressionColumns.put(
                 column,
-                TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column));
+                TemplateHelper.getClassExpressions(
+                    name, checker, parser, template, value, rowNum, column));
             break;
           case "disjoint":
             disjointExpressionColumns.put(
                 column,
-                TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column));
+                TemplateHelper.getClassExpressions(
+                    name, checker, parser, template, value, rowNum, column));
             break;
           default:
             break;
@@ -1163,12 +1169,14 @@ public class Template {
       } else if (template.startsWith("DOMAIN")) {
         // Handle domains
         Set<OWLClassExpression> expressions =
-            TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column);
+            TemplateHelper.getClassExpressions(
+                name, checker, parser, template, value, rowNum, column);
         addObjectPropertyDomains(property, expressions, row, column);
       } else if (template.startsWith("RANGE")) {
         // Handle ranges
         Set<OWLClassExpression> expressions =
-            TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column);
+            TemplateHelper.getClassExpressions(
+                name, checker, parser, template, value, rowNum, column);
         addObjectPropertyRanges(property, expressions, row, column);
       }
     }
@@ -1439,7 +1447,8 @@ public class Template {
       } else if (template.startsWith("DOMAIN")) {
         // Handle domains
         Set<OWLClassExpression> expressions =
-            TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column);
+            TemplateHelper.getClassExpressions(
+                name, checker, parser, template, value, rowNum, column);
         addDataPropertyDomains(property, expressions, row, column);
       } else if (template.startsWith("RANGE")) {
         // Handle ranges
@@ -1845,7 +1854,7 @@ public class Template {
         } else {
           // If the class is null, assume it is a class expression
           OWLClassExpression typeExpr =
-              TemplateHelper.tryParse(name, parser, type, rowNum, typeColumn);
+              TemplateHelper.tryParse(name, checker, parser, type, rowNum, typeColumn);
           axioms.add(dataFactory.getOWLClassAssertionAxiom(typeExpr, individual));
         }
       }
@@ -1896,7 +1905,8 @@ public class Template {
           template = template + " SPLIT=" + split;
         }
         Set<OWLClassExpression> typeExpressions =
-            TemplateHelper.getClassExpressions(name, parser, template, value, rowNum, column);
+            TemplateHelper.getClassExpressions(
+                name, checker, parser, template, value, rowNum, column);
         for (OWLClassExpression ce : typeExpressions) {
           axioms.add(dataFactory.getOWLClassAssertionAxiom(ce, individual));
         }

--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
@@ -949,6 +949,31 @@ public class TemplateHelper {
    */
   protected static OWLClassExpression tryParse(
       String tableName,
+      ManchesterOWLSyntaxClassExpressionParser parser,
+      String content,
+      int rowNum,
+      int column)
+      throws RowParseException {
+    return tryParse(tableName, null, parser, content, rowNum, column);
+  }
+
+  /**
+   * Given a Quoted Entity Checker to resolve labels, a Manchester class expression parser, and a
+   * content string, try to parse the content string. If the checker is not null, first try to get a
+   * named class. If not found, try to parse using the parser. Throw a detailed exception message if
+   * parsing fails.
+   *
+   * @param tableName name of table
+   * @param checker QuotedEntityChecker to resolve labels
+   * @param parser ManchesterOWLSyntaxClassExpressionParser to parse string
+   * @param content class expression string to parse
+   * @param rowNum the row number for logging
+   * @param column the column number for logging
+   * @return OWLClassExpression representation of the string
+   * @throws RowParseException if string cannot be parsed for any reason
+   */
+  protected static OWLClassExpression tryParse(
+      String tableName,
       QuotedEntityChecker checker,
       ManchesterOWLSyntaxClassExpressionParser parser,
       String content,

--- a/robot-core/src/test/java/org/obolibrary/robot/TemplateTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/TemplateTest.java
@@ -5,8 +5,9 @@ import static org.junit.Assert.assertEquals;
 import com.google.common.collect.Lists;
 import java.util.*;
 import org.junit.Test;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.manchestersyntax.parser.ManchesterOWLSyntaxClassExpressionParser;
+import org.semanticweb.owlapi.model.*;
 
 /**
  * Tests Template class and class methods.
@@ -129,5 +130,30 @@ public class TemplateTest extends CoreTest {
     OntologyHelper.setOntologyIRI(
         template, IRI.create("https://github.com/ontodev/robot/examples/template.owl"), null);
     assertIdentical("/docs-template.owl", template);
+  }
+
+  /**
+   * Test parsing a label that contains single quotes.
+   *
+   * @throws Exception on problem parsing
+   */
+  @Test
+  public void testParseClass() throws Exception {
+    OWLDataFactory df = OWLManager.getOWLDataFactory();
+    String label = "Streptococcus sp. 'group B'";
+    OWLClass expectedClass =
+        df.getOWLClass(IRI.create("http://purl.obolibrary.org/obo/NCBITaxon_1319"));
+
+    // Create the checker
+    QuotedEntityChecker checker = new QuotedEntityChecker();
+    checker.add(expectedClass, label);
+
+    // Create the parser
+    ManchesterOWLSyntaxClassExpressionParser parser =
+        new ManchesterOWLSyntaxClassExpressionParser(df, checker);
+
+    OWLClass actualClass =
+        TemplateHelper.tryParse("test", checker, parser, label, 0, 0).asOWLClass();
+    assert actualClass.getIRI().toString().equals(expectedClass.getIRI().toString());
   }
 }


### PR DESCRIPTION
- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

Currently, when a term label contains a single quote, we need to use CURIEs instead of labels in the parent column, or else the term cannot be parsed.

For example, the label:
> Streptococcus sp. 'group B'

Results in:
```
MANCHESTER PARSE ERROR the expression ''Streptococcus sp. 'group B'''  at row 1976, column 2 
in table "src/ontology/templates/taxon.tsv" cannot be parsed: encountered unknown 'Streptococcus sp. '
```

Typically, I would just use `NCBITaxon:1319` instead and the template would be OK, but now that we are using labels with [VALVE](https://github.com/ontodev/valve.py), we need to be able to reference all labels in the "Parent" columns or else certain functions fail.

This is a proposed fix that first attempts to use a `QuotedEntityChecker` to retrieve a class by label. If a class cannot be found, then the `ManchesterOWLSyntaxClassExpressionParser` is used to try to parse an expression. My one concern is that for large templates with a bunch of class expressions, this double-step may be less efficient. At the same time, it may actually be quicker in some cases where only labels are used. The relevant lines are here:
https://github.com/ontodev/robot/blob/e486ce9c009334be9b21a1c8a6c212ecba8dbb6c/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java#L987-L996