### PR TITLE
Fix exporting annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix printing violations in [`report`] [#823]
 - Fix handling of `rdf:type` in [`export`] [#834]
+- Fix missing annotations from [`export`] [#850]
 
 ## [1.8.1] - 2021-01-27
 
@@ -249,7 +250,9 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
-[#808]: https://github.com/ontodev/robot/pull/834
+[#850]: https://github.com/ontodev/robot/pull/850
+[#834]: https://github.com/ontodev/robot/pull/834
+[#823]: https://github.com/ontodev/robot/pull/823
 [#808]: https://github.com/ontodev/robot/pull/808
 [#802]: https://github.com/ontodev/robot/pull/802
 [#796]: https://github.com/ontodev/robot/pull/796

--- a/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
@@ -489,7 +489,7 @@ public class ExportOperation {
    * @param column Column for this cell
    * @return Cell for this Column containing entity type as string rendering
    */
-  private static Cell getEntityTypeCell(EntityType type, Column column) {
+  private static Cell getEntityTypeCell(EntityType<?> type, Column column) {
     ShortFormProvider provider = column.getShortFormProvider();
     String cellValue;
     if (provider instanceof CURIEShortFormProvider) {
@@ -560,6 +560,7 @@ public class ExportOperation {
         EntitySearcher.getAnnotationAssertionAxioms(entity, ontology)) {
       if (a.getProperty().getIRI().equals(ap.getIRI())) {
         if (a.getValue().isIRI()) {
+          // Render the IRI using the provider
           IRI iri = a.getValue().asIRI().orNull();
           if (iri != null) {
             Set<OWLEntity> entities = ontology.getEntitiesInSignature(iri);
@@ -568,7 +569,11 @@ public class ExportOperation {
             }
           }
         } else {
-          values.add(OntologyHelper.renderManchester(a.getValue(), provider, rt));
+          // Otherwise just get the value of the literal
+          OWLLiteral lit = a.getValue().asLiteral().orNull();
+          if (lit != null) {
+            values.add(lit.getLiteral());
+          }
         }
       }
     }


### PR DESCRIPTION
Resolves #847

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

We can just get the literal value of annotations in export, no need to go through the `renderManchester` function. This fixes missing annotations described in the issue above.
