### PR TITLE
Report: Equivalent class with no genus check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add links to query documentation for default rules in [`report`] [#879]
 - Ability to restrict [`report`] to base ontology [#872]
+- Add check for equivalent class with no genus to [`report`] [#865]
 
 ### Changed
 - Split equivalent class check [#856]
@@ -267,6 +268,7 @@ First official release of ROBOT!
 [#882]: https://github.com/ontodev/robot/pull/882
 [#874]: https://github.com/ontodev/robot/pull/874
 [#872]: https://github.com/ontodev/robot/pull/872
+[#865]: https://github.com/ontodev/robot/pull/865
 [#864]: https://github.com/ontodev/robot/pull/864
 [#858]: https://github.com/ontodev/robot/pull/858
 [#856]: https://github.com/ontodev/robot/pull/856

--- a/docs/report_queries/equivalent_class_axiom_no_genus.md
+++ b/docs/report_queries/equivalent_class_axiom_no_genus.md
@@ -10,12 +10,11 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
  ?entity owl:equivalentClass ?ec .
-  ?ec rdf:type owl:Restriction .
-  ?ec owl:someValuesFrom ?y .
-  ?ec owl:onProperty ?property .
+ ?entity owl:equivalentClass [ rdf:type owl:Restriction ;
+                              owl:someValuesFrom ?y ;
+                              owl:onProperty ?property ] .
   FILTER (!isBlank(?entity))
   FILTER (!isBlank(?y))
-  BIND("" as ?value)
 }
 ORDER BY ?entity
 ```

--- a/docs/report_queries/equivalent_class_axiom_no_genus.md
+++ b/docs/report_queries/equivalent_class_axiom_no_genus.md
@@ -1,0 +1,21 @@
+# Equivalent Class Axiom with no Genus
+
+**Problem:** An equivalent class axiom of the kind C = R some A is nearly always an indication of a problem. It basically means that anything that is R related to an A is equal to the class. While this is sometimes legit, most often this is accidental.
+
+**Solution:** Add a genus to the class expression like: C = B and R some A.
+
+```
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+ ?entity owl:equivalentClass ?ec .
+  ?ec rdf:type owl:Restriction .
+  ?ec owl:someValuesFrom ?y .
+  ?ec owl:onProperty ?property .
+  FILTER (!isBlank(?entity))
+  FILTER (!isBlank(?y))
+  BIND("" as ?value)
+}
+ORDER BY ?entity
+```

--- a/docs/report_queries/index.md
+++ b/docs/report_queries/index.md
@@ -15,6 +15,7 @@ See [`report`](../report) for more details.
 | [duplicate label synonym](duplicate_label_synonym)  | WARN
 | [duplicate label](duplicate_label)  | ERROR
 | [duplicate scoped synonym](duplicate_scoped_synonym)  | WARN
+| [equivalent class axiom no genus](equivalent_class_axiom_no_genus) | WARN
 | [equivalent pair](equivalent_pair)  | WARN
 | [invalid xref](invalid_xref)  | WARN
 | [label formatting](label_formatting)  | ERROR

--- a/robot-core/src/main/resources/report_profile.txt
+++ b/robot-core/src/main/resources/report_profile.txt
@@ -8,6 +8,7 @@ WARN	duplicate_label_synonym
 ERROR	duplicate_label
 WARN	duplicate_scoped_synonym
 WARN	equivalent_pair
+WARN	equivalent_class_axiom_no_genus
 WARN	invalid_xref
 ERROR	label_formatting
 ERROR	label_whitespace
@@ -23,4 +24,3 @@ ERROR	misused_obsolete_label
 ERROR	multiple_definitions
 ERROR	multiple_equivalent_classes
 ERROR	multiple_labels
-WARN	equivalent_class_axiom_no_genus

--- a/robot-core/src/main/resources/report_profile.txt
+++ b/robot-core/src/main/resources/report_profile.txt
@@ -23,3 +23,4 @@ ERROR	misused_obsolete_label
 ERROR	multiple_definitions
 ERROR	multiple_equivalent_classes
 ERROR	multiple_labels
+WARN	equivalent_class_axiom_no_genus

--- a/robot-core/src/main/resources/report_queries/equivalent_class_axiom_no_genus.rq
+++ b/robot-core/src/main/resources/report_queries/equivalent_class_axiom_no_genus.rq
@@ -9,11 +9,10 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
  ?entity owl:equivalentClass ?ec .
-  ?ec rdf:type owl:Restriction .
-  ?ec owl:someValuesFrom ?y .
-  ?ec owl:onProperty ?property .
+ ?entity owl:equivalentClass [ rdf:type owl:Restriction ;
+                              owl:someValuesFrom ?y ;
+                              owl:onProperty ?property ] .
   FILTER (!isBlank(?entity))
   FILTER (!isBlank(?y))
-  BIND("" as ?value)
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/equivalent_class_axiom_no_genus.rq
+++ b/robot-core/src/main/resources/report_queries/equivalent_class_axiom_no_genus.rq
@@ -1,0 +1,19 @@
+# # Equivalent Class Axiom with no Genus
+#
+# **Problem:** An equivalent class axiom of the kind C = R some A is nearly always an indication of a problem. It basically means that anything that is R related to an A is equal to the class. While this is sometimes legit, most often this is accidental.
+#
+# **Solution:** Add a genus to the class expression like: C = B and R some A.
+
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+ ?entity owl:equivalentClass ?ec .
+  ?ec rdf:type owl:Restriction .
+  ?ec owl:someValuesFrom ?y .
+  ?ec owl:onProperty ?property .
+  FILTER (!isBlank(?entity))
+  FILTER (!isBlank(?y))
+  BIND("" as ?value)
+}
+ORDER BY ?entity


### PR DESCRIPTION
Resolves #844

- [X] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

See issue. What needs to be determined is whether we all agree this should be `WARN` or `ERROR`; there may be even some that would argue for `INFO`.