### PR TITLE
Run query on TDB dataset without input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update to whelk 1.0.4
+- Run [`query`] on existing TDB dataset (instead of ontology input) in [#792]
 
 ### Fixed
 - Fix blank node subjects in [`report`] in [#767]
@@ -220,6 +221,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#792]: https://github.com/ontodev/robot/pull/792
 [#783]: https://github.com/ontodev/robot/pull/783
 [#767]: https://github.com/ontodev/robot/pull/767
 [#758]: https://github.com/ontodev/robot/pull/758

--- a/docs/query.md
+++ b/docs/query.md
@@ -77,7 +77,7 @@ For very large ontologies, it may be beneficial to load the ontology to a mappin
     robot query --input nucleus.ttl --tdb true \
      --query cell_part.sparql results/cell_part.csv
  
-Please note that this will only work with ontologies in RDF/XML or Turtle syntax, and not with Manchester Syntax. Attempting to load an ontology in a different syntax will result in a [Syntax Error](errors#syntax-error). ROBOT will create a directory to store the ontology as a dataset, which defaults to `.tdb`. You can change the location of the TDB directory by using `--tdb-directory <directory>`.
+Please note that this will only work with ontologies in RDF/XML or Turtle syntax, and not with Manchester Syntax. Attempting to load an ontology in a different syntax will result in a [Syntax Error](errors#syntax-error). ROBOT will create a directory to store the ontology as a dataset, which defaults to `.tdb`. You can change the location of the TDB directory by using `--tdb-directory <directory>`. If a `--tdb-directory` is specified, you do not need to include `--tdb true`. If you've already created a TDB directory, you can query from the TDB dataset without needing to specify an `--input` - just include the `--tdb-directory`.
 
 Once the query operation is complete, ROBOT will remove the TDB directory. If you are performing many query commands on one ontology, you can include `--keep-tdb-mappings true` to prevent ROBOT from removing the TDB directory. This will greatly reduce the execution time of subsequent queries.
 

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -503,12 +503,10 @@ public class IOHelper {
    * @throws JenaException if TDB directory can't be written to
    */
   public static Dataset loadToTDBDataset(String inputPath, String tdbDir) throws JenaException {
-    Dataset dataset;
-    if (new File(tdbDir).isDirectory()) {
-      dataset = TDBFactory.createDataset(tdbDir);
-      if (!dataset.isEmpty()) {
-        return dataset;
-      }
+    // First try opening existing dataset
+    Dataset dataset = openTDBDataset(tdbDir);
+    if (dataset != null) {
+      return dataset;
     }
     dataset = TDBFactory.createDataset(tdbDir);
     logger.debug(String.format("Parsing input '%s' to dataset", inputPath));
@@ -531,6 +529,23 @@ public class IOHelper {
     long time = (System.nanoTime() - start) / 1000000000;
     logger.debug(String.format("Parsing complete - took %s seconds", String.valueOf(time)));
     return dataset;
+  }
+
+  /**
+   * Given a path to a TDB directory, load the TDB as a Dataset.
+   *
+   * @param tdbDir path to existing TDB directory
+   * @return Dataset or null
+   */
+  public static Dataset openTDBDataset(String tdbDir) {
+    Dataset dataset;
+    if (new File(tdbDir).isDirectory()) {
+      dataset = TDBFactory.createDataset(tdbDir);
+      if (!dataset.isEmpty()) {
+        return dataset;
+      }
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
Some small QOL updates to `query` with TDB

- [x] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

Specifying both an `--input` and a `--tdb-directory` when the TDB directory already exists is redundant. The `--input` is not used for anything since we just load the TDB dataset. This updates the handling of the TDB options so that you can run `query` on an existing TDB dataset without `--input` as long as you have a `--tdb-directory`. Note that this will fail if the TDB directory doesn't exist or is empty, since there's nothing to load.

I also updated `--tdb-directory` to be useable without `--tdb true`, since this is also redundant. If you're including `--tdb-directory`, we assume you want `--tdb true`.