### PR TITLE
Improve template parse error messages

### DIFF
--- a/docs/template.md
+++ b/docs/template.md
@@ -310,6 +310,10 @@ AL rdfs:label@en
 
 The provided value cannot be parsed and may not be in proper Manchester syntax. See [Manchester Syntax](http://www.w3.org/2007/OWL/wiki/ManchesterSyntax) for more details. If you are using labels, make sure the labels are defined in the `--input` ontology or using the `LABEL` column. Also ensure that all properties use a label instead of a CURIE or IRI.
 
+When using a restriction (`some`, `only`, `min`, `max`, `exactly`, or `value`) the term that preceeds the restriction must be a property. 
+
+Terms joined using `and` or `or` must be of the same entity type, e.g., you cannot join an object property and a class in an expression.
+
 ### Merge Error
 
 `--merge-before` and `--merge-after` cannot be used simultaneously.

--- a/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
@@ -247,7 +247,7 @@ public class QueryCommand implements Command {
    * @throws IOException on problem running queries
    */
   private static void executeOnDisk(CommandLine line, List<List<String>> queries)
-    throws IOException, MissingArgumentException {
+      throws IOException, MissingArgumentException {
     Dataset dataset = createTDBDataset(line);
     boolean keepMappings = CommandLineHelper.getBooleanValue(line, "keep-tdb-mappings", false);
     String tdbDir = CommandLineHelper.getDefaultValue(line, "tdb-directory", ".tdb");

--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
@@ -932,6 +932,7 @@ public class TemplateHelper {
       expr = parser.parse(content);
     } catch (OWLParserException e) {
       String cause = getManchesterErrorCause(e);
+
       throw new RowParseException(
           String.format(manchesterParseError, content, rowNum, column + 1, tableName, cause),
           rowNum,
@@ -954,10 +955,23 @@ public class TemplateHelper {
     Pattern p = Pattern.compile(pattern);
     Matcher m = p.matcher(e.getMessage());
     if (m.find()) {
-      if (m.group(1).startsWith("'")) {
-        return "encountered unknown " + m.group(1);
+      // Maybe add a hint
+      String keyword = m.group(1);
+      String hint = "";
+      if (Arrays.asList("some", "only", "min", "max", "exactly", "value").contains(keyword)) {
+        hint =
+            String.format("\n\tHint: the term before '%s' must be declared as a property", keyword);
+      } else if (Arrays.asList("and", "or").contains(keyword)) {
+        hint =
+            String.format(
+                "\n\tHint: the terms joined by '%s' must be the same entity type", keyword);
+      }
+
+      // Return error message
+      if (keyword.startsWith("'")) {
+        return "\n\tencountered unknown " + keyword + hint;
       } else {
-        return String.format("encountered unknown '%s'", m.group(1));
+        return String.format("\n\tencountered unknown '%s'", keyword) + hint;
       }
     }
     return cause;


### PR DESCRIPTION
Resolves #795

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

When using a restriction with a non-property entity, you will see:
```
MANCHESTER PARSE ERROR the expression ('test 1' some 'test 4') at row 7, column 4 in table "test.tsv" cannot be parsed: encountered unexpected 'some'
	hint: the term before 'some' must be a property
For details see: http://robot.obolibrary.org/template#manchester-parse-error
```

For all other types of parse errors, you will now see some expected suggestions. These come directly from the parser, but I tried to format them as much as possible to make sense.

e.g., using a class in a restriction for a data property:
```
MANCHESTER PARSE ERROR the expression ('test 1' some 'test 3') at row 5, column 4 in table "test.tsv" cannot be parsed: encountered 'test 3', but expected one of:
	Datatype name
	not
	{ ... }
For details see: http://robot.obolibrary.org/template#manchester-parse-error
```

Or using an undeclared class:
```
MANCHESTER PARSE ERROR the expression ('test 1' some 'test 4') at row 5, column 4 in table "test.tsv" cannot be parsed: encountered 'test 4', but expected one of:
 name
	( ... )
	{ ... }
	Self
For details see: http://robot.obolibrary.org/template#manchester-parse-error
```