### PR TITLE
Add measure to side bar

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -38,6 +38,7 @@
           <a href="/extract">extract</a><br>
           <a href="/filter">filter</a><br>
           <a href="/materialize">materialize</a><br>
+          <a href="/merge">measure</a><br>
           <a href="/merge">merge</a><br>
           <a href="/mirror">mirror</a><br>
           <a href="/python">python</a><br>

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineInterface.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineInterface.java
@@ -29,8 +29,8 @@ public class CommandLineInterface {
     m.addCommand("extract", new ExtractCommand());
     m.addCommand("filter", new FilterCommand());
     m.addCommand("materialize", new MaterializeCommand());
-    m.addCommand("merge", new MergeCommand());
     m.addCommand("measure", new MeasureCommand());
+    m.addCommand("merge", new MergeCommand());
     m.addCommand("mirror", new MirrorCommand());
     m.addCommand("python", new PythonCommand());
     m.addCommand("query", new QueryCommand());


### PR DESCRIPTION
`measure` was missing from our docs navigation. It should also come before "merge" alphabetically in our list of commands.
