### PR TITLE
Workaround for blank nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix reported row number in [`validate`] error tables in [#727]
 - Fix equivalent class rendering for [`template`] in [#728]
 - Fix ontology IRI rendering for [`report`] in [#739]
+- Fix blank node subjects in [`report`] in [#767]
 
 ## [1.7.0] - 2020-07-31
 

--- a/robot-core/src/main/java/org/obolibrary/robot/DiffOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/DiffOperation.java
@@ -153,9 +153,7 @@ public class DiffOperation {
     return false;
   }
 
-  /**
-   * OWLOntologySetProvider for two (left and right) ontologies.
-   */
+  /** OWLOntologySetProvider for two (left and right) ontologies. */
   private static class DualOntologySetProvider implements OWLOntologySetProvider {
 
     private static final long serialVersionUID = -8942374248162307075L;

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
@@ -352,7 +352,12 @@ public class Report {
       Cell ruleCell = new Cell(columns.get(1), ruleName);
       for (Violation v : vs.getValue()) {
         // Subject of the violation for the following rows
-        String subject = OntologyHelper.renderManchester(v.entity, provider, displayRenderer);
+        String subject;
+        if (v.entity != null) {
+          subject = OntologyHelper.renderManchester(v.entity, provider, displayRenderer);
+        } else {
+          subject = v.subject;
+        }
         Cell subjectCell = new Cell(columns.get(2), subject);
         for (Entry<OWLEntity, List<OWLObject>> statement : v.entityStatements.entrySet()) {
           // Property of the violation for the following rows


### PR DESCRIPTION
Resolves #766 

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

This replaces blank node IDs with "blank node" in the report output, e.g.:
| Level | Rule Name | Subject | Property | Value |
| --- | --- | --- | --- | --- |
| ERROR | deprecated_class_reference | blank node | owl:someValuesFrom | FBbt:02 |
