### PR TITLE
Report: Adding first pass of built in vocab check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add links to query documentation for default rules in [`report`] [#879]
 - Ability to restrict [`report`] to base ontology [#872]
 - Add check for equivalent class with no genus to [`report`] [#865]
+- Add check for illegal use of built-in vocabulary [#867]
 
 ### Changed
 - Split equivalent class check [#856]
@@ -275,6 +276,7 @@ First official release of ROBOT!
 [#879]: https://github.com/ontodev/robot/pull/879
 [#874]: https://github.com/ontodev/robot/pull/874
 [#872]: https://github.com/ontodev/robot/pull/872
+[#867]: https://github.com/ontodev/robot/pull/867
 [#866]: https://github.com/ontodev/robot/pull/866
 [#865]: https://github.com/ontodev/robot/pull/865
 [#864]: https://github.com/ontodev/robot/pull/864

--- a/docs/report_queries/illegal_use_of_built_in_vocabulary.md
+++ b/docs/report_queries/illegal_use_of_built_in_vocabulary.md
@@ -1,0 +1,18 @@
+# Illegal annotation of built-in vocabulary
+
+**Problem:** Redefining built-in vocabulary should never be done.
+
+**Solution:** Remove any statements about build-in vocabulary
+
+```
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+  VALUES ?entity {
+      rdf:type
+    }
+  ?entity ?property ?value
+}
+ORDER BY ?entity
+```

--- a/docs/report_queries/illegal_use_of_built_in_vocabulary.md
+++ b/docs/report_queries/illegal_use_of_built_in_vocabulary.md
@@ -1,4 +1,4 @@
-# Illegal annotation of built-in vocabulary
+# Illegal Use of Built-In Vocabulary
 
 **Problem:** Redefining built-in vocabulary should never be done.
 

--- a/docs/report_queries/index.md
+++ b/docs/report_queries/index.md
@@ -16,6 +16,7 @@ See [`report`](../report) for more details.
 | [duplicate label](duplicate_label)  | ERROR
 | [duplicate scoped synonym](duplicate_scoped_synonym)  | WARN
 | [equivalent pair](equivalent_pair)  | WARN
+| [illegal use of built-in vocabulary](illegal_use_of_built_in_vocabulary) | ERROR
 | [invalid xref](invalid_xref)  | WARN
 | [label formatting](label_formatting)  | ERROR
 | [label whitespace](label_whitespace)  | ERROR

--- a/robot-core/src/main/resources/report_profile.txt
+++ b/robot-core/src/main/resources/report_profile.txt
@@ -8,6 +8,7 @@ WARN	duplicate_label_synonym
 ERROR	duplicate_label
 WARN	duplicate_scoped_synonym
 WARN	equivalent_pair
+ERROR	illegal_use_of_built_in_vocabulary
 WARN	invalid_xref
 ERROR	label_formatting
 ERROR	label_whitespace
@@ -23,4 +24,3 @@ ERROR	misused_obsolete_label
 ERROR	multiple_definitions
 ERROR	multiple_equivalent_classes
 ERROR	multiple_labels
-ERROR	illegal_use_of_built_in_vocabulary

--- a/robot-core/src/main/resources/report_profile.txt
+++ b/robot-core/src/main/resources/report_profile.txt
@@ -23,3 +23,4 @@ ERROR	misused_obsolete_label
 ERROR	multiple_definitions
 ERROR	multiple_equivalent_classes
 ERROR	multiple_labels
+ERROR	illegal_use_of_built_in_vocabulary

--- a/robot-core/src/main/resources/report_queries/illegal_use_of_built_in_vocabulary.rq
+++ b/robot-core/src/main/resources/report_queries/illegal_use_of_built_in_vocabulary.rq
@@ -1,0 +1,16 @@
+# # Illegal annotation of built-in vocabulary
+#
+# **Problem:** Formatting characters are used in a label. This may cause issues when trying to reference the entity by label.
+#
+# **Solution:** Remove formatting characters from label.
+
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+  VALUES ?entity {
+      rdf:type
+    }
+  ?entity ?property ?value
+}
+ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/illegal_use_of_built_in_vocabulary.rq
+++ b/robot-core/src/main/resources/report_queries/illegal_use_of_built_in_vocabulary.rq
@@ -1,8 +1,8 @@
 # # Illegal annotation of built-in vocabulary
 #
-# **Problem:** Formatting characters are used in a label. This may cause issues when trying to reference the entity by label.
+# **Problem:** Redefining built-in vocabulary should never be done.
 #
-# **Solution:** Remove formatting characters from label.
+# **Solution:** Remove any statements about build-in vocabulary
 
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>

--- a/robot-core/src/main/resources/report_queries/illegal_use_of_built_in_vocabulary.rq
+++ b/robot-core/src/main/resources/report_queries/illegal_use_of_built_in_vocabulary.rq
@@ -1,4 +1,4 @@
-# # Illegal annotation of built-in vocabulary
+# # Illegal Use of Built-In Vocabulary
 #
 # **Problem:** Redefining built-in vocabulary should never be done.
 #


### PR DESCRIPTION
Resolves #835 

- [X] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

Adding a first check to prevent use of rdf:type in an axiom as a subject. Its less than what we wanted, but maybe lets just build the check up slowly slowly.
