### PR TITLE
Update owl-diff version.

### DIFF
--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -170,7 +170,7 @@
     <dependency>
       <groupId>org.geneontology</groupId>
       <artifactId>owl-diff_${scala.version}</artifactId>
-      <version>1.2.1</version>
+      <version>1.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.geneontology</groupId>


### PR DESCRIPTION
This version of owl-diff does not emit a difference when comparing two anonymous ontology IDs. (cc @beckyjackson)