### PR TITLE
Report: Adding replacedBy check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to restrict [`report`] to base ontology [#872]
 - Add check for equivalent class with no genus to [`report`] [#865]
 - Add check for illegal use of built-in vocabulary [#867]
+- Add check for misused replaced-by annotation [#869]
 
 ### Changed
 - Split equivalent class check [#856]
@@ -276,6 +277,7 @@ First official release of ROBOT!
 [#879]: https://github.com/ontodev/robot/pull/879
 [#874]: https://github.com/ontodev/robot/pull/874
 [#872]: https://github.com/ontodev/robot/pull/872
+[#869]: https://github.com/ontodev/robot/pull/869
 [#867]: https://github.com/ontodev/robot/pull/867
 [#866]: https://github.com/ontodev/robot/pull/866
 [#865]: https://github.com/ontodev/robot/pull/865

--- a/docs/report_queries/index.md
+++ b/docs/report_queries/index.md
@@ -15,9 +15,9 @@ See [`report`](../report) for more details.
 | [duplicate label synonym](duplicate_label_synonym)  | WARN
 | [duplicate label](duplicate_label)  | ERROR
 | [duplicate scoped synonym](duplicate_scoped_synonym)  | WARN
-| [equivalent class axiom no genus](equivalent_class_axiom_no_genus) | WARN
 | [equivalent pair](equivalent_pair)  | WARN
-| [illegal use of built-in vocabulary](illegal_use_of_built_in_vocabulary) | ERROR
+| [equivalent class axiom no genus](equivalent_class_axiom_no_genus)  | WARN
+| [illegal use of built in vocabulary](illegal_use_of_built_in_vocabulary)  | ERROR
 | [invalid xref](invalid_xref)  | WARN
 | [label formatting](label_formatting)  | ERROR
 | [label whitespace](label_whitespace)  | ERROR
@@ -30,7 +30,7 @@ See [`report`](../report) for more details.
 | [missing ontology title](missing_ontology_title)  | ERROR
 | [missing superclass](missing_superclass)  | INFO
 | [misused obsolete label](misused_obsolete_label)  | ERROR
-| [misused replaced by](misused_replaced_by) | ERROR
+| [misused replaced by](misused_replaced_by)  | ERROR
 | [multiple definitions](multiple_definitions)  | ERROR
 | [multiple equivalent classes](multiple_equivalent_classes)  | WARN
 | [multiple equivalent class definitions](multiple_equivalent_class_definitions)  | ERROR

--- a/docs/report_queries/index.md
+++ b/docs/report_queries/index.md
@@ -28,6 +28,7 @@ See [`report`](../report) for more details.
 | [missing ontology title](missing_ontology_title)  | ERROR
 | [missing superclass](missing_superclass)  | INFO
 | [misused obsolete label](misused_obsolete_label)  | ERROR
+| [misused replaced by](misused_replaced_by) | ERROR
 | [multiple definitions](multiple_definitions)  | ERROR
 | [multiple equivalent classes](multiple_equivalent_classes)  | ERROR
 | [multiple labels](multiple_labels)  | ERROR

--- a/docs/report_queries/misused_replaced_by.md
+++ b/docs/report_queries/misused_replaced_by.md
@@ -1,0 +1,18 @@
+# Misused Replaced-by Annotation
+
+**Problem:** A replaced-by annotation was used on a non-obsolete class.
+
+**Solution:** Remove the replaced-by annotation or obsolete the class.
+
+```sparql
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+ VALUES ?property { <http://purl.obolibrary.org/obo/IAO_0100001> }
+ ?entity ?property ?value .
+ FILTER NOT EXISTS { ?entity owl:deprecated true }
+ FILTER (?entity != oboInOwl:ObsoleteClass)
+}
+ORDER BY ?entity
+```

--- a/docs/report_queries/misused_replaced_by.md
+++ b/docs/report_queries/misused_replaced_by.md
@@ -12,7 +12,6 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
  VALUES ?property { <http://purl.obolibrary.org/obo/IAO_0100001> }
  ?entity ?property ?value .
  FILTER NOT EXISTS { ?entity owl:deprecated true }
- FILTER (?entity != oboInOwl:ObsoleteClass)
 }
 ORDER BY ?entity
 ```

--- a/robot-core/src/main/resources/report_profile.txt
+++ b/robot-core/src/main/resources/report_profile.txt
@@ -23,3 +23,4 @@ ERROR	misused_obsolete_label
 ERROR	multiple_definitions
 ERROR	multiple_equivalent_classes
 ERROR	multiple_labels
+ERROR	misused_replaced_by

--- a/robot-core/src/main/resources/report_profile.txt
+++ b/robot-core/src/main/resources/report_profile.txt
@@ -20,7 +20,7 @@ ERROR	missing_ontology_license
 ERROR	missing_ontology_title
 INFO	missing_superclass
 ERROR	misused_obsolete_label
+ERROR	misused_replaced_by
 ERROR	multiple_definitions
 ERROR	multiple_equivalent_classes
 ERROR	multiple_labels
-ERROR	misused_replaced_by

--- a/robot-core/src/main/resources/report_queries/misused_replaced_by.rq
+++ b/robot-core/src/main/resources/report_queries/misused_replaced_by.rq
@@ -11,6 +11,5 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
  VALUES ?property { <http://purl.obolibrary.org/obo/IAO_0100001> }
  ?entity ?property ?value .
  FILTER NOT EXISTS { ?entity owl:deprecated true }
- FILTER (?entity != oboInOwl:ObsoleteClass)
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/misused_replaced_by.rq
+++ b/robot-core/src/main/resources/report_queries/misused_replaced_by.rq
@@ -1,0 +1,16 @@
+# # Misused Replaced-by Annotation
+#
+# **Problem:** A replaced-by annotation was used on a non-obsolete class.
+#
+# **Solution:** Remove the replaced-by annotation or obsolete the class.
+
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+ VALUES ?property { <http://purl.obolibrary.org/obo/IAO_0100001> }
+ ?entity ?property ?value .
+ FILTER NOT EXISTS { ?entity owl:deprecated true }
+ FILTER (?entity != oboInOwl:ObsoleteClass)
+}
+ORDER BY ?entity


### PR DESCRIPTION
Resolves #288 

- [X] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

This introduces a check for illegal replaced-by annotation involving non-obsolete terms.
