### PR TITLE
Report: Adding undeclared synonymtype and subsettype checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add check for equivalent class with no genus to [`report`] [#865]
 - Add check for illegal use of built-in vocabulary [#867]
 - Add check for misused replaced-by annotation [#869]
+- Add checks for undeclared synonymtype and subsettype [#870]
 
 ### Changed
 - Split equivalent class check [#856]
@@ -277,6 +278,7 @@ First official release of ROBOT!
 [#879]: https://github.com/ontodev/robot/pull/879
 [#874]: https://github.com/ontodev/robot/pull/874
 [#872]: https://github.com/ontodev/robot/pull/872
+[#870]: https://github.com/ontodev/robot/pull/870
 [#869]: https://github.com/ontodev/robot/pull/869
 [#867]: https://github.com/ontodev/robot/pull/867
 [#866]: https://github.com/ontodev/robot/pull/866

--- a/docs/examples/report.tsv
+++ b/docs/examples/report.tsv
@@ -3,6 +3,46 @@ ERROR	missing_ontology_description	https://github.com/ontodev/robot/examples/edi
 ERROR	missing_ontology_license	https://github.com/ontodev/robot/examples/edit.owl	dc:license	
 ERROR	missing_ontology_title	https://github.com/ontodev/robot/examples/edit.owl	dc11:title	
 WARN	annotation_whitespace	obo:UBPROP_0000007	IAO:0000232	Used to connect a class to an adjectival form of its label. For example, a class with label 'intestine' may have a relational adjective 'intestinal'. 
+WARN	missing_subset_declaration	obo:uberon/core#disjointness_axiom_removed	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000064>
+WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000064>
+WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000468>
+WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000475>
+WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000916>
+WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000949>
+WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0001235>
+WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002100>
+WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002530>
+WARN	missing_subset_declaration	obo:uberon/core#grouping_class	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0006858>
+WARN	missing_subset_declaration	obo:uberon/core#non_informative	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0009569>
+WARN	missing_subset_declaration	obo:uberon/core#non_informative	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0013702>
+WARN	missing_subset_declaration	obo:uberon/core#organ_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002368>
+WARN	missing_subset_declaration	obo:uberon/core#organ_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002369>
+WARN	missing_subset_declaration	obo:uberon/core#organ_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0006858>
+WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000467>
+WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000468>
+WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000475>
+WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000916>
+WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000949>
+WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0001235>
+WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0001851>
+WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002100>
+WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002368>
+WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002369>
+WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002530>
+WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000061>
+WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000062>
+WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000064>
+WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000465>
+WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000467>
+WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000468>
+WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000475>
+WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000480>
+WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0001062>
+WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0001851>
+WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0010000>
+WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0011676>
+WARN	missing_subset_declaration	obo:uberon/core#vertebrate_core	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000949>
+WARN	missing_subset_declaration	obo:uberon/core#vertebrate_core	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002100>
 WARN	duplicate_label_synonym	UBERON:0000949	oboInOwl:hasExactSynonym	endocrine system
 WARN	duplicate_label_synonym	UBERON:0001851	oboInOwl:hasExactSynonym	cortex
 WARN	missing_definition	BFO:0000050	IAO:0000115	

--- a/docs/examples/report.tsv
+++ b/docs/examples/report.tsv
@@ -3,46 +3,14 @@ ERROR	missing_ontology_description	https://github.com/ontodev/robot/examples/edi
 ERROR	missing_ontology_license	https://github.com/ontodev/robot/examples/edit.owl	dc:license	
 ERROR	missing_ontology_title	https://github.com/ontodev/robot/examples/edit.owl	dc11:title	
 WARN	annotation_whitespace	obo:UBPROP_0000007	IAO:0000232	Used to connect a class to an adjectival form of its label. For example, a class with label 'intestine' may have a relational adjective 'intestinal'. 
-WARN	missing_subset_declaration	obo:uberon/core#disjointness_axiom_removed	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000064>
-WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000064>
-WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000468>
-WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000475>
-WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000916>
-WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000949>
-WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0001235>
-WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002100>
-WARN	missing_subset_declaration	obo:uberon/core#efo_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002530>
-WARN	missing_subset_declaration	obo:uberon/core#grouping_class	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0006858>
-WARN	missing_subset_declaration	obo:uberon/core#non_informative	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0009569>
-WARN	missing_subset_declaration	obo:uberon/core#non_informative	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0013702>
-WARN	missing_subset_declaration	obo:uberon/core#organ_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002368>
-WARN	missing_subset_declaration	obo:uberon/core#organ_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002369>
-WARN	missing_subset_declaration	obo:uberon/core#organ_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0006858>
-WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000467>
-WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000468>
-WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000475>
-WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000916>
-WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000949>
-WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0001235>
-WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0001851>
-WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002100>
-WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002368>
-WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002369>
-WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002530>
-WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000061>
-WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000062>
-WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000064>
-WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000465>
-WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000467>
-WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000468>
-WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000475>
-WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000480>
-WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0001062>
-WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0001851>
-WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0010000>
-WARN	missing_subset_declaration	obo:uberon/core#upper_level	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0011676>
-WARN	missing_subset_declaration	obo:uberon/core#vertebrate_core	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0000949>
-WARN	missing_subset_declaration	obo:uberon/core#vertebrate_core	oboInOwl:inSubset	<http://purl.obolibrary.org/obo/UBERON_0002100>
+WARN	missing_subset_declaration	obo:uberon/core#disjointness_axiom_removed	rdfs:subPropertyOf	
+WARN	missing_subset_declaration	obo:uberon/core#efo_slim	rdfs:subPropertyOf	
+WARN	missing_subset_declaration	obo:uberon/core#grouping_class	rdfs:subPropertyOf	
+WARN	missing_subset_declaration	obo:uberon/core#non_informative	rdfs:subPropertyOf	
+WARN	missing_subset_declaration	obo:uberon/core#organ_slim	rdfs:subPropertyOf	
+WARN	missing_subset_declaration	obo:uberon/core#uberon_slim	rdfs:subPropertyOf	
+WARN	missing_subset_declaration	obo:uberon/core#upper_level	rdfs:subPropertyOf	
+WARN	missing_subset_declaration	obo:uberon/core#vertebrate_core	rdfs:subPropertyOf	
 WARN	duplicate_label_synonym	UBERON:0000949	oboInOwl:hasExactSynonym	endocrine system
 WARN	duplicate_label_synonym	UBERON:0001851	oboInOwl:hasExactSynonym	cortex
 WARN	missing_definition	BFO:0000050	IAO:0000115	

--- a/docs/report_queries/index.md
+++ b/docs/report_queries/index.md
@@ -26,7 +26,9 @@ See [`report`](../report) for more details.
 | [missing ontology description](missing_ontology_description)  | ERROR
 | [missing ontology license](missing_ontology_license)  | ERROR
 | [missing ontology title](missing_ontology_title)  | ERROR
+| [missing subset declaration](missing_subset_declaration)  | WARN
 | [missing superclass](missing_superclass)  | INFO
+| [missing synonym type declaration](missing_synonymtype_declaration)  | WARN
 | [misused obsolete label](misused_obsolete_label)  | ERROR
 | [multiple definitions](multiple_definitions)  | ERROR
 | [multiple equivalent classes](multiple_equivalent_classes)  | ERROR

--- a/docs/report_queries/missing_subset_declaration.md
+++ b/docs/report_queries/missing_subset_declaration.md
@@ -1,0 +1,17 @@
+# Missing Subset Declaration
+
+**Problem:** A subset is used in an annotation, but is not properly declared as a child of oboInOwl:SubsetProperty. This can cause problems with conversions to OBO format.
+
+**Solution:** Make the subset a child of oboInOwl:SubsetProperty.
+
+```sparql
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+   VALUES ?property { oboInOwl:inSubset }
+   ?value ?property ?entity .
+   FILTER NOT EXISTS { ?entity rdfs:subPropertyOf oboInOwl:SubsetProperty }
+}
+ORDER BY ?entity
+```

--- a/docs/report_queries/missing_subset_declaration.md
+++ b/docs/report_queries/missing_subset_declaration.md
@@ -9,9 +9,9 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
-   VALUES ?property { oboInOwl:inSubset }
-   ?value ?property ?entity .
-   FILTER NOT EXISTS { ?entity rdfs:subPropertyOf oboInOwl:SubsetProperty }
+    VALUES ?property { rdfs:subPropertyOf }
+    ?x oboInOwl:inSubset ?entity .
+    FILTER NOT EXISTS { ?entity ?property oboInOwl:SubsetProperty }
 }
 ORDER BY ?entity
 ```

--- a/docs/report_queries/missing_synonymtype_declaration.md
+++ b/docs/report_queries/missing_synonymtype_declaration.md
@@ -1,0 +1,17 @@
+# Missing Synonym Type Declaration
+
+**Problem:** A synonym type is used in an annotation, but is not properly declared as a child of oboInOwl:SynonymTypeProperty. This can cause problems with conversions to OBO format.
+
+**Solution:** Make the synonym type a child of oboInOwl:SynonymTypeProperty.
+
+```sparql
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+   VALUES ?property { oboInOwl:hasSynonymType }
+   ?value ?property ?entity .
+   FILTER NOT EXISTS { ?entity rdfs:subPropertyOf oboInOwl:SynonymTypeProperty }
+}
+ORDER BY ?entity
+```

--- a/docs/report_queries/missing_synonymtype_declaration.md
+++ b/docs/report_queries/missing_synonymtype_declaration.md
@@ -9,9 +9,9 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
-   VALUES ?property { oboInOwl:hasSynonymType }
-   ?value ?property ?entity .
-   FILTER NOT EXISTS { ?entity rdfs:subPropertyOf oboInOwl:SynonymTypeProperty }
+    VALUES ?property { rdfs:subPropertyOf }
+    ?x oboInOwl:hasSynonymType ?entity .
+    FILTER NOT EXISTS { ?entity ?property oboInOwl:SynonymTypeProperty }
 }
 ORDER BY ?entity
 ```

--- a/robot-core/src/main/resources/report_profile.txt
+++ b/robot-core/src/main/resources/report_profile.txt
@@ -18,10 +18,10 @@ WARN	missing_obsolete_label
 ERROR	missing_ontology_description
 ERROR	missing_ontology_license
 ERROR	missing_ontology_title
+WARN	missing_subset_declaration
 INFO	missing_superclass
+WARN	missing_synonymtype_declaration
 ERROR	misused_obsolete_label
 ERROR	multiple_definitions
 ERROR	multiple_equivalent_classes
 ERROR	multiple_labels
-WARN	missing_subset_declaration
-WARN	missing_synonymtype_declaration

--- a/robot-core/src/main/resources/report_profile.txt
+++ b/robot-core/src/main/resources/report_profile.txt
@@ -23,3 +23,5 @@ ERROR	misused_obsolete_label
 ERROR	multiple_definitions
 ERROR	multiple_equivalent_classes
 ERROR	multiple_labels
+WARN	missing_subset_declaration
+WARN	missing_synonymtype_declaration

--- a/robot-core/src/main/resources/report_queries/missing_subset_declaration.rq
+++ b/robot-core/src/main/resources/report_queries/missing_subset_declaration.rq
@@ -1,0 +1,15 @@
+# # Missing Subset Declaration
+#
+# **Problem:** A synonym type is used in an annotation, but is not properly declared as a child of oboInOwl:SynonymTypeProperty. This can cause problems with conversions to OBO format.
+#
+# **Solution:** Make the synonym type a child of oboInOwl:SubsetProperty.
+
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+   VALUES ?property { oboInOwl:inSubset }
+   ?value ?property ?entity .
+   FILTER NOT EXISTS { ?entity rdfs:subPropertyOf oboInOwl:SubsetProperty }
+}
+ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/missing_subset_declaration.rq
+++ b/robot-core/src/main/resources/report_queries/missing_subset_declaration.rq
@@ -8,8 +8,8 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
-   VALUES ?property { oboInOwl:inSubset }
-   ?value ?property ?entity .
-   FILTER NOT EXISTS { ?entity rdfs:subPropertyOf oboInOwl:SubsetProperty }
+    VALUES ?property { rdfs:subPropertyOf }
+    ?x oboInOwl:inSubset ?entity .
+    FILTER NOT EXISTS { ?entity ?property oboInOwl:SubsetProperty }
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/missing_synonymtype_declaration.rq
+++ b/robot-core/src/main/resources/report_queries/missing_synonymtype_declaration.rq
@@ -1,0 +1,15 @@
+# # Missing Synonym Type Declaration
+#
+# **Problem:** A synonym type is used in an annotation, but is not properly declared as a child of oboInOwl:SynonymTypeProperty. This can cause problems with conversions to OBO format.
+#
+# **Solution:** Make the synonym type a child of oboInOwl:SynonymTypeProperty.
+
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+   VALUES ?property { oboInOwl:hasSynonymType }
+   ?value ?property ?entity .
+   FILTER NOT EXISTS { ?entity rdfs:subPropertyOf oboInOwl:SynonymTypeProperty }
+}
+ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/missing_synonymtype_declaration.rq
+++ b/robot-core/src/main/resources/report_queries/missing_synonymtype_declaration.rq
@@ -8,8 +8,8 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE {
-   VALUES ?property { oboInOwl:hasSynonymType }
-   ?value ?property ?entity .
-   FILTER NOT EXISTS { ?entity rdfs:subPropertyOf oboInOwl:SynonymTypeProperty }
+    VALUES ?property { rdfs:subPropertyOf }
+    ?x oboInOwl:hasSynonymType ?entity .
+    FILTER NOT EXISTS { ?entity ?property oboInOwl:SynonymTypeProperty }
 }
 ORDER BY ?entity

--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,0 @@
-#./bin/robot report -i $ONT --output results/report_uberon.tsv

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,1 @@
+#./bin/robot report -i $ONT --output results/report_uberon.tsv


### PR DESCRIPTION
Resolves #862 
Resolves #861 

- [X] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

This pull request adds two new checks, for undeclared synonym types and undeclared subsets. These can cause problems in OBO serialisations and are easily removed accidentally because of ROBOT slme extract, for example.
