### PR TITLE
Remove extra print statement from 'report --print N'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix printing violations in [`report`] [#823]
+
 ## [1.8.1] - 2021-01-27
 
 ### Fixed

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -487,11 +487,6 @@ public class ReportOperation {
       format = "tsv";
     }
 
-    if (print > 0) {
-      Table reportTable = report.toTable("tsv");
-      printNViolations(reportTable.toList(""), print, "\t");
-    }
-
     // Process different output formats while writing print lines if requested
     // First check if format is JSON or YAML
     // We don't use the Table for these formats because we want to group by violation level and rule


### PR DESCRIPTION
Resolves #823

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated
