### PR TITLE
Fix template handling of full IRIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix blank node subjects in [`report`] in [#767]
+- Fixed IRI handling for [`template`] in [#783]
 
 ## [1.7.1] - 2020-10-22
 
@@ -219,6 +220,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#783]: https://github.com/ontodev/robot/pull/783
 [#767]: https://github.com/ontodev/robot/pull/767
 [#758]: https://github.com/ontodev/robot/pull/758
 [#739]: https://github.com/ontodev/robot/pull/739

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -32,6 +32,12 @@ One of the required files (often `--input`) could not be found. This is often ca
 
 When specifying the `--output` (or `--format` for converting), make sure the file has a valid extension. See [convert](/convert) for a current list of ontology formats.
 
+### Invalid Element Error
+
+This error usually appears when running [`template`](/template) and special characters are used within the local ID part of a CURIE or IRI (e.g., `obo:IAO?0000115` or `http://purl.obolibrary.org/obo/IAO:0000115`). Local IDs may only include alphanumeric characters, underscores, and dashes.
+
+When rendering the output, only properties are validated for illegal characters. OWLAPI will allow local IDs with illegal characters to be used as subjects and objects.
+
 ### Invalid Ontology File Error
 
 ROBOT was expecting an ontology file, and the file exists, but is not in a recognized format. Adding the `-vvv` option will print a stack trace that shows how the underlying OWLAPI library tried to parse the ontology file. This will include details and line numbers that can help isolate the problem.
@@ -57,6 +63,14 @@ When matching an IRI by pattern, the pattern should contain one or more wildcard
 ### Invalid Prefix Error
 
 Prefixes (added with `--prefix`) should be strings in the following format: `"foo: http://foo/bar#"`. See [Prefixes](/global#prefixes) for more details on adding prefixes.
+
+### Invalid QName Error
+
+This error usually occurs when running [`template`](/template). When using a CURIE or IRI to point to a property in the ROBOT template string (e.g., `A <property>`), it must be a valid QName. When a QName is expanded, the *local* part of the ID (the part after the last `/` or `#`) must start with an alphabetic character. The following characters must be alphanumeric, underscores, or dashes.
+
+For example, the IRI `http://purl.obolibrary.org/obo/BFO_0000001` is valid because the local part begins with the character `B`. This may be referenced with the CURIE `BFO:0000001`. The IRI `http://purl.obolibrary.org/obo/0000001` is **not** valid because the local part begins with the character `0`. Even though `obo:0000001` looks like a valid CURIE, it expands into an invalid QName.
+
+When rendering the output, only properties are validated for QNames. OWLAPI will allow invalid QNames as subjects and objects.
 
 ### Invalid Reasoner Error
 
@@ -116,6 +130,14 @@ If a prefix is incorrectly formatted, or if the prefix target does not point to 
 ```
 robot -p "robot: http://purl.obolibrary.org/robot/"
 ```
+
+### Undefined Prefix Error
+
+This error usually occurs when running [`template`](/template). If you use a CURIE in one of the ROBOT template strings as a property (e.g., `A ex:0000115`) but do not define the prefix of that CURIE, ROBOT will be unable to save the ontology file.
+
+To resolve this, make sure all CURIEs use prefixes that are defined. ROBOT includes a set of [default prefixes](https://github.com/ontodev/robot/blob/master/robot-core/src/main/resources/obo_context.jsonld), but you can also define your own prefixes. To include a custom prefix, you see [prefixes](/global#prefixes).
+
+When rendering the output, only properties are validated for QNames. OWLAPI will allow undefined prefixes to be used in subjects and objects, but the IRI will be the unexpanded version of the CURIE (i.e., the IRI will just be `ex:0000115`).
 
 ### Unknown Arg Error
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -34,9 +34,9 @@ When specifying the `--output` (or `--format` for converting), make sure the fil
 
 ### Invalid Element Error
 
-This error usually appears when running [`template`](/template) and special characters are used within the local ID part of a CURIE or IRI (e.g., `obo:IAO?0000115` or `http://purl.obolibrary.org/obo/IAO:0000115`). Local IDs may only include alphanumeric characters, underscores, and dashes.
+This error occurs when ROBOT tries to convert an IRI to an XML element name for writing but encounters an illegal character. Common illegal characters include `/` and `:`. This error usually occurs when creating new ontology terms with [`template`](/template). See [Namespaces in XML](https://www.w3.org/TR/REC-xml-names/) for full details on legal XML element names.
 
-When rendering the output, only properties are validated for illegal characters. OWLAPI will allow local IDs with illegal characters to be used as subjects and objects.
+The solution is usually to add a new [prefix](/global#prefixes) so that the illegal character is no longer part of the element name. For example, the prefix `ex` for `http://example.com/` is valid, and `http://example.com/foo/bar` is a valid IRI, but `ex:foo/bar` is not a valid element name. By defining a new prefix `foo` for `http://example.com/foo/` we can now use `foo:bar` as a valid element name for the same IRI `http://example.com/foo/bar`.
 
 ### Invalid Ontology File Error
 
@@ -63,14 +63,6 @@ When matching an IRI by pattern, the pattern should contain one or more wildcard
 ### Invalid Prefix Error
 
 Prefixes (added with `--prefix`) should be strings in the following format: `"foo: http://foo/bar#"`. See [Prefixes](/global#prefixes) for more details on adding prefixes.
-
-### Invalid QName Error
-
-This error usually occurs when running [`template`](/template). When using a CURIE or IRI to point to a property in the ROBOT template string (e.g., `A <property>`), it must be a valid QName. When a QName is expanded, the *local* part of the ID (the part after the last `/` or `#`) must start with an alphabetic character. The following characters must be alphanumeric, underscores, or dashes.
-
-For example, the IRI `http://purl.obolibrary.org/obo/BFO_0000001` is valid because the local part begins with the character `B`. This may be referenced with the CURIE `BFO:0000001`. The IRI `http://purl.obolibrary.org/obo/0000001` is **not** valid because the local part begins with the character `0`. Even though `obo:0000001` looks like a valid CURIE, it expands into an invalid QName.
-
-When rendering the output, only properties are validated for QNames. OWLAPI will allow invalid QNames as subjects and objects.
 
 ### Invalid Reasoner Error
 
@@ -135,9 +127,9 @@ robot -p "robot: http://purl.obolibrary.org/robot/"
 
 This error usually occurs when running [`template`](/template). If you use a CURIE in one of the ROBOT template strings as a property (e.g., `A ex:0000115`) but do not define the prefix of that CURIE, ROBOT will be unable to save the ontology file.
 
-To resolve this, make sure all CURIEs use prefixes that are defined. ROBOT includes a set of [default prefixes](https://github.com/ontodev/robot/blob/master/robot-core/src/main/resources/obo_context.jsonld), but you can also define your own prefixes. To include a custom prefix, you see [prefixes](/global#prefixes).
+To resolve this, make sure all CURIEs use prefixes that are defined. ROBOT includes a set of [default prefixes](https://github.com/ontodev/robot/blob/master/robot-core/src/main/resources/obo_context.jsonld), but you can also define your own prefixes. To include a custom prefix, see [prefixes](/global#prefixes).
 
-When rendering the output, only properties are validated for QNames. OWLAPI will allow undefined prefixes to be used in subjects and objects, but the IRI will be the unexpanded version of the CURIE (i.e., the IRI will just be `ex:0000115`).
+When rendering the output, only properties are validated for [QNames](https://en.wikipedia.org/wiki/QName). OWLAPI will allow undefined prefixes to be used in subjects and objects, but the IRI will be the unexpanded version of the CURIE (i.e., the IRI will just be `ex:0000115`).
 
 ### Unknown Arg Error
 

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -821,6 +821,24 @@ public class IOHelper {
   }
 
   /**
+   * Given a term string, use the current prefixes to create an IRI.
+   *
+   * @deprecated replaced by {@link #createIRI(String)}
+   * @param term the term to convert to an IRI
+   * @param qName if true, validate that the IRI expands to a QName
+   * @return the new IRI or null
+   */
+  @Deprecated
+  public IRI createIRI(String term, boolean qName) {
+    IRI iri = createIRI(term);
+    // Check that this is a valid QName
+    if (qName && !iri.getRemainder().isPresent()) {
+      return null;
+    }
+    return iri;
+  }
+
+  /**
    * Given a set of term identifier strings, return a set of IRIs.
    *
    * @param terms the set of term identifier strings
@@ -890,29 +908,6 @@ public class IOHelper {
     OWLDataFactory df = manager.getOWLDataFactory();
     OWLDatatype datatype = df.getOWLDatatype(type);
     return df.getOWLLiteral(value, datatype);
-  }
-
-  /**
-   * Determine if a string is a valid QName. Adapted from:
-   *
-   * @see org.semanticweb.owlapi.io.XMLUtils#isQName(CharSequence)
-   * @param iri IRI to check
-   * @return true if valid QName
-   */
-  public boolean hasValidLocalID(IRI iri) {
-    String s = iri.getShortForm();
-    if (0 >= s.length()) {
-      // local ID is empty
-      return false;
-    }
-    for (int i = 0; i < s.length(); ) {
-      int codePoint = Character.codePointAt(s, i);
-      if (!XMLUtils.isXMLNameChar(codePoint)) {
-        return false;
-      }
-      i += Character.charCount(codePoint);
-    }
-    return true;
   }
 
   /**
@@ -1222,9 +1217,9 @@ public class IOHelper {
    *
    * @see org.semanticweb.owlapi.io.XMLUtils#isQName(CharSequence)
    * @param s Character sequence to check
-   * @return true if valid QName
+   * @return true if valid CURIE
    */
-  private static boolean isValidCURIE(CharSequence s) {
+  public static boolean isValidCURIE(CharSequence s) {
     if (s == null || 0 >= s.length()) {
       // string is null or empty
       return false;

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -918,9 +918,9 @@ public class IOHelper {
         return iriString.replace(ns, prefix);
       }
     }
-    // Could not match, just return full IRI
+    // Could not match, return short form with no prefix
     logger.warn("Unable to find namespace for: " + iri);
-    return null;
+    return ":" + iri.getShortForm();
   }
 
   /**

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -69,9 +69,6 @@ public class IOHelper {
   private static final String invalidElementError =
       NS + "INVALID ELEMENT ERROR \"%s\" contains invalid characters";
 
-  private static final String invalidQNameError =
-      NS + "INVALID QNAME ERROR \"%s\" cannot be converted to a QName";
-
   /** Error message when the specified file cannot be loaded. Expects the file name. */
   private static final String invalidOntologyFileError =
       NS + "INVALID ONTOLOGY FILE ERROR Could not load a valid ontology from file: %s";
@@ -1252,24 +1249,6 @@ public class IOHelper {
   }
 
   /**
-   * Determine if the short form of an IRI contains invalid characters.
-   *
-   * @param iri IRI to check
-   * @return true if no invalid characters found
-   */
-  public static boolean shortFormIsValid(IRI iri) {
-    String s = iri.getShortForm();
-    for (int i = 0; i < s.length(); ) {
-      int codePoint = Character.codePointAt(s, i);
-      if (!XMLUtils.isXMLNameChar(codePoint)) {
-        return false;
-      }
-      i += Character.charCount(codePoint);
-    }
-    return true;
-  }
-
-  /**
    * Read comma-separated values from a path to a list of lists of strings.
    *
    * @param path file path to the CSV file
@@ -1596,11 +1575,7 @@ public class IOHelper {
             String prefix = element.split(":")[0];
             throw new IOException(String.format(undefinedPrefixError, e2.getElementName(), prefix));
           } else {
-            if (shortFormIsValid(IRI.create(element))) {
-              throw new IOException(String.format(invalidElementError, element));
-            } else {
-              throw new IOException(String.format(invalidQNameError, element));
-            }
+            throw new IOException(String.format(invalidElementError, element));
           }
         }
         throw new IOException(String.format(ontologyStorageError, ontologyIRI.toString()), e);

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -1582,9 +1582,6 @@ public class IOHelper {
       // use native save functionality
       try {
         ontology.getOWLOntologyManager().saveOntology(ontology, format, ontologyIRI);
-      } catch (IllegalElementNameException e) {
-        IllegalElementNameException e2 = (IllegalElementNameException) e.getCause();
-        throw new IOException(String.format(invalidElementError, e2.getElementName()));
       } catch (OWLOntologyStorageException e) {
         // Determine if its caused by an OBO Format error
         if (format instanceof OBODocumentFormat

--- a/robot-core/src/main/java/org/obolibrary/robot/QuotedEntityChecker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/QuotedEntityChecker.java
@@ -293,7 +293,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
   public IRI getIRI(String name, boolean create) {
     IRI iri = iris.getOrDefault(name, null);
     if (iri == null && ioHelper != null && create) {
-      iri = ioHelper.createIRI(name, true);
+      iri = ioHelper.createIRI(name);
     }
     return iri;
   }
@@ -337,7 +337,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
       return dataFactory.getOWLAnnotationProperty(iri);
     }
     if (create && ioHelper != null) {
-      iri = ioHelper.createIRI(name, true);
+      iri = ioHelper.createIRI(name);
       if (iri != null) {
         return dataFactory.getOWLAnnotationProperty(iri);
       }
@@ -358,7 +358,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
       return dataFactory.getOWLClass(iri);
     }
     if (ioHelper != null) {
-      iri = ioHelper.createIRI(name, true);
+      iri = ioHelper.createIRI(name);
       if (iri != null) {
         return dataFactory.getOWLClass(iri);
       }
@@ -379,7 +379,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
       return dataFactory.getOWLDataProperty(iri);
     }
     if (ioHelper != null) {
-      iri = ioHelper.createIRI(name, true);
+      iri = ioHelper.createIRI(name);
       if (iri != null) {
         return dataFactory.getOWLDataProperty(iri);
       }
@@ -413,7 +413,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
       return dataFactory.getOWLDatatype(iri);
     }
     if (create && ioHelper != null) {
-      iri = ioHelper.createIRI(name, true);
+      iri = ioHelper.createIRI(name);
       if (iri != null) {
         return dataFactory.getOWLDatatype(iri);
       }
@@ -434,7 +434,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
       return dataFactory.getOWLNamedIndividual(iri);
     }
     if (ioHelper != null) {
-      iri = ioHelper.createIRI(name, true);
+      iri = ioHelper.createIRI(name);
       if (iri != null) {
         return dataFactory.getOWLNamedIndividual(iri);
       }
@@ -455,7 +455,7 @@ public class QuotedEntityChecker implements OWLEntityChecker {
       return dataFactory.getOWLObjectProperty(iri);
     }
     if (ioHelper != null) {
-      iri = ioHelper.createIRI(name, true);
+      iri = ioHelper.createIRI(name);
       if (iri != null) {
         return dataFactory.getOWLObjectProperty(iri);
       }

--- a/robot-core/src/main/java/org/obolibrary/robot/Template.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/Template.java
@@ -595,13 +595,13 @@ public class Template {
         type = "class";
       }
 
-      IRI iri = ioHelper.createIRI(id, true);
+      IRI iri = ioHelper.createIRI(id);
       if (iri == null) {
         iri = IRI.create(id);
       }
 
       // Try to resolve a CURIE
-      IRI typeIRI = ioHelper.createIRI(type, true);
+      IRI typeIRI = ioHelper.createIRI(type);
 
       // Set to IRI string or to type string
       String typeOrIRI = type;
@@ -747,7 +747,7 @@ public class Template {
     }
 
     // Try to resolve a CURIE
-    IRI typeIRI = ioHelper.createIRI(type, true);
+    IRI typeIRI = ioHelper.createIRI(type);
 
     // Set to IRI string or to type string
     String typeOrIRI = type;
@@ -1826,7 +1826,7 @@ public class Template {
       type = type.trim();
 
       // Try to resolve a CURIE
-      IRI typeIRI = ioHelper.createIRI(type, true);
+      IRI typeIRI = ioHelper.createIRI(type);
 
       // Set to IRI string or to type string
       String typeOrIRI = type;
@@ -2217,7 +2217,7 @@ public class Template {
       throw new Exception("You must specify either an ID or a label");
     }
     if (id != null) {
-      return ioHelper.createIRI(id, true);
+      return ioHelper.createIRI(id);
     }
     return checker.getIRI(label, true);
   }

--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
@@ -525,7 +525,7 @@ public class TemplateHelper {
       if (id == null || id.trim().isEmpty()) {
         continue;
       }
-      IRI iri = ioHelper.createIRI(id, true);
+      IRI iri = ioHelper.createIRI(id);
       if (iri == null) {
         continue;
       }

--- a/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
@@ -1,6 +1,6 @@
 package org.obolibrary.robot;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import com.github.jsonldjava.core.Context;
 import java.io.File;

--- a/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
@@ -119,41 +119,6 @@ public class IOHelperTest extends CoreTest {
   }
 
   /**
-   * Test getQName & isQName methods.
-   *
-   * @throws IOException on problem creating IOHelper
-   */
-  @Test
-  public void testIsQName() throws IOException {
-    IOHelper ioh = new IOHelper(false);
-    ioh.addPrefix("obo", "http://purl.obolibrary.org/obo/");
-
-    // Test a valid QName (obo:BFO_0000001)
-    IRI iri = IRI.create("http://purl.obolibrary.org/obo/BFO_0000001");
-    String qName = ioh.getQName(iri);
-    assertEquals("obo:BFO_0000001", qName);
-    assertTrue(IOHelper.isQName(qName));
-
-    // Test an invalid QName (obo:BFO/0000001)
-    iri = IRI.create("http://purl.obolibrary.org/obo/BFO/0000001");
-    qName = ioh.getQName(iri);
-    assertEquals("obo:BFO/0000001", qName);
-    assertFalse(IOHelper.isQName(qName));
-
-    // Test QName with undefined namespace (hash separator)
-    iri = IRI.create("http://example.com#BFO_0000001");
-    qName = ioh.getQName(iri);
-    assertEquals(":BFO_0000001", qName);
-    assertTrue(IOHelper.isQName(qName));
-
-    // Test QName with undefined namespace (slash separator)
-    iri = IRI.create("http://example.com/resource/1");
-    qName = ioh.getQName(iri);
-    assertEquals(":1", qName);
-    assertTrue(IOHelper.isQName(qName));
-  }
-
-  /**
    * Test prefix maps.
    *
    * @throws IOException on file problem

--- a/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
@@ -1,6 +1,6 @@
 package org.obolibrary.robot;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import com.github.jsonldjava.core.Context;
 import java.io.File;
@@ -116,6 +116,35 @@ public class IOHelperTest extends CoreTest {
     expected.put("foo", "http://example.com#");
     expected.put("bar", "http://example.com#");
     assertEquals("Check JSON prefixes", expected, ioh.getPrefixes());
+  }
+
+  /**
+   * Test getQName & isQName methods.
+   *
+   * @throws IOException on problem creating IOHelper
+   */
+  @Test
+  public void testIsQName() throws IOException {
+    IOHelper ioh = new IOHelper(false);
+    ioh.addPrefix("obo", "http://purl.obolibrary.org/obo/");
+
+    // Test a valid QName (obo:BFO_0000001)
+    IRI iri = IRI.create("http://purl.obolibrary.org/obo/BFO_0000001");
+    String qName = ioh.getQName(iri);
+    assertEquals("obo:BFO_0000001", qName);
+    assertTrue(IOHelper.isQName(qName));
+
+    // Test an invalid QName (obo:BFO/0000001)
+    iri = IRI.create("http://purl.obolibrary.org/obo/BFO/0000001");
+    qName = ioh.getQName(iri);
+    assertEquals("obo:BFO/0000001", qName);
+    assertFalse(IOHelper.isQName(qName));
+
+    // Test QName with undefined namespace
+    iri = IRI.create("http://example.com#BFO_0000001");
+    qName = ioh.getQName(iri);
+    assertEquals(":BFO_0000001", qName);
+    assertTrue(IOHelper.isQName(qName));
   }
 
   /**

--- a/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
@@ -140,10 +140,16 @@ public class IOHelperTest extends CoreTest {
     assertEquals("obo:BFO/0000001", qName);
     assertFalse(IOHelper.isQName(qName));
 
-    // Test QName with undefined namespace
+    // Test QName with undefined namespace (hash separator)
     iri = IRI.create("http://example.com#BFO_0000001");
     qName = ioh.getQName(iri);
     assertEquals(":BFO_0000001", qName);
+    assertTrue(IOHelper.isQName(qName));
+
+    // Test QName with undefined namespace (slash separator)
+    iri = IRI.create("http://example.com/resource/1");
+    qName = ioh.getQName(iri);
+    assertEquals(":1", qName);
     assertTrue(IOHelper.isQName(qName));
   }
 


### PR DESCRIPTION
Resolves #782

- [ ] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

In the issue, `http://example.com/resource/1` is not a *technically* a valid QName, and we updated the processing of IDs/IRIs in templates last May to make sure all IRIs were also valid QNames. This is because the writer would fail on invalid QNames, but it seems like it's only *certain* invalid QNames... Even though it's not valid, OWLAPI seems to still handle it OK as opposed to the CURIEs that were never expanded to IRIs (see https://github.com/ontodev/robot/issues/688).

The QName check in OWLAPI fails every time for `http://example.com/resource/1` so I made a hack around it with a new `isQName` method in IOHelper. It will still fail for CURIEs with undefined namespaces, as we expect.