### PR TITLE
Fix "SubClasses" handling in export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Explanations for inconsistent and unsatisfiable classes in [`explain`] [#779]
 
+### Fixed
+- Allow case-insensitive "SubClasses" in [`export`] header [#802]
+
 ## [1.7.2] - 2020-11-18
 
 ### Changed
@@ -230,6 +233,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#802]: https://github.com/ontodev/robot/pull/802
 [#796]: https://github.com/ontodev/robot/pull/796
 [#793]: https://github.com/ontodev/robot/pull/793
 [#792]: https://github.com/ontodev/robot/pull/792

--- a/docs/examples/nucleus.json
+++ b/docs/examples/nucleus.json
@@ -3,33 +3,31 @@
     "ID": "GO:0005575",
     "LABEL": [
       "cellular_component"
+    ],
+    "SubClasses": [
+      "cell",
+      "cell part",
+      "membrane-enclosed lumen",
+      "organelle",
+      "organelle part"
     ]
   },
   {
     "ID": "GO:0005622",
     "LABEL": [
       "intracellular"
-    ],
-    "SubClass Of": [
-      "cell part"
     ]
   },
   {
     "ID": "GO:0005623",
     "LABEL": [
       "cell"
-    ],
-    "SubClass Of": [
-      "cellular_component"
     ]
   },
   {
     "ID": "GO:0005634",
     "LABEL": [
       "nucleus"
-    ],
-    "SubClass Of": [
-      "intracellular membrane-bounded organelle"
     ]
   },
   {
@@ -37,19 +35,14 @@
     "LABEL": [
       "membrane-enclosed lumen"
     ],
-    "SubClass Of": [
-      "cellular_component"
+    "SubClasses": [
+      "organelle lumen"
     ]
   },
   {
     "ID": "GO:0031981",
     "LABEL": [
       "nuclear lumen"
-    ],
-    "SubClass Of": [
-      "'part of' some nucleus",
-      "intracellular organelle lumen",
-      "nuclear part"
     ]
   },
   {
@@ -57,8 +50,9 @@
     "LABEL": [
       "organelle"
     ],
-    "SubClass Of": [
-      "cellular_component"
+    "SubClasses": [
+      "intracellular organelle",
+      "membrane-bounded organelle"
     ]
   },
   {
@@ -66,8 +60,8 @@
     "LABEL": [
       "membrane-bounded organelle"
     ],
-    "SubClass Of": [
-      "organelle"
+    "SubClasses": [
+      "intracellular membrane-bounded organelle"
     ]
   },
   {
@@ -75,10 +69,8 @@
     "LABEL": [
       "intracellular organelle"
     ],
-    "SubClass Of": [
-      "'part of' some intracellular",
-      "intracellular part",
-      "organelle"
+    "SubClasses": [
+      "intracellular membrane-bounded organelle"
     ]
   },
   {
@@ -86,9 +78,8 @@
     "LABEL": [
       "intracellular membrane-bounded organelle"
     ],
-    "SubClass Of": [
-      "intracellular organelle",
-      "membrane-bounded organelle"
+    "SubClasses": [
+      "nucleus"
     ]
   },
   {
@@ -96,10 +87,8 @@
     "LABEL": [
       "organelle lumen"
     ],
-    "SubClass Of": [
-      "'part of' some organelle",
-      "membrane-enclosed lumen",
-      "organelle part"
+    "SubClasses": [
+      "intracellular organelle lumen"
     ]
   },
   {
@@ -107,9 +96,9 @@
     "LABEL": [
       "organelle part"
     ],
-    "SubClass Of": [
-      "'part of' some organelle",
-      "cellular_component"
+    "SubClasses": [
+      "intracellular organelle part",
+      "organelle lumen"
     ]
   },
   {
@@ -117,9 +106,9 @@
     "LABEL": [
       "intracellular part"
     ],
-    "SubClass Of": [
-      "'part of' some intracellular",
-      "cell part"
+    "SubClasses": [
+      "intracellular organelle",
+      "intracellular organelle part"
     ]
   },
   {
@@ -127,9 +116,8 @@
     "LABEL": [
       "nuclear part"
     ],
-    "SubClass Of": [
-      "'part of' some nucleus",
-      "intracellular organelle part"
+    "SubClasses": [
+      "nuclear lumen"
     ]
   },
   {
@@ -137,12 +125,9 @@
     "LABEL": [
       "intracellular organelle part"
     ],
-    "SubClass Of": [
-      "'part of' some 'intracellular organelle'",
-      "'part of' some intracellular",
-      "'part of' some organelle",
-      "intracellular part",
-      "organelle part"
+    "SubClasses": [
+      "intracellular organelle lumen",
+      "nuclear part"
     ]
   },
   {
@@ -150,9 +135,9 @@
     "LABEL": [
       "cell part"
     ],
-    "SubClass Of": [
-      "'part of' some cell",
-      "cellular_component"
+    "SubClasses": [
+      "intracellular",
+      "intracellular part"
     ]
   },
   {
@@ -160,10 +145,8 @@
     "LABEL": [
       "intracellular organelle lumen"
     ],
-    "SubClass Of": [
-      "'part of' some 'intracellular organelle'",
-      "intracellular organelle part",
-      "organelle lumen"
+    "SubClasses": [
+      "nuclear lumen"
     ]
   }
 ]

--- a/docs/export.md
+++ b/docs/export.md
@@ -40,7 +40,7 @@ These can be specified with the `--format` option:
 If this option is not included, `export` will predict the format based on the file extension:
  
     robot export --input nucleus_part_of.owl \
-      --header "ID|LABEL|SubClass Of" \
+      --header "ID|LABEL|SubClasses" \
       --export results/nucleus.json
 
 ### Columns

--- a/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
@@ -941,7 +941,7 @@ public class ExportOperation {
       ShortFormProvider provider = col.getShortFormProvider();
 
       Cell cell;
-      switch (colName) {
+      switch (colName.toUpperCase()) {
         case "IRI":
           String iriString = entity.getIRI().toString();
           if (format.toLowerCase().startsWith("html")) {
@@ -968,7 +968,7 @@ public class ExportOperation {
           List<String> values = getSynonyms(ontology, entity);
           row.add(new Cell(col, values));
           continue;
-        case "subclasses":
+        case "SUBCLASSES":
           if (entity.isOWLClass()) {
             Collection<OWLClassExpression> subclasses =
                 EntitySearcher.getSubClasses(entity.asOWLClass(), ontology);


### PR DESCRIPTION
Resolves #801

- [x] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

Allows for any case "SubClasses" to be used in the header.
