### PR TITLE
Report: Allowing dcterms for description and title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Split equivalent class check [#856]
+- Allow Dublin Core "terms" namespace (`http://purl.org/dc/terms/`) for `description` and `title` properties on ontology. [#741]
 
 ### Fixed
 - Fix printing violations in [`report`] [#823]

--- a/docs/examples/report.tsv
+++ b/docs/examples/report.tsv
@@ -1,18 +1,18 @@
 Level	Rule Name	Subject	Property	Value
 ERROR	missing_ontology_license	https://github.com/ontodev/robot/examples/edit.owl	dc:license	
-ERROR	missing_ontology_title	https://github.com/ontodev/robot/examples/edit.owl	dc11:title	
+ERROR	missing_ontology_description	https://github.com/ontodev/robot/examples/edit.owl	dc:description	
 ERROR	missing_ontology_title	https://github.com/ontodev/robot/examples/edit.owl	dc:title	
 WARN	annotation_whitespace	obo:UBPROP_0000007	IAO:0000232	Used to connect a class to an adjectival form of its label. For example, a class with label 'intestine' may have a relational adjective 'intestinal'. 
+WARN	duplicate_scoped_synonym	UBERON:0002368	oboInOwl:hasExactSynonym	ductless gland
+WARN	duplicate_scoped_synonym	UBERON:0002368	oboInOwl:hasRelatedSynonym	ductless gland
+WARN	duplicate_scoped_synonym	UBERON:0002369	oboInOwl:hasExactSynonym	glandula suprarenalis
+WARN	duplicate_scoped_synonym	UBERON:0002369	oboInOwl:hasRelatedSynonym	glandula suprarenalis
 WARN	duplicate_label_synonym	UBERON:0000949	oboInOwl:hasExactSynonym	endocrine system
 WARN	duplicate_label_synonym	UBERON:0001851	oboInOwl:hasExactSynonym	cortex
-WARN	duplicate_scoped_synonym	UBERON:0002369	oboInOwl:hasExactSynonym	glandula suprarenalis
-WARN	duplicate_scoped_synonym	UBERON:0002368	oboInOwl:hasRelatedSynonym	ductless gland
-WARN	duplicate_scoped_synonym	UBERON:0002368	oboInOwl:hasExactSynonym	ductless gland
-WARN	duplicate_scoped_synonym	UBERON:0002369	oboInOwl:hasRelatedSynonym	glandula suprarenalis
-WARN	missing_definition	IAO:0000116	IAO:0000115	
-WARN	missing_definition	obo:UBPROP_0000007	IAO:0000115	
-WARN	missing_definition	IAO:0000115	IAO:0000115	
-WARN	missing_definition	IAO:0000232	IAO:0000115	
 WARN	missing_definition	BFO:0000050	IAO:0000115	
+WARN	missing_definition	IAO:0000115	IAO:0000115	
+WARN	missing_definition	IAO:0000116	IAO:0000115	
+WARN	missing_definition	IAO:0000232	IAO:0000115	
 WARN	missing_definition	UBERON:0009569	IAO:0000115	
+WARN	missing_definition	obo:UBPROP_0000007	IAO:0000115	
 INFO	missing_superclass	UBERON:0001062	rdfs:subClassOf	

--- a/docs/examples/report.tsv
+++ b/docs/examples/report.tsv
@@ -1,7 +1,7 @@
 Level	Rule Name	Subject	Property	Value
-ERROR	missing_ontology_description	https://github.com/ontodev/robot/examples/edit.owl	dc11:description	
 ERROR	missing_ontology_license	https://github.com/ontodev/robot/examples/edit.owl	dc:license	
 ERROR	missing_ontology_title	https://github.com/ontodev/robot/examples/edit.owl	dc11:title	
+ERROR	missing_ontology_title	https://github.com/ontodev/robot/examples/edit.owl	dc:title	
 WARN	annotation_whitespace	obo:UBPROP_0000007	IAO:0000232	Used to connect a class to an adjectival form of its label. For example, a class with label 'intestine' may have a relational adjective 'intestinal'. 
 WARN	duplicate_label_synonym	UBERON:0000949	oboInOwl:hasExactSynonym	endocrine system
 WARN	duplicate_label_synonym	UBERON:0001851	oboInOwl:hasExactSynonym	cortex

--- a/docs/report_queries/missing_ontology_description.md
+++ b/docs/report_queries/missing_ontology_description.md
@@ -6,10 +6,11 @@
 
 ```sparql
 PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
- VALUES ?property { dc:description }
+ VALUES ?property { dc:description dcterms:description }
  ?entity a owl:Ontology .
  OPTIONAL { ?entity ?property ?value }
  FILTER (!bound(?value))

--- a/docs/report_queries/missing_ontology_description.md
+++ b/docs/report_queries/missing_ontology_description.md
@@ -10,9 +10,12 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
-  VALUES ?property { dc:description dcterms:description }
   ?entity a owl:Ontology .
-  OPTIONAL { ?entity ?property ?value }
-  FILTER (!bound(?value))
+  FILTER NOT EXISTS { 
+    {?entity dc:description ?value . }
+      UNION 
+    {?entity dcterms:description ?value . }
+  }
+  BIND(dcterms:description as ?property)
 }
 ```

--- a/docs/report_queries/missing_ontology_description.md
+++ b/docs/report_queries/missing_ontology_description.md
@@ -10,9 +10,9 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
+  VALUES ?property { dc:description dcterms:description }
   ?entity a owl:Ontology .
   OPTIONAL { ?entity ?property ?value }
   FILTER (!bound(?value))
 }
- VALUES ?property { dc:description dcterms:description }
 ```

--- a/docs/report_queries/missing_ontology_title.md
+++ b/docs/report_queries/missing_ontology_title.md
@@ -6,12 +6,13 @@
 
 ```sparql
 PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
- VALUES ?property { dc:title }
  ?entity a owl:Ontology .
  OPTIONAL { ?entity ?property ?value }
  FILTER (!bound(?value))
+  VALUES ?property { dc:title dcterms:title }
 }
 ```

--- a/docs/report_queries/missing_ontology_title.md
+++ b/docs/report_queries/missing_ontology_title.md
@@ -10,9 +10,12 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
-  VALUES ?property { dc:title dcterms:title }
   ?entity a owl:Ontology .
-  OPTIONAL { ?entity ?property ?value }
-  FILTER (!bound(?value))
+  FILTER NOT EXISTS { 
+    {?entity dc:title ?value . }
+      UNION 
+    {?entity dcterms:title ?value . }
+  }
+  BIND(dcterms:title as ?property)
 }
 ```

--- a/robot-core/src/main/resources/report_queries/missing_ontology_description.rq
+++ b/robot-core/src/main/resources/report_queries/missing_ontology_description.rq
@@ -9,8 +9,11 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
-  VALUES ?property { dc:description dcterms:description }
   ?entity a owl:Ontology .
-  OPTIONAL { ?entity ?property ?value }
-  FILTER (!bound(?value))
+  FILTER NOT EXISTS { 
+    {?entity dc:description ?value . }
+      UNION 
+    {?entity dcterms:description ?value . }
+  }
+  BIND(dcterms:description as ?property)
 }

--- a/robot-core/src/main/resources/report_queries/missing_ontology_description.rq
+++ b/robot-core/src/main/resources/report_queries/missing_ontology_description.rq
@@ -5,11 +5,12 @@
 # **Solution:** Add the missing description. See link for appropriate property.
 
 PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
-  VALUES ?property { dc:description }
   ?entity a owl:Ontology .
   OPTIONAL { ?entity ?property ?value }
   FILTER (!bound(?value))
 }
+ VALUES ?property { dc:description dcterms:description }

--- a/robot-core/src/main/resources/report_queries/missing_ontology_description.rq
+++ b/robot-core/src/main/resources/report_queries/missing_ontology_description.rq
@@ -9,8 +9,8 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
+  VALUES ?property { dc:description dcterms:description }
   ?entity a owl:Ontology .
   OPTIONAL { ?entity ?property ?value }
   FILTER (!bound(?value))
 }
- VALUES ?property { dc:description dcterms:description }

--- a/robot-core/src/main/resources/report_queries/missing_ontology_title.rq
+++ b/robot-core/src/main/resources/report_queries/missing_ontology_title.rq
@@ -9,8 +9,11 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
-  VALUES ?property { dc:title dcterms:title }
   ?entity a owl:Ontology .
-  OPTIONAL { ?entity ?property ?value }
-  FILTER (!bound(?value))
+  FILTER NOT EXISTS { 
+    {?entity dc:title ?value . }
+      UNION 
+    {?entity dcterms:title ?value . }
+  }
+  BIND(dcterms:title as ?property)
 }

--- a/robot-core/src/main/resources/report_queries/missing_ontology_title.rq
+++ b/robot-core/src/main/resources/report_queries/missing_ontology_title.rq
@@ -5,10 +5,11 @@
 # **Solution:** Add the missing title. See link for appropriate property.
 
 PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
-  VALUES ?property { dc:title }
+  VALUES ?property { dc:title dcterms:title }
   ?entity a owl:Ontology .
   OPTIONAL { ?entity ?property ?value }
   FILTER (!bound(?value))


### PR DESCRIPTION
fixes #741

As part of a multiphase process, we allow, at first, both dcterms and dc elements, and will phase out elements next year.

- [X] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

[DESCRIPTION, mentioning relevant #ISSUE]
