### PR TITLE
Adding functionality to restrict report to base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add links to query documentation for default rules in [`report`] [#879]
+- Ability to restrict [`report`] to base ontology [#872]
 
 ### Fixed
 - Fix printing violations in [`report`] [#823]
@@ -257,6 +258,7 @@ First official release of ROBOT!
 [`validate`]: http://robot.obolibrary.org/validate
 
 [#874]: https://github.com/ontodev/robot/pull/874
+[#872]: https://github.com/ontodev/robot/pull/872
 [#858]: https://github.com/ontodev/robot/pull/858
 [#850]: https://github.com/ontodev/robot/pull/850
 [#834]: https://github.com/ontodev/robot/pull/834

--- a/docs/examples/my-base-report.tsv
+++ b/docs/examples/my-base-report.tsv
@@ -1,0 +1,14 @@
+Level	Rule Name	Subject	Property	Value
+ERROR	missing_ontology_description	https://github.com/ontodev/robot/examples/edit.owl	dc11:description	
+ERROR	missing_ontology_license	https://github.com/ontodev/robot/examples/edit.owl	dc:license	
+ERROR	missing_ontology_title	https://github.com/ontodev/robot/examples/edit.owl	dc11:title	
+WARN	annotation_whitespace	obo:UBPROP_0000007	IAO:0000232	Used to connect a class to an adjectival form of its label. For example, a class with label 'intestine' may have a relational adjective 'intestinal'. 
+WARN	duplicate_label_synonym	UBERON:0000949	oboInOwl:hasExactSynonym	endocrine system
+WARN	duplicate_label_synonym	UBERON:0001851	oboInOwl:hasExactSynonym	cortex
+WARN	missing_definition	UBERON:0009569	IAO:0000115	
+WARN	missing_definition	obo:UBPROP_0000007	IAO:0000115	
+WARN	duplicate_scoped_synonym	UBERON:0002368	oboInOwl:hasExactSynonym	ductless gland
+WARN	duplicate_scoped_synonym	UBERON:0002368	oboInOwl:hasRelatedSynonym	ductless gland
+WARN	duplicate_scoped_synonym	UBERON:0002369	oboInOwl:hasExactSynonym	glandula suprarenalis
+WARN	duplicate_scoped_synonym	UBERON:0002369	oboInOwl:hasRelatedSynonym	glandula suprarenalis
+INFO	missing_superclass	UBERON:0001062	rdfs:subClassOf	

--- a/docs/report.md
+++ b/docs/report.md
@@ -8,7 +8,7 @@
 4. [Queries](#queries)
 5. [Profiles (`--profile`)](#profiles)
 6. [Executing on Disk (`--tdb`)](#executing-on-disk)
-7. [Limiting Results (`--limit`)](#limiting-results)
+7. [Limiting Results (`--limit`, `--base-iri`)](#limiting-results)
 
 ## Overview
 
@@ -153,6 +153,22 @@ robot report --input edit.owl \
 ```
 
 This example will only include the first 10,000 results for each report query, meaning that some violation counts may be incomplete. Typically, you should not need to include a limit, but when working with large ontologies (using TDB), there may be hundreds of thousands of results.
+
+The results can also be restricted to entities following one or more URI prefixes.
+
+```
+robot report --input edit.owl \
+  --base-iri "http://purl.obolibrary.org/obo/UBERON_" \
+  --base-iri "https://github.com/ontodev/robot/examples/edit" \
+  --base-iri "http://purl.obolibrary.org/obo/UBPROP_" \
+  --output my-base-report.tsv
+```
+
+Note that if you want annotations on your ontology itself be checked, be sure to
+include a suitable URI prefix. For example, in the snippet above, we have
+included `https://github.com/ontodev/robot/examples/edit`, which ensures that
+ontology annotations on `https://github.com/ontodev/robot/examples/edit.owl` are
+included in the test results.
 
 ## Working with import closures
 

--- a/robot-command/src/main/java/org/obolibrary/robot/ReportCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ReportCommand.java
@@ -1,6 +1,7 @@
 package org.obolibrary.robot;
 
 import com.google.common.collect.Lists;
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
@@ -32,6 +33,7 @@ public class ReportCommand implements Command {
     o.addOption("I", "input-iri", true, "load ontology from an IRI");
     o.addOption("o", "output", true, "save report to a file");
     o.addOption("p", "profile", true, "reporting rules and levels to use");
+    o.addOption(null, "base-iri", true, "specify a base namespace");
     o.addOption("f", "format", true, "save report in a given format (TSV or YAML)");
     o.addOption("F", "fail-on", true, "logging level to fail on");
     o.addOption("l", "labels", true, "if true, use labels for output");
@@ -132,6 +134,9 @@ public class ReportCommand implements Command {
         throw new IllegalArgumentException(String.format(missingOutputError, format));
       }
     }
+
+    List<String> baseNamespaces = CommandLineHelper.getBaseNamespaces(line, ioHelper);
+    baseNamespaces.forEach(ioHelper::addBaseNamespace);
 
     boolean success;
 

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -91,6 +91,7 @@ public class ReportOperation {
     options.put("labels", "false");
     options.put("format", null);
     options.put("profile", null);
+    options.put("base-iri", null);
     options.put("tdb", "false");
     options.put("tdb-directory", ".tdb");
     options.put("keep-tdb-mappings", "false");
@@ -925,6 +926,23 @@ public class ReportOperation {
       // skip RDFS and OWL terms
       if (entity.contains("/rdf-schema#") || entity.contains("/owl#")) {
         continue;
+      }
+
+      if (!ioHelper.getBaseNamespaces().isEmpty()) {
+        boolean base = false;
+        for (String base_prefix : ioHelper.getBaseNamespaces()) {
+          if (entity.startsWith(base_prefix)) {
+            logger.info(
+                String.format(
+                    "Skipping entity '%s' from report because it follows the base-namespace.",
+                    entity));
+            base = true;
+            break;
+          }
+        }
+        if (!base) {
+          continue;
+        }
       }
 
       Violation violation;


### PR DESCRIPTION
Resolves #830 

- [X] `docs/` have been added/updated
- [X] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

This is my attempt to do as little damage as possible, while introducing the ability to restrict the report to specified entities. I have run a few tests locally, and it works as expected, but best have a good look.