### PR TITLE
Report: Fixing duplicate_label_synonym

### DIFF
--- a/docs/report_queries/duplicate_label_synonym.md
+++ b/docs/report_queries/duplicate_label_synonym.md
@@ -21,7 +21,7 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
  FILTER NOT EXISTS { ?entity owl:deprecated true }
  FILTER NOT EXISTS { ?entity2 owl:deprecated true }
  ?entity rdfs:label ?value .
- ?entity ?property ?value .
+ ?entity2 ?property ?value .
 }
 ORDER BY ?entity
 ```

--- a/docs/report_queries/duplicate_label_synonym.md
+++ b/docs/report_queries/duplicate_label_synonym.md
@@ -11,14 +11,14 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
- VALUES ?property {
-   obo:IAO_0000118
-   oboInOwl:hasExactSynonym
- }
- FILTER NOT EXISTS { ?entity owl:deprecated true }
- FILTER NOT EXISTS { ?entity2 owl:deprecated true }
- ?entity rdfs:label ?value .
- ?entity2 ?property ?value .
+  VALUES ?property {
+    obo:IAO_0000118
+    oboInOwl:hasExactSynonym
+  }
+  FILTER NOT EXISTS { ?entity owl:deprecated true }
+  FILTER NOT EXISTS { ?entity2 owl:deprecated true }
+  ?entity rdfs:label ?value .
+  ?entity2 ?property ?value .
   FILTER (!isBlank(?entity))
   FILTER (!isBlank(?entity2))
 }

--- a/docs/report_queries/duplicate_label_synonym.md
+++ b/docs/report_queries/duplicate_label_synonym.md
@@ -14,14 +14,13 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
  VALUES ?property {
    obo:IAO_0000118
    oboInOwl:hasExactSynonym
-   oboInOwl:hasRelatedSynonym
-   oboInOwl:hasNarrowSynonym
-   oboInOwl:hasBroadSynonym
  }
  FILTER NOT EXISTS { ?entity owl:deprecated true }
  FILTER NOT EXISTS { ?entity2 owl:deprecated true }
  ?entity rdfs:label ?value .
  ?entity2 ?property ?value .
+  FILTER (!isBlank(?entity))
+  FILTER (!isBlank(?entity2))
 }
 ORDER BY ?entity
 ```

--- a/robot-core/src/main/resources/report_queries/duplicate_label_synonym.rq
+++ b/robot-core/src/main/resources/report_queries/duplicate_label_synonym.rq
@@ -20,7 +20,7 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   FILTER NOT EXISTS { ?entity owl:deprecated true }
   FILTER NOT EXISTS { ?entity2 owl:deprecated true }
   ?entity rdfs:label ?value .
-  ?entity ?property ?value .
+  ?entity2 ?property ?value .
   FILTER (!isBlank(?entity))
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/duplicate_label_synonym.rq
+++ b/robot-core/src/main/resources/report_queries/duplicate_label_synonym.rq
@@ -13,14 +13,12 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   VALUES ?property {
     obo:IAO_0000118
     oboInOwl:hasExactSynonym
-    oboInOwl:hasRelatedSynonym
-    oboInOwl:hasNarrowSynonym
-    oboInOwl:hasBroadSynonym
   }
   FILTER NOT EXISTS { ?entity owl:deprecated true }
   FILTER NOT EXISTS { ?entity2 owl:deprecated true }
   ?entity rdfs:label ?value .
   ?entity2 ?property ?value .
   FILTER (!isBlank(?entity))
+  FILTER (!isBlank(?entity2))
 }
 ORDER BY ?entity


### PR DESCRIPTION
Resolves #747 

- [X] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

This test is a bit hard to wrap around, but the goal of this test, unchanged by this PR, is:

```
An entity shares a label with an exact synonym. This causes ambiguity. Excludes deprecated entities.
```

Hence, this PR:

1. Reduces the scope of the test to comparing labels with *exact synonyms and alternative terms*, excluding now all other synonym types
2. Looking not only at the entity itself (`entity`), but also checking that there is no other entity (`entity2`) that has an exact synonym that is the same as the label of `entity`.
