### PR TITLE
Replace validate with validate-profile in docs

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -50,7 +50,7 @@
           <a href="/report">report</a><br>
           <a href="/template">template</a><br>
           <a href="/unmerge">unmerge</a><br>
-          <a href="/validate">validate</a><br>
+          <a href="/validate-profile">validate-profile</a><br>
           <a href="/verify">verify</a><br>
           - - - - - - - - - -<br>
           <small>ROBOT is licensed under the </small><br>


### PR DESCRIPTION
Currently, the docs have `validate` but not `validate-profile`. I think the docs should hide the `validate` command for now, since it's not released.