### PR TITLE
Maven updates & clean up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.7</version>
+            <version>1.6.8</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>
@@ -105,7 +105,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>2.2.1</version>
+            <version>3.2.0</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -118,7 +118,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.0.1</version>
+            <version>3.2.0</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -131,7 +131,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -149,6 +149,39 @@
 
   <dependencies>
     <dependency>
+      <groupId>net.sourceforge.owlapi</groupId>
+      <artifactId>owlapi-api</artifactId>
+      <version>4.5.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.owlapi</groupId>
+      <artifactId>owlapi-apibinding</artifactId>
+      <version>4.5.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.owlapi</groupId>
+      <artifactId>owlapi-rio</artifactId>
+      <version>4.5.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.1</version>
@@ -156,12 +189,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.10</version>
-    </dependency>
-    <dependency>
-      <groupId>net.sourceforge.owlapi</groupId>
-      <artifactId>owlapi-distribution</artifactId>
-      <version>4.5.6</version>
+      <version>1.7.30</version>
     </dependency>
     <dependency>
       <groupId>org.semanticweb.elk</groupId>
@@ -186,11 +214,39 @@
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>org.semanticweb.hermit</artifactId>
       <version>1.3.8.413</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sourceforge.owlapi</groupId>
+          <artifactId>owlapi-distribution</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.geronimo.specs</groupId>
+          <artifactId>geronimo-javamail_1.4_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.geronimo.specs</groupId>
+          <artifactId>geronimo-activation_1.1_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.woodstox</groupId>
+          <artifactId>woodstox-core-asl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>jfact</artifactId>
       <version>4.0.4</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sourceforge.owlapi</groupId>
+          <artifactId>owlapi-distribution</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 
@@ -199,7 +255,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.7.1</version>
+        <version>3.9.1</version>
       </plugin>
       <plugin>
         <groupId>org.obolibrary.robot</groupId>
@@ -214,7 +270,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.2.0</version>
         <configuration>
           <links>
             <link>https://commons.apache.org/proper/commons-cli/javadocs/api-1.2/</link>
@@ -223,8 +279,9 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,15 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArgument>-Xlint:all</compilerArgument>
+              <showWarnings>true</showWarnings>
+              <showDeprecation>true</showDeprecation>
+            </configuration>
+          </plugin>
+          <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
             <version>1.6.8</version>
@@ -230,6 +239,14 @@
         <exclusion>
           <groupId>org.apache.geronimo.specs</groupId>
           <artifactId>geronimo-activation_1.1_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.geronimo.specs</groupId>
+          <artifactId>geronimo-stax-api_1.0_spec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>jaxen</groupId>
+          <artifactId>jaxen</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.codehaus.woodstox</groupId>

--- a/robot-command/pom.xml
+++ b/robot-command/pom.xml
@@ -18,7 +18,7 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.10</version>
+        <version>2.9</version>
         <executions>
           <execution>
             <goals>

--- a/robot-command/pom.xml
+++ b/robot-command/pom.xml
@@ -18,7 +18,7 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.1.0</version>
+        <version>2.10</version>
         <executions>
           <execution>
             <goals>
@@ -32,7 +32,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.18.1</version>
+        <version>3.0.0-M5</version>
         <executions>
           <execution>
             <goals>
@@ -47,7 +47,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.3</version>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -55,6 +55,43 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:obographs</artifact>
+                  <excludes>
+                    <exclude>obo_context.jsonld</exclude>
+                  </excludes>
+                </filter>
+                <!-- Only one log4j.properties file needs to be included, we'll use the CLI one -->
+                <!-- We keep the core log4.properties file for logging from ROBOT as a library -->
+                <filter>
+                  <artifact>*:robot-core</artifact>
+                  <excludes>
+                    <exclude>log4j.properties</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>**/module-info.class</exclude>
+                    <exclude>module-info.class</exclude>
+                    <exclude>META-INF/*.MF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/DEPENDENCIES</exclude>
+                    <exclude>LICENSE</exclude>
+                    <exclude>LICENSE.txt</exclude>
+                    <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/LICENSE.*</exclude>
+                    <exclude>NOTICE</exclude>
+                    <exclude>META-INF/NOTICE</exclude>
+                    <exclude>META-INF/NOTICE.*</exclude>
+                    <exclude>plugin.xml</exclude>
+                    <exclude>META-INF/*.xml</exclude>
+                    <exclude>META-INF/maven/org.apache.ws.commons.axiom/axiom-common-impl/*</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <finalName>robot</finalName>
               <outputDirectory>${project.parent.basedir}/bin</outputDirectory>
               <transformers>
@@ -72,6 +109,16 @@
 
   <dependencies>
     <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>2.5.6</version>
+    </dependency>
+    <dependency>
       <groupId>org.obolibrary.robot</groupId>
       <artifactId>robot-core</artifactId>
       <version>${project.parent.version}</version>
@@ -79,12 +126,12 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.2</version>
+      <version>1.4</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.8.0</version>
     </dependency>
   </dependencies>
 </project>

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
@@ -914,7 +914,7 @@ public class CommandLineHelper {
     o.addOption(null, "catalog", true, "use catalog from provided file");
     o.addOption("p", "prefix", true, "add a prefix 'foo: http://bar'");
     o.addOption("P", "prefixes", true, "use prefixes from JSON-LD file");
-    o.addOption("noprefixes", false, "do not use default prefixes");
+    o.addOption(null, "noprefixes", false, "do not use default prefixes");
     o.addOption(null, "add-prefix", true, "add prefix 'foo: http://bar' to the output");
     o.addOption(null, "add-prefixes", true, "add JSON-LD prefixes to the output");
     o.addOption("x", "xml-entities", false, "use entity substitution with ontology XML output");

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
@@ -6,20 +6,15 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.util.*;
 import java.util.jar.JarFile;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.PosixParser;
+import org.apache.commons.cli.*;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOExceptionWithCause;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.geneontology.reasoner.ExpressionMaterializingReasonerFactory;
 import org.geneontology.whelk.owlapi.WhelkOWLReasonerFactory;
@@ -719,7 +714,8 @@ public class CommandLineHelper {
         if (!prefixFile.exists()) {
           throw new IOException(String.format(IOHelper.fileDoesNotExistError, prefixFilePath));
         }
-        Context json = IOHelper.parseContext(FileUtils.readFileToString(prefixFile));
+        Context json =
+            IOHelper.parseContext(FileUtils.readFileToString(prefixFile, Charset.defaultCharset()));
         addPrefixes.putAll(json.getPrefixes(false));
       }
     }
@@ -782,7 +778,7 @@ public class CommandLineHelper {
     }
     if (paths != null) {
       for (String path : getOptionValues(line, paths)) {
-        termStrings.add(FileUtils.readFileToString(new File(path)));
+        termStrings.add(FileUtils.readFileToString(new File(path), Charset.defaultCharset()));
       }
     }
 
@@ -865,7 +861,7 @@ public class CommandLineHelper {
       try {
         uri = resource.toURI();
       } catch (URISyntaxException e) {
-        throw new IOExceptionWithCause(e);
+        throw new IOException(e);
       }
       File f = new File(uri);
       InputStream is = new FileInputStream(f);
@@ -936,7 +932,7 @@ public class CommandLineHelper {
   public static CommandLine maybeGetCommandLine(
       String usage, Options options, String[] args, boolean stopAtNonOption)
       throws ParseException, IOException {
-    CommandLineParser parser = new PosixParser();
+    CommandLineParser parser = new DefaultParser();
     CommandLine line = parser.parse(options, args, stopAtNonOption);
 
     String level;

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandManager.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandManager.java
@@ -5,11 +5,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.PosixParser;
+import org.apache.commons.cli.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,7 +116,7 @@ public class CommandManager implements Command {
    */
   public List<String> getOptionArgs(Options options, List<String> arguments) throws ParseException {
     // parse all options until a non-option is found
-    CommandLineParser parser = new PosixParser();
+    CommandLineParser parser = new DefaultParser();
     CommandLine line = parser.parse(options, asArgs(arguments), true);
 
     int index = arguments.size() - line.getArgList().size();

--- a/robot-command/src/main/java/org/obolibrary/robot/ExplainCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ExplainCommand.java
@@ -268,8 +268,7 @@ public class ExplainCommand implements Command {
     Set<OWLAxiom> explanationsAxioms =
         explanations.stream().flatMap(e -> e.getAxioms().stream()).collect(Collectors.toSet());
     Set<IRI> explanationTerms =
-        explanationsAxioms
-            .stream()
+        explanationsAxioms.stream()
             .flatMap(ax -> ax.getSignature().stream().map(OWLNamedObject::getIRI))
             .collect(Collectors.toSet());
     Set<OWLAnnotationAssertionAxiom> annotations =
@@ -289,8 +288,7 @@ public class ExplainCommand implements Command {
     Map<OWLAxiom, Integer> mapMostUsedAxioms = new HashMap<>();
     explanations.forEach(e -> e.getAxioms().forEach(ax -> countUp(ax, mapMostUsedAxioms)));
     String result =
-        explanations
-            .stream()
+        explanations.stream()
             .map(e -> ExplainOperation.renderExplanationAsMarkdown(e, man))
             .collect(Collectors.joining("\n\n\n"));
     String summary = ExplainOperation.renderAxiomImpactSummary(mapMostUsedAxioms, ontology, man);

--- a/robot-command/src/main/java/org/obolibrary/robot/ExtendedPosixParser.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ExtendedPosixParser.java
@@ -5,9 +5,10 @@ import org.apache.commons.cli.ParseException;
 import org.apache.commons.cli.PosixParser;
 
 /**
- * A custom CommandLineParser that ignores unrecognized options without throwing an exeception. See
+ * A custom CommandLineParser that ignores unrecognized options without throwing an exception. See
  * http://stackoverflow.com/a/8613949
  */
+@Deprecated
 public class ExtendedPosixParser extends PosixParser {
   /** Flag for ignoring unrecognized options. */
   private boolean ignoreUnrecognizedOption;
@@ -17,6 +18,7 @@ public class ExtendedPosixParser extends PosixParser {
    *
    * @param ignoreUnrecognizedOption when true, silently ignore unrecognized options
    */
+  @Deprecated
   public ExtendedPosixParser(final boolean ignoreUnrecognizedOption) {
     this.ignoreUnrecognizedOption = ignoreUnrecognizedOption;
   }
@@ -29,8 +31,10 @@ public class ExtendedPosixParser extends PosixParser {
    * @param iter the iterator for the super class to deal with
    * @throws ParseException on any problems
    */
+  @Deprecated
   @Override
-  protected void processOption(final String arg, final ListIterator iter) throws ParseException {
+  protected void processOption(final String arg, final ListIterator<String> iter)
+      throws ParseException {
     boolean hasOption = getOptions().hasOption(arg);
 
     if (hasOption || !ignoreUnrecognizedOption) {

--- a/robot-command/src/main/java/org/obolibrary/robot/ExtendedPosixParser.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ExtendedPosixParser.java
@@ -1,14 +1,14 @@
 package org.obolibrary.robot;
 
 import java.util.ListIterator;
-import org.apache.commons.cli.ParseException;
-import org.apache.commons.cli.PosixParser;
+import org.apache.commons.cli.*;
 
 /**
  * A custom CommandLineParser that ignores unrecognized options without throwing an exception. See
  * http://stackoverflow.com/a/8613949
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class ExtendedPosixParser extends PosixParser {
   /** Flag for ignoring unrecognized options. */
   private boolean ignoreUnrecognizedOption;

--- a/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
@@ -234,7 +234,7 @@ public class QueryCommand implements Command {
       runQueries(line, dataset, queries);
     } finally {
       dataset.close();
-      TDBFactory.release(dataset);
+      // TDBFactory.release(dataset);
     }
   }
 

--- a/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/QueryCommand.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.util.*;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.MissingArgumentException;
@@ -285,7 +286,7 @@ public class QueryCommand implements Command {
       if (!f.exists()) {
         throw new Exception(String.format(missingFileError, updatePath));
       }
-      updates.put(f.getPath(), FileUtils.readFileToString(f));
+      updates.put(f.getPath(), FileUtils.readFileToString(f, Charset.defaultCharset()));
     }
 
     // Load the ontology as a model, ignoring imports
@@ -390,7 +391,7 @@ public class QueryCommand implements Command {
       String queryPath = q.get(0);
       String outputPath = q.get(1);
 
-      String query = FileUtils.readFileToString(new File(queryPath));
+      String query = FileUtils.readFileToString(new File(queryPath), Charset.defaultCharset());
 
       String formatName = format;
       if (formatName == null) {

--- a/robot-command/src/main/java/org/obolibrary/robot/VerifyCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/VerifyCommand.java
@@ -1,6 +1,7 @@
 package org.obolibrary.robot;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
@@ -123,7 +124,7 @@ public class VerifyCommand implements Command {
     boolean passing = true;
     for (String filePath : queryFilePaths) {
       File queryFile = new File(filePath);
-      String queryString = FileUtils.readFileToString(queryFile);
+      String queryString = FileUtils.readFileToString(queryFile, Charset.defaultCharset());
       String csvPath = FilenameUtils.getBaseName(filePath).concat(".csv");
       boolean result =
           QueryOperation.runVerify(

--- a/robot-command/src/test/java/org/obolibrary/robot/CommandLineHelperTest.java
+++ b/robot-command/src/test/java/org/obolibrary/robot/CommandLineHelperTest.java
@@ -1,17 +1,14 @@
 package org.obolibrary.robot;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 /** Tests for CommandLineHelper. */
 public class CommandLineHelperTest {
-  /** The exception to expect, if any. */
-  @Rule public ExpectedException exception = ExpectedException.none();
 
   /**
    * Test command line splitting.
@@ -45,8 +42,11 @@ public class CommandLineHelperTest {
     args.add("nested \"quotes\" with \\\" escapes and\nnewlines");
     assertEquals("Nested quotations", CommandLineHelper.parseArgList(arg), args);
 
-    arg = "unbalanced 'quotes";
-    exception.expect(Exception.class);
-    CommandLineHelper.parseArgList(arg);
+    // Expect an Exception here
+    assertThrows(
+        Exception.class,
+        () -> {
+          CommandLineHelper.parseArgList("unbalanced 'quotes");
+        });
   }
 }

--- a/robot-command/src/test/java/org/obolibrary/robot/CommandLineIT.java
+++ b/robot-command/src/test/java/org/obolibrary/robot/CommandLineIT.java
@@ -8,7 +8,9 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.geneontology.owl.differ.Differ;
 import org.junit.Test;
+import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.OWLOntology;
 
 /** Integration tests check the commands in `examples/README.md`. */
@@ -132,7 +134,6 @@ public class CommandLineIT {
    * @throws Exception on IO problems or file differences
    */
   private void compareResults() throws Exception {
-    IOHelper ioHelper = new IOHelper();
     File resultsDir = new File(resultsPath);
     for (File resultFile : resultsDir.listFiles()) {
       if (!resultFile.isFile()) {
@@ -153,10 +154,14 @@ public class CommandLineIT {
       }
 
       if (resultFile.getName().endsWith(".owl") || resultFile.getName().endsWith(".ttl")) {
-        // Compare OWL files using DiffOperation
-        OWLOntology exampleOnt = ioHelper.loadOntology(exampleFile);
-        OWLOntology resultOnt = ioHelper.loadOntology(resultFile);
-        if (!DiffOperation.equals(exampleOnt, resultOnt)) {
+        // Compare OWL files using Differ
+        OWLOntology exampleOnt =
+            OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(exampleFile);
+        OWLOntology resultOnt =
+            OWLManager.createOWLOntologyManager().loadOntologyFromOntologyDocument(resultFile);
+
+        Differ.BasicDiff diff = Differ.diff(exampleOnt, resultOnt);
+        if (!diff.isEmpty()) {
           throw new Exception(
               "Integration test ontology '"
                   + resultsPath

--- a/robot-command/src/test/java/org/obolibrary/robot/CommandLineIT.java
+++ b/robot-command/src/test/java/org/obolibrary/robot/CommandLineIT.java
@@ -3,8 +3,8 @@ package org.obolibrary.robot;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -50,9 +50,9 @@ public class CommandLineIT {
    * @throws IOException if the README cannot be read
    */
   private List<String> extractCommands(File docFile) throws IOException {
-    String content = FileUtils.readFileToString(docFile);
-    List<String> lines = Arrays.asList(content.replaceAll("\\r", "").split("\\n"));
-    List<String> commands = new ArrayList<String>();
+    String content = FileUtils.readFileToString(docFile, Charset.defaultCharset());
+    String[] lines = content.replaceAll("\\r", "").split("\\n");
+    List<String> commands = new ArrayList<>();
 
     boolean collecting = false;
     String collected = null;
@@ -105,7 +105,7 @@ public class CommandLineIT {
             + "\n\n";
 
     FileOutputStream outputStream = new FileOutputStream(outputPath, true);
-    IOUtils.write(header, outputStream);
+    IOUtils.write(header, outputStream, Charset.defaultCharset());
 
     List<String> arguments = CommandLineHelper.parseArgList(command);
     arguments.remove(0);

--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -22,7 +22,7 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.10</version>
+        <version>2.9</version>
         <executions>
           <execution>
             <goals>

--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -22,7 +22,7 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.1.0</version>
+        <version>2.10</version>
         <executions>
           <execution>
             <goals>
@@ -74,64 +74,158 @@
 
   <dependencies>
     <dependency>
+      <groupId>net.sourceforge.owlapi</groupId>
+      <artifactId>owlapi-api</artifactId>
+      <version>4.5.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.owlapi</groupId>
+      <artifactId>owlapi-apibinding</artifactId>
+      <version>4.5.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.sourceforge.owlapi</groupId>
+      <artifactId>owlapi-rio</artifactId>
+      <version>4.5.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-arq</artifactId>
-      <version>3.8.0</version>
+      <version>3.17.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.github.jsonld-java</groupId>
+          <artifactId>jsonld-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>jcl-over-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-tdb</artifactId>
-      <version>3.8.0</version>
+      <version>3.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi</artifactId>
-      <version>4.1.2</version>
+      <version>5.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>jcl-over-slf4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi-ooxml</artifactId>
-      <version>4.1.2</version>
+      <version>5.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.xmlgraphics</groupId>
+          <artifactId>batik-all</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.jsonld-java</groupId>
       <artifactId>jsonld-java</artifactId>
-      <version>0.5.1</version>
+      <version>0.13.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>jcl-over-slf4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore-osgi</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient-osgi</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.hubspot.jinjava</groupId>
       <artifactId>jinjava</artifactId>
-      <version>2.5.2</version>
+      <version>2.5.6</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.15</version>
+      <version>1.28</version>
     </dependency>
     <dependency>
       <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
-      <version>4.3.2</version>
+      <version>5.3</version>
     </dependency>
     <dependency>
       <groupId>org.geneontology</groupId>
       <artifactId>expression-materializing-reasoner</artifactId>
       <version>0.1.3</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sourceforge.owlapi</groupId>
+          <artifactId>owlapi-distribution</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.geneontology</groupId>
       <artifactId>obographs</artifactId>
       <version>0.2.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sourceforge.owlapi</groupId>
+          <artifactId>owlapi-distribution</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.3</version>
+      <version>2.12.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>2.9.3</version>
+      <version>2.12.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.12.2</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
@@ -171,21 +265,33 @@
       <groupId>org.geneontology</groupId>
       <artifactId>owl-diff_${scala.version}</artifactId>
       <version>1.2.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sourceforge.owlapi</groupId>
+          <artifactId>owlapi-distribution</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.geneontology</groupId>
       <artifactId>whelk-owlapi_${scala.version}</artifactId>
       <version>1.0.4</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.sourceforge.owlapi</groupId>
+          <artifactId>owlapi-distribution</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.0</version>
+      <version>2.8.6</version>
     </dependency>
     <dependency>
       <groupId>net.sf.py4j</groupId>
       <artifactId>py4j</artifactId>
-      <version>0.10.8.1</version>
+      <version>0.10.9.2</version>
     </dependency>
   </dependencies>
 </project>

--- a/robot-core/src/main/java/org/obolibrary/robot/ExplainOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExplainOperation.java
@@ -276,8 +276,7 @@ public class ExplainOperation {
     }
     if (!tree.isLeaf()) builder.append("\n");
     String children =
-        tree.getChildren()
-            .stream()
+        tree.getChildren().stream()
             .map(child -> renderTree(child, renderer))
             .collect(Collectors.joining("\n"));
     builder.append(children);

--- a/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
@@ -656,8 +656,7 @@ public class ExportOperation {
     if (entity.isOWLNamedIndividual()) {
       OWLNamedIndividual i = entity.asOWLNamedIndividual();
       Collection<OWLIndividual> propVals = EntitySearcher.getObjectPropertyValues(i, op, ontology);
-      return propVals
-          .stream()
+      return propVals.stream()
           .filter(OWLIndividual::isNamed)
           .map(pv -> OntologyHelper.renderManchester(pv.asOWLNamedIndividual(), provider, rt))
           .collect(Collectors.toList());
@@ -1329,16 +1328,14 @@ public class ExportOperation {
       boolean includeAnonymous) {
     // Try to convert to object property expressions
     Collection<OWLObjectPropertyExpression> opes =
-        props
-            .stream()
+        props.stream()
             .map(p -> (OWLPropertyExpression) p)
             .filter(OWLPropertyExpression::isObjectPropertyExpression)
             .map(p -> (OWLObjectPropertyExpression) p)
             .collect(Collectors.toList());
     // Try to convert to data property expressions
     Collection<OWLDataPropertyExpression> dpes =
-        props
-            .stream()
+        props.stream()
             .map(p -> (OWLPropertyExpression) p)
             .filter(OWLPropertyExpression::isDataPropertyExpression)
             .map(p -> (OWLDataPropertyExpression) p)

--- a/robot-core/src/main/java/org/obolibrary/robot/MireotOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/MireotOperation.java
@@ -757,8 +757,7 @@ public class MireotOperation {
     Set<IRI> classIRIs = classes.stream().map(OWLNamedObject::getIRI).collect(Collectors.toSet());
     Set<OWLNamedIndividual> individuals = inputOntology.getIndividualsInSignature();
     individuals =
-        individuals
-            .stream()
+        individuals.stream()
             .filter(i -> !classIRIs.contains(i.getIRI()))
             .collect(Collectors.toSet());
 

--- a/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReasonOperation.java
@@ -399,9 +399,7 @@ public class ReasonOperation {
         logger.info("Placing inferred axioms with annotations into a new ontology");
         manager.removeAxioms(
             ontology,
-            ontology
-                .getAxioms()
-                .stream()
+            ontology.getAxioms().stream()
                 .filter(nonap -> !(nonap instanceof OWLAnnotationAssertionAxiom))
                 .collect(Collectors.toSet()));
 
@@ -440,9 +438,7 @@ public class ReasonOperation {
     // get all entities that 'belong' to the main ontology
     // see: https://github.com/ontodev/robot/issues/296
     Set<OWLEntity> ontologyEntities =
-        ontology
-            .getAxioms(AxiomType.DECLARATION)
-            .stream()
+        ontology.getAxioms(AxiomType.DECLARATION).stream()
             .map(OWLDeclarationAxiom::getEntity)
             .collect(Collectors.toSet());
 

--- a/robot-core/src/main/java/org/obolibrary/robot/RenameOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/RenameOperation.java
@@ -92,8 +92,7 @@ public class RenameOperation {
       String oldBase = mapping.getKey();
       String newBase = mapping.getValue();
       Set<IRI> matchIRIs =
-          allIRIs
-              .stream()
+          allIRIs.stream()
               .filter(iri -> iri.toString().startsWith(oldBase))
               .collect(Collectors.toSet());
       if (matchIRIs.isEmpty()) {

--- a/robot-core/src/main/java/org/obolibrary/robot/RepairOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/RepairOperation.java
@@ -241,9 +241,7 @@ public class RepairOperation {
       }
       axiomsToPreserve.addAll(ontology.getDeclarationAxioms(obsObj));
       axiomsToPreserve.addAll(
-          ontology
-              .getAnnotationAssertionAxioms(obsObj.getIRI())
-              .stream()
+          ontology.getAnnotationAssertionAxioms(obsObj.getIRI()).stream()
               .filter(ax -> !migrateAnnotations.contains(ax.getProperty()))
               .collect(Collectors.toSet()));
       logger.info("Replacing: " + obsObj + " -> " + replacedBy);

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -4,6 +4,7 @@ import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -649,7 +650,7 @@ public class ReportOperation {
         if (!file.exists()) {
           throw new IOException(String.format(missingQueryError, file.getPath()));
         }
-        queries.put(rule, FileUtils.readFileToString(file));
+        queries.put(rule, FileUtils.readFileToString(file, Charset.defaultCharset()));
       } else {
         // Process a relative path
         String path = rule.substring(5);
@@ -657,7 +658,7 @@ public class ReportOperation {
         if (!file.exists()) {
           throw new IOException(String.format(missingQueryError, file.getPath()));
         }
-        queries.put(rule, FileUtils.readFileToString(file));
+        queries.put(rule, FileUtils.readFileToString(file, Charset.defaultCharset()));
       }
     }
     return queries;
@@ -688,7 +689,8 @@ public class ReportOperation {
         // Only add it to the queries if the rule set contains that rule
         // If rules == null, include all rules
         if (rules == null || rules.contains(ruleName)) {
-          queries.put(ruleName, FileUtils.readFileToString(new File(qPath)));
+          queries.put(
+              ruleName, FileUtils.readFileToString(new File(qPath), Charset.defaultCharset()));
         }
       }
       return queries;

--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
@@ -1038,8 +1038,7 @@ public class TemplateHelper {
       // Some of these have hard to understand "expected" values, so we rewrite them the best we can
       String expected = m.group(2);
       List<String> expectedSplit =
-          Lists.newArrayList(expected.split("\n"))
-              .stream()
+          Lists.newArrayList(expected.split("\n")).stream()
               .map(String::trim)
               .filter(x -> !x.equals(""))
               .collect(Collectors.toList());

--- a/robot-core/src/test/java/org/obolibrary/robot/CoreTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/CoreTest.java
@@ -11,7 +11,6 @@ import java.net.URISyntaxException;
 import java.util.Set;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.*;
-import uk.ac.manchester.cs.owl.owlapi.OWLDataFactoryImpl;
 
 /** Helper methods for core tests. */
 public class CoreTest {
@@ -23,7 +22,7 @@ public class CoreTest {
   protected static IRI simpleIRI = IRI.create(base + "simple.owl");
 
   /** Shared data factory. */
-  protected static OWLDataFactory dataFactory = new OWLDataFactoryImpl();
+  protected static OWLDataFactory dataFactory = OWLManager.getOWLDataFactory();
 
   /**
    * Load an ontology from a resource path.

--- a/robot-core/src/test/java/org/obolibrary/robot/DiffOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/DiffOperationTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -53,7 +54,9 @@ public class DiffOperationTest extends CoreTest {
     boolean actual = DiffOperation.compare(simple, simple1, writer);
     System.out.println(writer.toString());
     assertFalse(actual);
-    String expected = IOUtils.toString(this.getClass().getResourceAsStream("/simple1.diff"));
+    String expected =
+        IOUtils.toString(
+            this.getClass().getResourceAsStream("/simple1.diff"), Charset.defaultCharset());
     assertEquals(expected, writer.toString());
   }
 
@@ -61,10 +64,9 @@ public class DiffOperationTest extends CoreTest {
    * Compare one ontology to a modified copy with labels in output.
    *
    * @throws IOException on file problem
-   * @throws OWLOntologyCreationException on ontology problem
    */
   @Test
-  public void testCompareModifiedWithLabels() throws IOException, OWLOntologyCreationException {
+  public void testCompareModifiedWithLabels() throws IOException {
     OWLOntology simple = loadOntology("/simple.owl");
     OWLOntology elk = loadOntology("/simple_elk.owl");
 
@@ -74,7 +76,9 @@ public class DiffOperationTest extends CoreTest {
     boolean actual = DiffOperation.compare(simple, elk, new IOHelper(), writer, options);
     System.out.println(writer.toString());
     assertFalse(actual);
-    String expected = IOUtils.toString(this.getClass().getResourceAsStream("/simple.diff"));
+    String expected =
+        IOUtils.toString(
+            this.getClass().getResourceAsStream("/simple.diff"), Charset.defaultCharset());
     assertEquals(expected, writer.toString());
   }
 }

--- a/robot-core/src/test/java/org/obolibrary/robot/QueryOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/QueryOperationTest.java
@@ -15,7 +15,6 @@ import org.apache.jena.rdf.model.*;
 import org.apache.jena.riot.Lang;
 import org.junit.Test;
 import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyStorageException;
 
 /**
@@ -116,11 +115,9 @@ public class QueryOperationTest extends CoreTest {
    *
    * @throws IOException on IO error
    * @throws OWLOntologyStorageException on ontology error
-   * @throws OWLOntologyCreationException on ontology error
    */
   @Test
-  public void testExecUpdate()
-      throws IOException, OWLOntologyCreationException, OWLOntologyStorageException {
+  public void testExecUpdate() throws IOException, OWLOntologyStorageException {
     OWLOntology inputOntology = loadOntology("/simple.owl");
     Model model = QueryOperation.loadOntologyAsModel(inputOntology);
     String updateString =
@@ -130,7 +127,7 @@ public class QueryOperationTest extends CoreTest {
             + "s:test2 rdfs:label \"test 2\" ."
             + " } WHERE {}";
     QueryOperation.execUpdate(model, updateString);
-    OWLOntology outputOntology = QueryOperation.convertModel(model);
+    OWLOntology outputOntology = QueryOperation.convertModel(model, new IOHelper(), null);
     assertIdentical("/simple_update.owl", outputOntology);
   }
 

--- a/robot-core/src/test/java/org/obolibrary/robot/TemplateHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/TemplateHelperTest.java
@@ -51,7 +51,7 @@ public class TemplateHelperTest extends CoreTest {
     String value = "oboInOwl:inSubset|oboInOwl:id";
     String split = "|";
     Set<OWLAnnotationProperty> properties =
-        TemplateHelper.getAnnotationProperties(checker, value, split);
+        TemplateHelper.getAnnotationProperties(checker, value, split, 0);
 
     OWLAnnotationProperty p1 = checker.getOWLAnnotationProperty("oboInOwl:inSubset");
     OWLAnnotationProperty p2 = checker.getOWLAnnotationProperty("oboInOwl:id");
@@ -231,7 +231,7 @@ public class TemplateHelperTest extends CoreTest {
     QuotedEntityChecker checker = new QuotedEntityChecker();
     checker.setIOHelper(new IOHelper());
 
-    anns = TemplateHelper.getStringAnnotations(checker, "A rdfs:label", null, "bar");
+    anns = TemplateHelper.getStringAnnotations(checker, "A rdfs:label", null, "bar", 0);
     for (OWLAnnotation a : anns) {
       ann = a;
     }
@@ -245,13 +245,14 @@ public class TemplateHelperTest extends CoreTest {
     }
     assertEquals("Annotation(rdfs:label \"1\"^^xsd:integer)", ann.toString());
 
-    anns = TemplateHelper.getLanguageAnnotations(checker, "AL rdfs:label@en", null, "bar");
+    anns = TemplateHelper.getLanguageAnnotations(checker, "AL rdfs:label@en", null, "bar", 0);
     for (OWLAnnotation a : anns) {
       ann = a;
     }
     assertEquals("Annotation(rdfs:label \"bar\"@en)", ann.toString());
 
-    ann = TemplateHelper.getIRIAnnotation(checker, "AI rdfs:label", IRI.create("http://bar.com"));
+    ann =
+        TemplateHelper.getIRIAnnotation(checker, "AI rdfs:label", IRI.create("http://bar.com"), 0);
     assertEquals("Annotation(rdfs:label <http://bar.com>)", ann.toString());
   }
 }


### PR DESCRIPTION
This PR updates Maven plugins and project dependencies to their latest versions. It also adds in a bunch of exclusions to remove the warning messages from packaging. The `mvn` output is still pretty noisy, but I don't think there's anything we can do about those INFO messages.

Resolves #805 #839

Notes:
* `fmt-maven-plugin` 2.9.x is the latest version that supports Java 8. Java 11 is required for 2.10.x and up.
* I had to update a couple of classes to replace deprecated methods
* We have one warning left coming from `ExtendedPosixParser.java` - this class is never used, and even though I deprecated it, it still shows as using a deprecated API. Ideally we can remove this entirely?

**Problem with using classes from `robot-core` in command line tests:**

Java 8 passes, but later versions fail on `CommandLineIT` with
```
java.lang.NoClassDefFoundError: org/obolibrary/robot/IOHelper
```
It seems like the tests fail to include workspace dependencies... Looking at the logs, it looks like all the tests actually run (which is good), and then `compareResults()` fails because the test module cannot find `IOHelper`. We can resolve this by not using `robot-core` classes, and the JAR still works fine. I'm not sure what changed between Java versions to cause this issue, though.
