### PR TITLE
Fix entity rendering in report when value is an entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing annotations from [`export`] [#850]
 - Fail on unknown rule names in [`report`] [#858]
 - Fix behaviour of `--preserve-structure` when using internal or external axiom selectors for [`remove`] or [`filter`] [#816]
+- Fix value rendering for entities in [`report`] [#874]
 
 ## [1.8.1] - 2021-01-27
 
@@ -252,6 +253,8 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#874]: https://github.com/ontodev/robot/pull/874
+[#858]: https://github.com/ontodev/robot/pull/858
 [#850]: https://github.com/ontodev/robot/pull/850
 [#834]: https://github.com/ontodev/robot/pull/834
 [#823]: https://github.com/ontodev/robot/pull/823

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -926,6 +926,11 @@ public class IOHelper {
       logger.warn(e.getMessage());
       return null;
     }
+
+    if (iri.toString().contains(" ")) {
+      // Invalid IRI
+      return null;
+    }
     return iri;
   }
 

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -944,7 +944,7 @@ public class ReportOperation {
         OWLEntity e = dataFactory.getOWLClass(ioHelper.createIRI(property));
         if (value != null) {
           IRI valIRI = ioHelper.createIRI(value);
-          if (valIRI != null && !valIRI.toString().contains(" ")) {
+          if (valIRI != null) {
             OWLEntity v = dataFactory.getOWLClass(valIRI);
             violation.addStatement(e, v);
           } else {

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -785,7 +785,7 @@ public class ReportOperation {
     if (path == null) {
       is = ReportOperation.class.getResourceAsStream("/report_profile.txt");
     } else {
-      is = new FileInputStream(new File(path));
+      is = new FileInputStream(path);
     }
     try (BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
       String line;
@@ -944,13 +944,14 @@ public class ReportOperation {
         OWLEntity e = dataFactory.getOWLClass(ioHelper.createIRI(property));
         if (value != null) {
           IRI valIRI = ioHelper.createIRI(value);
-          if (valIRI != null) {
-            violation.addStatement(e, valIRI);
+          if (valIRI != null && !valIRI.toString().contains(" ")) {
+            OWLEntity v = dataFactory.getOWLClass(valIRI);
+            violation.addStatement(e, v);
           } else {
-            violation.addStatement(e, dataFactory.getOWLLiteral(value));
+            violation.addStatement(e, value);
           }
         } else {
-          violation.addStatement(e, null);
+          violation.addStatement(e, "");
         }
       }
       violations.add(violation);

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/Violation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/Violation.java
@@ -113,10 +113,14 @@ public class Violation {
    */
   @Deprecated
   public void addStatement(OWLEntity property, OWLObject object) {
-    // Do nothing
-    logger.error(
-        String.format(
-            "Cannot add OWLObject '%s'; use an OWLEntity or String literal instead.",
-            object.toString()));
+    logger.error("Do not add OWLObjects to Violations; use an OWLEntity or String literal instead");
+    if (object instanceof OWLEntity) {
+      addStatement(property, (OWLEntity) object);
+    } else if (object instanceof OWLLiteral) {
+      OWLLiteral lit = (OWLLiteral) object;
+      addStatement(property, lit.getLiteral());
+    } else {
+      addStatement(property, object.toString());
+    }
   }
 }

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/Violation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/Violation.java
@@ -13,8 +13,11 @@ public class Violation {
   public String subject;
 
   // Statements about OWLEntity subject
-  public Map<OWLEntity, List<OWLObject>> entityStatements = new HashMap<>();
+  public Map<OWLEntity, List<OWLEntity>> entityStatements = new HashMap<>();
   // Statements about String subject
+  public Map<OWLEntity, List<String>> literalStatements = new HashMap<>();
+
+  // Deprecated statements with string properties
   public Map<String, List<String>> statements = new HashMap<>();
 
   /**
@@ -27,13 +30,22 @@ public class Violation {
   }
 
   /**
-   * Add a statement to the Violation about the subject.
+   * Create a new Violation object about a String. This is used for blank nodes.
+   *
+   * @param subject String subject
+   */
+  public Violation(String subject) {
+    this.subject = subject;
+  }
+
+  /**
+   * Add a statement with an OWLEntity value to the Violation about the subject.
    *
    * @param property OWLEntity property
-   * @param value OWLObject value
+   * @param value OWLEntity value
    */
-  public void addStatement(OWLEntity property, OWLObject value) {
-    List<OWLObject> values;
+  public void addStatement(OWLEntity property, OWLEntity value) {
+    List<OWLEntity> values;
     if (entityStatements.get(property) != null) {
       // This property already has one value in the map
       // Add this value to the existing list
@@ -51,19 +63,38 @@ public class Violation {
     entityStatements.put(property, values);
   }
 
-  /** @param subject String subject */
-  public Violation(String subject) {
-    this.subject = subject;
+  /**
+   * Add a literal statement to the Violation about the subject.
+   *
+   * @param property OWLEntity property
+   * @param value String literal value
+   */
+  public void addStatement(OWLEntity property, String value) {
+    List<String> values;
+    if (literalStatements.get(property) != null) {
+      values = new ArrayList<>(literalStatements.get(property));
+      values.add(value);
+    } else {
+      if (value != null) {
+        values = Collections.singletonList(value);
+      } else {
+        values = Collections.emptyList();
+      }
+    }
+    literalStatements.put(property, values);
   }
 
   /**
    * @param property String property
    * @param value String value
+   * @deprecated String properties are no longer recommended; create an OWLEntity for the property
+   *     instead
    */
+  @Deprecated
   public void addStatement(String property, String value) {
     List<String> values;
     if (statements.get(property) != null) {
-      values = new ArrayList<String>(statements.get(property));
+      values = new ArrayList<>(statements.get(property));
       values.add(value);
     } else {
       if (value != null) {
@@ -73,5 +104,19 @@ public class Violation {
       }
     }
     statements.put(property, values);
+  }
+
+  /**
+   * @param property String property
+   * @param object OWLObject value
+   * @deprecated OWLObjects are no longer supported; use OWLEntity or String literal instead
+   */
+  @Deprecated
+  public void addStatement(OWLEntity property, OWLObject object) {
+    // Do nothing
+    logger.error(
+        String.format(
+            "Cannot add OWLObject '%s'; use an OWLEntity or String literal instead.",
+            object.toString()));
   }
 }


### PR DESCRIPTION
Resolves #855

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

Oddly enough, the Manchester render doesn't like `OWLObjects` so I switched the Violations to use `OWLEntities` and now the values render correctly when they're not just literals.
