### PR TITLE
Make sure report fails on unknown rule names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix printing violations in [`report`] [#823]
 - Fix handling of `rdf:type` in [`export`] [#834]
 - Fix missing annotations from [`export`] [#850]
+- Fail on unknown rule names in [`report`] [#858]
 
 ## [1.8.1] - 2021-01-27
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -187,3 +187,7 @@ The argument for the `--print` option must be a number.
 ### Report Level Error
 
 The logging level defined in a profile must be `ERROR`, `WARN`, or `INFO`.
+
+### Unknown Report Query
+
+When not using the `file:` prefix in your `--profile`, make sure you are only using rule names from the list of [default report queries](report_queries/)).

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -66,6 +66,10 @@ public class ReportOperation {
   private static final String reportLevelError =
       NS + "REPORT LEVEL ERROR '%s' is not a valid reporting level.";
 
+  /** Error message when a report query name or path in report profile cannot be found. */
+  private static final String unknownReportQuery =
+      NS + "UNKNOWN REPORT QUERY one or more rule names ('%s') are not valid default rules";
+
   /** Reporting level INFO. */
   private static final String INFO = "INFO";
 
@@ -683,12 +687,21 @@ public class ReportOperation {
         throw new IOException(
             "Cannot access report query files. There are no files in the directory.");
       }
+      Set<String> defaultRuleNames = new HashSet<>();
       for (String qPath : queryFilePaths) {
         String ruleName = qPath.substring(qPath.lastIndexOf("/")).split(".")[0];
+        defaultRuleNames.add(ruleName);
         // Only add it to the queries if the rule set contains that rule
         // If rules == null, include all rules
         if (rules == null || rules.contains(ruleName)) {
           queries.put(ruleName, FileUtils.readFileToString(new File(qPath)));
+        }
+      }
+      // Check that all the provided rule names are valid defaults
+      if (rules != null) {
+        rules.removeAll(defaultRuleNames);
+        if (rules.size() > 0) {
+          throw new IOException(String.format(unknownReportQuery, String.join(", ", rules)));
         }
       }
       return queries;
@@ -715,6 +728,7 @@ public class ReportOperation {
               "Cannot access report query files in JAR. There are no entries in the JAR.");
         }
         // Track rules that have successfully been retrieved
+        Set<String> defaultRuleNames = new HashSet<>();
         while (entries.hasMoreElements()) {
           JarEntry resource = entries.nextElement();
           String resourceName = resource.getName();
@@ -723,6 +737,7 @@ public class ReportOperation {
             String ruleName =
                 resourceName.substring(
                     resourceName.lastIndexOf("/") + 1, resourceName.indexOf(".rq"));
+            defaultRuleNames.add(ruleName);
             // Only add it to the queries if the rule set contains that rule
             // If rules == null, include all rules
             if (rules == null || rules.contains(ruleName)) {
@@ -739,6 +754,13 @@ public class ReportOperation {
               String queryString = fullQueryString.substring(fullQueryString.indexOf("PREFIX"));
               queries.put(ruleName, queryString);
             }
+          }
+        }
+        // Check that all the provided rule names are valid defaults
+        if (rules != null) {
+          rules.removeAll(defaultRuleNames);
+          if (rules.size() > 0) {
+            throw new IOException(String.format(unknownReportQuery, String.join(", ", rules)));
           }
         }
       }


### PR DESCRIPTION
In #856, the `mvn verify` should have failed on the missing query, but `report` just ignores any rule names that aren't in the default rules. I think that this should instead be a hard fail.

- [x] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated
