### PR TITLE
Override declarations for rdf:type in 'export'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix printing violations in [`report`] [#823]
+- Fix handling of `rdf:type` in [`export`] [#834]
 
 ## [1.8.1] - 2021-01-27
 
@@ -248,6 +249,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#808]: https://github.com/ontodev/robot/pull/834
 [#808]: https://github.com/ontodev/robot/pull/808
 [#802]: https://github.com/ontodev/robot/pull/802
 [#796]: https://github.com/ontodev/robot/pull/796

--- a/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
@@ -199,9 +199,9 @@ public class ExportOperation {
       updateLabelMap(labelMap);
 
       // Try to resolve a CURIE or a label
-      IRI iri = ioHelper.createIRI(colName);
+      IRI iri = labelMap.getOrDefault(colName, null);
       if (iri == null) {
-        iri = labelMap.getOrDefault(colName, null);
+        iri = ioHelper.createIRI(colName);
       }
 
       // Handle the default column rendering
@@ -276,6 +276,13 @@ public class ExportOperation {
           break;
         default:
           throw new Exception(String.format(unknownTagError, c, currentEntityFormat));
+      }
+
+      if (iri != null && iri.toString().equals("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")) {
+        // Override any declarations
+        ap = null;
+        dp = null;
+        op = null;
       }
 
       Column column;
@@ -931,6 +938,7 @@ public class ExportOperation {
 
       String colName = col.getName();
       OWLProperty colProperty = col.getProperty();
+
       if (colProperty instanceof OWLAnnotationProperty) {
         OWLAnnotationProperty maybeLabel = (OWLAnnotationProperty) colProperty;
         if (maybeLabel.isLabel()) {


### PR DESCRIPTION
Resolves #833

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

If `rdf:type` has a declaration attached to it, always ignore it (e.g., if it's been declared as an annotation property)