### PR TITLE
Report: Adding check for invalid entity URIs

### DIFF
--- a/docs/report_queries/invalid_entity_uri.md
+++ b/docs/report_queries/invalid_entity_uri.md
@@ -1,6 +1,6 @@
 # Invalid Entity URI
 
-**Problem:** OBO entities are formatted http://purl.obolibrary.org/obo/IDSPACE_0000000. This format is assumed by many OBO tools. Often, accidentally typos cause entity to be ignored during processing.
+**Problem:** An entity's URI is not formatted correctly. OBO entities are formatted http://purl.obolibrary.org/obo/IDSPACE_0000000. This format is assumed by many OBO tools. Often, accidental typos cause an entity to be malformed, which can cause problems for tools that deal with OBO ontologies.
 
 **Solution:** Fix the entity OBO URI.
 

--- a/docs/report_queries/invalid_entity_uri.md
+++ b/docs/report_queries/invalid_entity_uri.md
@@ -1,0 +1,21 @@
+# Invalid Entity URI
+
+**Problem:** OBO entities are formatted http://purl.obolibrary.org/obo/IDSPACE_0000000. This format is assumed by many OBO tools. Often, accidentally typos cause entity to be ignored during processing.
+
+**Solution:** Fix the entity OBO URI.
+
+```
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+  ?entity rdf:type ?value .
+  FILTER (!isBlank(?entity))
+  FILTER(
+    STRSTARTS(str(?entity),"https://purl.obolibrary.org/obo/") ||
+    STRSTARTS(str(?entity),"http://purl.org/obo/") ||
+    STRSTARTS(str(?entity),"http://www.obofoundry.org/") ||
+    (STRSTARTS(str(?entity),"https://purl.obolibrary.org/") && regex(str(?entity),"http[:][/][/]purl[.]obolibrary[.]org[/][^o][^b][^o]"))
+  )
+}
+ORDER BY ?entity
+```

--- a/robot-core/src/main/resources/report_profile.txt
+++ b/robot-core/src/main/resources/report_profile.txt
@@ -23,4 +23,4 @@ ERROR	misused_obsolete_label
 ERROR	multiple_definitions
 ERROR	multiple_equivalent_classes
 ERROR	multiple_labels
-ERROR	invalid_entity_uri
+WARN	invalid_entity_uri

--- a/robot-core/src/main/resources/report_profile.txt
+++ b/robot-core/src/main/resources/report_profile.txt
@@ -23,3 +23,4 @@ ERROR	misused_obsolete_label
 ERROR	multiple_definitions
 ERROR	multiple_equivalent_classes
 ERROR	multiple_labels
+ERROR	invalid_entity_uri

--- a/robot-core/src/main/resources/report_queries/invalid_entity_uri.rq
+++ b/robot-core/src/main/resources/report_queries/invalid_entity_uri.rq
@@ -1,0 +1,19 @@
+# # Invalid Entity URI
+#
+# **Problem:** OBO entities are formatted http://purl.obolibrary.org/obo/IDSPACE_0000000. This format is assumed by many OBO tools. Often, accidentally typos cause entity to be ignored during processing.
+#
+# **Solution:** Fix the entity OBO URI.
+
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+  ?entity rdf:type ?value .
+  FILTER (!isBlank(?entity))
+  FILTER(
+    STRSTARTS(str(?entity),"https://purl.obolibrary.org/obo/") ||
+    STRSTARTS(str(?entity),"http://purl.org/obo/") ||
+    STRSTARTS(str(?entity),"http://www.obofoundry.org/") ||
+    (STRSTARTS(str(?entity),"https://purl.obolibrary.org/") && regex(str(?entity),"http[:][/][/]purl[.]obolibrary[.]org[/][^o][^b][^o]"))
+  )
+}
+ORDER BY ?entity


### PR DESCRIPTION
Resolves #790

- [X] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

This PR adds a check for typical mistakes in entity URIs. Careful review please, I tested the query, but not 1000% sure it will not fire in unintended situations.
