### PR TITLE
Add links for builtin rules to HTML reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Links for default rules in HTML outputs for [`report`] [#875]
+
 ### Fixed
 - Fix printing violations in [`report`] [#823]
 - Fix handling of `rdf:type` in [`export`] [#834]
@@ -253,6 +256,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#875]: https://github.com/ontodev/robot/pull/875
 [#874]: https://github.com/ontodev/robot/pull/874
 [#858]: https://github.com/ontodev/robot/pull/858
 [#850]: https://github.com/ontodev/robot/pull/850

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
@@ -192,28 +192,14 @@ public class Report {
   }
 
   /**
-   * Given a rule name, it's reporting level, and a list of the violations from the ontology, add
-   * the violations to the correct map.
+   * Given a rule name, if it's builtin or not, it's reporting level, and a list of the violations
+   * from the ontology, add the violations to the correct map.
    *
    * @param ruleName name of rule
+   * @param builtin Boolean representing if rule is builtin or not
    * @param level reporting level of rule
    * @param violations list of violations from this rule
    */
-  public void addViolations(String ruleName, String level, List<Violation> violations) {
-    logger.debug("violation found: " + ruleName);
-    if (INFO.equals(level)) {
-      info.put(ruleName, Pair.of(violations, false));
-      infoCount += violations.size();
-    } else if (WARN.equals(level)) {
-      warn.put(ruleName, Pair.of(violations, false));
-      warnCount += violations.size();
-    } else if (ERROR.equals(level)) {
-      error.put(ruleName, Pair.of(violations, false));
-      errorCount += violations.size();
-    }
-    // Otherwise do nothing
-  }
-
   public void addViolations(
       String ruleName, Boolean builtin, String level, List<Violation> violations) {
     logger.debug("violation found: " + ruleName);
@@ -581,6 +567,31 @@ public class Report {
       }
     }
     return sb.toString();
+  }
+
+  /**
+   * Given a rule name, it's reporting level, and a list of the violations from the ontology, add
+   * the violations to the correct map.
+   *
+   * @param ruleName name of rule
+   * @param level reporting level of rule
+   * @param violations list of violations from this rule
+   * @deprecated use {@link #addViolations(String, Boolean, String, List)}
+   */
+  @Deprecated
+  public void addViolations(String ruleName, String level, List<Violation> violations) {
+    logger.debug("violation found: " + ruleName);
+    if (INFO.equals(level)) {
+      info.put(ruleName, Pair.of(violations, false));
+      infoCount += violations.size();
+    } else if (WARN.equals(level)) {
+      warn.put(ruleName, Pair.of(violations, false));
+      warnCount += violations.size();
+    } else if (ERROR.equals(level)) {
+      error.put(ruleName, Pair.of(violations, false));
+      errorCount += violations.size();
+    }
+    // Otherwise do nothing
   }
 
   /**

--- a/robot-core/src/main/java/org/obolibrary/robot/export/Cell.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/export/Cell.java
@@ -11,12 +11,12 @@ import org.apache.poi.ss.usermodel.IndexedColors;
 public class Cell {
 
   // Column object used to build this cell
-  private Column column;
+  private final Column column;
 
   // List of output values for this cell
-  private List<CellValue> values = new ArrayList<>();
+  private final List<CellValue> values = new ArrayList<>();
 
-  private List<String> displayValues = new ArrayList<>();
+  private final List<String> displayValues = new ArrayList<>();
   private String sortValueString;
 
   // Styles for XLSX output
@@ -26,6 +26,8 @@ public class Cell {
 
   // Styles for HTML output
   private String htmlClass = null;
+  // Option to add a link to a value (separate from rendered entities)
+  private String href = null;
 
   // Comment can appear as an XLSX Comment or an HTML tooltip
   // This is not required and can be returned null
@@ -147,6 +149,15 @@ public class Cell {
   }
 
   /**
+   * Get an href link for the cell or null.
+   *
+   * @return String link or null
+   */
+  public String getHref() {
+    return href;
+  }
+
+  /**
    * Get the font color for this cell in an XLSX workbook.
    *
    * @return IndexedColors value for font
@@ -191,6 +202,14 @@ public class Cell {
     this.comment = comment;
   }
 
+  /**
+   * Add a link to this Cell.
+   *
+   * @param href String href link
+   */
+  public void setHref(String href) {
+    this.href = href;
+  }
   /**
    * Add an HTML class to this Cell.
    *

--- a/robot-core/src/main/java/org/obolibrary/robot/export/Row.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/export/Row.java
@@ -249,6 +249,12 @@ public class Row {
         value = String.join(split, values);
         htmlClass = cell.getHTMLClass();
         comment = cell.getComment();
+
+        // Maybe wrap cell in href (separate from entity rendering)
+        String href = cell.getHref();
+        if (href != null) {
+          value = String.format("<a href=\"%s\">%s</a>", href, value);
+        }
       } else {
         value = "";
       }


### PR DESCRIPTION
Resolves #871

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

I'm not sure I'm super happy with this implementation, but aside from maintaining a list of builtin queries in the `Report` class, this is the best way I could think to do it. I don't want another list to add to every time we add a new default report query. The queries now have an extra layer of info - a boolean if they are builtin or not.

When we change things in Report, I need to deprecate old methods to maintain backwards compatibility. These deprecated methods are starting to build up. Are we planning on removing them at any point?