### PR TITLE
Add doc page for export-prefixes

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -34,6 +34,7 @@
           <a href="/diff">diff</a><br>
           <a href="/explain">explain</a><br>
           <a href="/export">export</a><br>
+          <a href="/export-prefixes">export-prefixes</a><br>
           <a href="/extract">extract</a><br>
           <a href="/filter">filter</a><br>
           <a href="/materialize">materialize</a><br>

--- a/docs/export-prefixes.md
+++ b/docs/export-prefixes.md
@@ -1,0 +1,30 @@
+# Export Prefixes
+
+You can print or save the current [prefixes](/global#prefixes) using the `export-prefixes` command:
+
+    robot --prefixes foo.json \
+      --prefix "bar: http://bar#" \
+      --prefix "baz: http://baz#" \
+      export-prefixes
+
+This prints the [default prefixes](https://github.com/ontodev/robot/blob/master/robot-core/src/main/resources/obo_context.jsonld) *plus* the user-added prefixes in [JSON-LD format](https://json-ld.org/) The prefixes are contained within a `@context` that can be used to resolve [JSON-LD compact IRIs](https://www.w3.org/TR/json-ld/#compact-iris). For the above, command, the printed output would look something like:
+
+```json
+{
+  "@context": {
+    "obo": "http://purl.obolibrary.org/obo/",
+    "oboInOwl": "http://www.geneontology.org/formats/oboInOwl#",
+    ...
+    "foo": "http://foo#",
+    "bar": "http://bar#",
+    "baz": "http://baz#"
+	}
+}
+```
+
+You can also include an output to write the prefixes to a file:
+
+    robot --noprefixes --prefix "foo: http://foo#" \
+      export-prefixes --output results/foo.json
+
+The `--noprefixes` flag is used in this example, meaning the default prefixes are not included. For more details on adding prefixes, see [prefixes](/global#prefixes).

--- a/docs/export-prefixes.md
+++ b/docs/export-prefixes.md
@@ -9,7 +9,7 @@ You can print or save the current [prefixes](/global#prefixes) using the `export
 
 This prints the [default prefixes](https://github.com/ontodev/robot/blob/master/robot-core/src/main/resources/obo_context.jsonld) *plus* the user-added prefixes in [JSON-LD format](https://json-ld.org/) The prefixes are contained within a `@context` that can be used to resolve [JSON-LD compact IRIs](https://www.w3.org/TR/json-ld/#compact-iris). For the above, command, the printed output would look something like:
 
-```json
+```
 {
   "@context": {
     "obo": "http://purl.obolibrary.org/obo/",
@@ -18,7 +18,7 @@ This prints the [default prefixes](https://github.com/ontodev/robot/blob/master/
     "foo": "http://foo#",
     "bar": "http://bar#",
     "baz": "http://baz#"
-	}
+  }
 }
 ```
 

--- a/docs/global.md
+++ b/docs/global.md
@@ -52,13 +52,7 @@ Terms in OBO and OWL are identified using [IRIs](https://en.wikipedia.org/wiki/I
 
 For robot we use the JSON-LD format. See [`obo_context.jsonld`](https://github.com/ontodev/robot/blob/master/robot-core/src/main/resources/obo_context.jsonld) for the JSON-LD context that is used by default. It includes common, general linked-data prefixes, and prefixes for all the OBO library projects.
 
-If you do not want to use the defaults, you can use the `--noprefixes` option. If you want to replace the defaults, use the `--prefixes` option and specify your JSON-LD file. Whatever your choice, you can add more prefixes using the `--prefix` option, as many times as you like. Finally, you can print or save the current prefixes using the `export-prefixes` command. Here are some examples:
-
-    robot --noprefixes --prefix "foo: http://foo#" \
-      export-prefixes --output results/foo.json
-
-    robot --prefixes foo.json -p "bar: http://bar#" -p "baz: http://baz#" \
-      export-prefixes
+If you do not want to use the defaults, you can use the `--noprefixes` option. If you want to replace the defaults, use the `--prefixes` option and specify your JSON-LD file. Whatever your choice, you can add more prefixes using the `--prefix` option, as many times as you like. Finally, you can print or save the current prefixes using the [`export-prefixes`](/export-prefixes) command.
 
 The various prefix options can be used with any command. When chaining commands, you usually want to specify all the prefix options first, so that they are used "globally" by all commands. But you can also use prefix options for single commands. Here's a silly example with a global prefix "foo" and a local prefix "bar". The first export includes both the global and local prefixes, while the second export includes only the global prefix.
 


### PR DESCRIPTION
Adds a doc page for the `export-prefixes` command.
