### PR TITLE
Add ReportQuery objects to Report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add links to query documentation for default rules in [`report`] [#879]
+
 ### Fixed
 - Fix printing violations in [`report`] [#823]
 - Fix handling of `rdf:type` in [`export`] [#834]

--- a/docs/examples/report.tsv
+++ b/docs/examples/report.tsv
@@ -4,15 +4,15 @@ ERROR	missing_ontology_license	https://github.com/ontodev/robot/examples/edit.ow
 ERROR	missing_ontology_title	https://github.com/ontodev/robot/examples/edit.owl	dc11:title	
 WARN	duplicate_label_synonym	UBERON:0000949	oboInOwl:hasExactSynonym	endocrine system
 WARN	duplicate_label_synonym	UBERON:0001851	oboInOwl:hasExactSynonym	cortex
-WARN	duplicate_scoped_synonym	UBERON:0002368	oboInOwl:hasExactSynonym	ductless gland
 WARN	duplicate_scoped_synonym	UBERON:0002369	oboInOwl:hasExactSynonym	glandula suprarenalis
 WARN	duplicate_scoped_synonym	UBERON:0002368	oboInOwl:hasRelatedSynonym	ductless gland
+WARN	duplicate_scoped_synonym	UBERON:0002368	oboInOwl:hasExactSynonym	ductless gland
 WARN	duplicate_scoped_synonym	UBERON:0002369	oboInOwl:hasRelatedSynonym	glandula suprarenalis
-WARN	missing_definition	BFO:0000050	IAO:0000115	
-WARN	missing_definition	IAO:0000232	IAO:0000115	
+WARN	missing_definition	IAO:0000116	IAO:0000115	
 WARN	missing_definition	obo:UBPROP_0000007	IAO:0000115	
 WARN	missing_definition	IAO:0000115	IAO:0000115	
-WARN	missing_definition	IAO:0000116	IAO:0000115	
+WARN	missing_definition	IAO:0000232	IAO:0000115	
+WARN	missing_definition	BFO:0000050	IAO:0000115	
 WARN	missing_definition	UBERON:0009569	IAO:0000115	
 WARN	annotation_whitespace	obo:UBPROP_0000007	IAO:0000232	Used to connect a class to an adjectival form of its label. For example, a class with label 'intestine' may have a relational adjective 'intestinal'. 
 INFO	missing_superclass	UBERON:0001062	rdfs:subClassOf	

--- a/docs/examples/report.tsv
+++ b/docs/examples/report.tsv
@@ -5,14 +5,14 @@ ERROR	missing_ontology_title	https://github.com/ontodev/robot/examples/edit.owl	
 WARN	annotation_whitespace	obo:UBPROP_0000007	IAO:0000232	Used to connect a class to an adjectival form of its label. For example, a class with label 'intestine' may have a relational adjective 'intestinal'. 
 WARN	duplicate_label_synonym	UBERON:0000949	oboInOwl:hasExactSynonym	endocrine system
 WARN	duplicate_label_synonym	UBERON:0001851	oboInOwl:hasExactSynonym	cortex
+WARN	duplicate_scoped_synonym	UBERON:0002368	oboInOwl:hasExactSynonym	ductless gland
+WARN	duplicate_scoped_synonym	UBERON:0002369	oboInOwl:hasExactSynonym	glandula suprarenalis
+WARN	duplicate_scoped_synonym	UBERON:0002368	oboInOwl:hasRelatedSynonym	ductless gland
+WARN	duplicate_scoped_synonym	UBERON:0002369	oboInOwl:hasRelatedSynonym	glandula suprarenalis
 WARN	missing_definition	BFO:0000050	IAO:0000115	
+WARN	missing_definition	IAO:0000232	IAO:0000115	
+WARN	missing_definition	obo:UBPROP_0000007	IAO:0000115	
 WARN	missing_definition	IAO:0000115	IAO:0000115	
 WARN	missing_definition	IAO:0000116	IAO:0000115	
-WARN	missing_definition	IAO:0000232	IAO:0000115	
 WARN	missing_definition	UBERON:0009569	IAO:0000115	
-WARN	missing_definition	obo:UBPROP_0000007	IAO:0000115	
-WARN	duplicate_scoped_synonym	UBERON:0002368	oboInOwl:hasExactSynonym	ductless gland
-WARN	duplicate_scoped_synonym	UBERON:0002368	oboInOwl:hasRelatedSynonym	ductless gland
-WARN	duplicate_scoped_synonym	UBERON:0002369	oboInOwl:hasExactSynonym	glandula suprarenalis
-WARN	duplicate_scoped_synonym	UBERON:0002369	oboInOwl:hasRelatedSynonym	glandula suprarenalis
 INFO	missing_superclass	UBERON:0001062	rdfs:subClassOf	

--- a/docs/examples/report.tsv
+++ b/docs/examples/report.tsv
@@ -2,7 +2,6 @@ Level	Rule Name	Subject	Property	Value
 ERROR	missing_ontology_description	https://github.com/ontodev/robot/examples/edit.owl	dc11:description	
 ERROR	missing_ontology_license	https://github.com/ontodev/robot/examples/edit.owl	dc:license	
 ERROR	missing_ontology_title	https://github.com/ontodev/robot/examples/edit.owl	dc11:title	
-WARN	annotation_whitespace	obo:UBPROP_0000007	IAO:0000232	Used to connect a class to an adjectival form of its label. For example, a class with label 'intestine' may have a relational adjective 'intestinal'. 
 WARN	duplicate_label_synonym	UBERON:0000949	oboInOwl:hasExactSynonym	endocrine system
 WARN	duplicate_label_synonym	UBERON:0001851	oboInOwl:hasExactSynonym	cortex
 WARN	duplicate_scoped_synonym	UBERON:0002368	oboInOwl:hasExactSynonym	ductless gland
@@ -15,4 +14,5 @@ WARN	missing_definition	obo:UBPROP_0000007	IAO:0000115
 WARN	missing_definition	IAO:0000115	IAO:0000115	
 WARN	missing_definition	IAO:0000116	IAO:0000115	
 WARN	missing_definition	UBERON:0009569	IAO:0000115	
+WARN	annotation_whitespace	obo:UBPROP_0000007	IAO:0000232	Used to connect a class to an adjectival form of its label. For example, a class with label 'intestine' may have a relational adjective 'intestinal'. 
 INFO	missing_superclass	UBERON:0001062	rdfs:subClassOf	

--- a/robot-command/src/test/java/org/obolibrary/robot/CommandLineIT.java
+++ b/robot-command/src/test/java/org/obolibrary/robot/CommandLineIT.java
@@ -155,6 +155,8 @@ public class CommandLineIT {
                 + "'");
       }
 
+      // Check for file differences
+      boolean hasDiff = false;
       if (resultFile.getName().endsWith(".owl") || resultFile.getName().endsWith(".ttl")) {
         // Compare OWL files using Differ
         OWLOntology exampleOnt =
@@ -164,13 +166,7 @@ public class CommandLineIT {
 
         Differ.BasicDiff diff = Differ.diff(exampleOnt, resultOnt);
         if (!diff.isEmpty()) {
-          throw new Exception(
-              "Integration test ontology '"
-                  + resultsPath
-                  + resultFile.getName()
-                  + "' is different from example ontology '"
-                  + examplePath
-                  + "'");
+          hasDiff = true;
         }
       } else if (resultFile.getName().endsWith(".tsv")) {
         // Read TSVs as sets of lines and compare ignoring ordering differences
@@ -183,41 +179,25 @@ public class CommandLineIT {
         exampleLines.removeAll(resultLines);
         // Check for extra lines
         resultLines.removeAll(exampleCopy);
-        if (!exampleLines.isEmpty() && !resultLines.isEmpty()) {
-          throw new Exception(
-              String.format(
-                      "Integration test file '%s' contains %d lines not in example file:",
-                      resultsPath + resultFile.getName(), resultLines.size())
-                  + String.join("\n\t", resultLines)
-                  + "\n\n"
-                  + String.format(
-                      "Integration test file '%s' is missing %d lines from example file:",
-                      resultsPath + resultFile.getName(), exampleLines.size())
-                  + String.join("\n\t", exampleLines));
-        } else if (!exampleLines.isEmpty()) {
-          throw new Exception(
-              String.format(
-                      "Integration test file '%s' is missing %d lines from example file:",
-                      resultsPath + resultFile.getName(), exampleLines.size())
-                  + String.join("\n\t", exampleLines));
-        } else if (!resultLines.isEmpty()) {
-          throw new Exception(
-              String.format(
-                      "Integration test file '%s' contains %d lines not in example file:",
-                      resultsPath + resultFile.getName(), resultLines.size())
-                  + String.join("\n\t", resultLines));
+        if (!exampleLines.isEmpty() || !resultLines.isEmpty()) {
+          hasDiff = true;
         }
       } else {
         // Compare all other files
         if (!FileUtils.contentEquals(exampleFile, resultFile)) {
-          throw new Exception(
-              "Integration test file '"
-                  + resultsPath
-                  + resultFile.getName()
-                  + "' is different from example file '"
-                  + examplePath
-                  + "'");
+          hasDiff = true;
         }
+      }
+
+      // Throw exception on any diff
+      if (hasDiff) {
+        throw new Exception(
+            "Integration test ontology '"
+                + resultsPath
+                + resultFile.getName()
+                + "' is different from example ontology '"
+                + examplePath
+                + "'");
       }
     }
   }

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -288,8 +288,7 @@ public class ReportOperation {
       }
       queryString = String.join("\n", lines);
       // Use the query to get violations
-      List<Violation> violations =
-          getViolations(ioHelper, dataset, queryName, queryString, options);
+      Set<Violation> violations = getViolations(ioHelper, dataset, queryName, queryString, options);
       // If violations is not returned properly, the query did not have the correct format
       if (violations == null) {
         throw new Exception(String.format(missingEntityBinding, queryName));
@@ -440,8 +439,7 @@ public class ReportOperation {
       }
       queryString = String.join("\n", lines);
       // Use the query to get violations
-      List<Violation> violations =
-          getViolations(ioHelper, dataset, queryName, queryString, options);
+      Set<Violation> violations = getViolations(ioHelper, dataset, queryName, queryString, options);
       // If violations is not returned properly, the query did not have the correct format
       if (violations == null) {
         throw new Exception(String.format(missingEntityBinding, queryName));
@@ -846,7 +844,7 @@ public class ReportOperation {
    * @return List of Violations
    * @throws IOException on issue parsing query
    */
-  private static List<Violation> getViolations(
+  private static Set<Violation> getViolations(
       IOHelper ioHelper,
       Dataset dataset,
       String queryName,
@@ -910,9 +908,9 @@ public class ReportOperation {
    * @return list of Violation objects
    * @throws Exception on malformed query
    */
-  private static List<Violation> getViolationsFromResults(
+  private static Set<Violation> getViolationsFromResults(
       IOHelper ioHelper, String queryName, ResultSet violationSet, Integer limit) throws Exception {
-    List<Violation> violations = new ArrayList<>();
+    Set<Violation> violations = new HashSet<>();
 
     // Counter for stopping at limit
     int c = 0;

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -20,6 +20,7 @@ import org.apache.jena.tdb.TDBFactory;
 import org.apache.jena.tdb.transaction.TDBTransactionException;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.obolibrary.robot.checks.Report;
+import org.obolibrary.robot.checks.ReportQuery;
 import org.obolibrary.robot.checks.Violation;
 import org.obolibrary.robot.export.Table;
 import org.semanticweb.owlapi.apibinding.OWLManager;
@@ -30,7 +31,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Report issues with an ontology using a series of QC SPARQL queries.
  *
- * @author <a href="mailto:rctauber@gmail.com">Becky Tauber</a>
+ * @author <a href="mailto:rbca.jackson@gmail.com">Rebecca Jackson</a>
  * @author <a href="mailto:james@overton.ca">James A. Overton</a>
  */
 public class ReportOperation {
@@ -261,8 +262,10 @@ public class ReportOperation {
 
     // The profile is a map of rule name and reporting level
     Map<String, String> profile = getProfile(profilePath);
-    // The queries is a map of rule name and query string
-    Map<String, String> queries = getQueryStrings(profile.keySet());
+    // We get the queries for the rules from the profile
+    Set<ReportQuery> reportQueries = getReportQueries(profile);
+
+    Dataset dataset = QueryOperation.loadOntologyAsDataset(ontology, false);
 
     // Create the report object
     Report report;
@@ -272,9 +275,9 @@ public class ReportOperation {
       report = new Report(ontology, useLabels);
     }
 
-    Dataset dataset = QueryOperation.loadOntologyAsDataset(ontology, false);
-    for (String queryName : queries.keySet()) {
-      String fullQueryString = queries.get(queryName);
+    for (ReportQuery rq : reportQueries) {
+      String queryName = rq.getRuleName();
+      String fullQueryString = rq.getQuery();
       String queryString;
       // Remove any comments
       List<String> lines = new ArrayList<>();
@@ -291,9 +294,9 @@ public class ReportOperation {
       if (violations == null) {
         throw new Exception(String.format(missingEntityBinding, queryName));
       }
-      report.addViolations(queryName, profile.get(queryName), violations);
+      rq.addViolations(violations);
+      report.addReportQuery(rq);
     }
-
     return report;
   }
 
@@ -397,8 +400,8 @@ public class ReportOperation {
 
     // The profile is a map of rule name and reporting level
     Map<String, String> profile = getProfile(profilePath);
-    // The queries is a map of rule name and query string
-    Map<String, String> queries = getQueryStrings(profile.keySet());
+    // We get the queries for the rules from the profile
+    Set<ReportQuery> reportQueries = getReportQueries(profile);
 
     boolean useLabels = OptionsHelper.optionIsTrue(options, "labels");
     Map<IRI, String> labelMap = null;
@@ -424,8 +427,9 @@ public class ReportOperation {
     // Create the report object (maybe using labels)
     Report report = new Report(labelMap);
 
-    for (String queryName : queries.keySet()) {
-      String fullQueryString = queries.get(queryName);
+    for (ReportQuery rq : reportQueries) {
+      String queryName = rq.getRuleName();
+      String fullQueryString = rq.getQuery();
       String queryString;
       // Remove any comments
       List<String> lines = new ArrayList<>();
@@ -442,9 +446,9 @@ public class ReportOperation {
       if (violations == null) {
         throw new Exception(String.format(missingEntityBinding, queryName));
       }
-      report.addViolations(queryName, profile.get(queryName), violations);
+      rq.addViolations(violations);
+      report.addReportQuery(rq);
     }
-
     return report;
   }
 
@@ -461,7 +465,7 @@ public class ReportOperation {
   public static boolean processReport(Report report, String outputPath, Map<String, String> options)
       throws IOException {
     // Print violations to terminal
-    Integer violationCount = report.getTotalViolations();
+    int violationCount = report.getTotalViolations();
     if (violationCount != 0) {
       System.out.println("Violations: " + violationCount);
       System.out.println("-----------------");
@@ -610,29 +614,42 @@ public class ReportOperation {
   }
 
   /**
-   * Given a set of rules (either as the default rule names or URL to a file), return a map of the
-   * rule names and the corresponding query strings.
+   * Create a list of ReportQuery objects based on the profile.
    *
-   * @param rules set of rules to get queries for
-   * @return map of rule name and query string
-   * @throws IOException on any issue reading the query file
-   * @throws URISyntaxException on issue converting URL to URI
+   * @param profile Map of rule name to violation level
+   * @return List of Report Query objects
+   * @throws IOException on problem getting query strings
+   * @throws URISyntaxException on problem getting query strings
    */
-  private static Map<String, String> getQueryStrings(Set<String> rules)
+  private static Set<ReportQuery> getReportQueries(Map<String, String> profile)
       throws IOException, URISyntaxException {
+    Set<ReportQuery> reportQueries = new HashSet<>();
     Set<String> defaultRules = new HashSet<>();
     Set<String> userRules = new HashSet<>();
-    Map<String, String> queries = new HashMap<>();
-    for (String rule : rules) {
+    for (String rule : profile.keySet()) {
       if (rule.startsWith("file:")) {
         userRules.add(rule);
       } else {
         defaultRules.add(rule);
       }
     }
-    queries.putAll(getDefaultQueryStrings(defaultRules));
-    queries.putAll(getUserQueryStrings(userRules));
-    return queries;
+
+    Map<String, String> defaultQueryStrings = getDefaultQueryStrings(defaultRules);
+    for (Map.Entry<String, String> qs : defaultQueryStrings.entrySet()) {
+      String ruleName = qs.getKey();
+      String ruleURL = "http://robot.obolibrary.org/report_queries/" + ruleName;
+      ReportQuery rq = new ReportQuery(ruleName, ruleURL, qs.getValue(), profile.get(ruleName));
+      reportQueries.add(rq);
+    }
+    Map<String, String> userQueryStrings = getUserQueryStrings(userRules);
+    for (Map.Entry<String, String> qs : userQueryStrings.entrySet()) {
+      String rulePath = qs.getKey();
+      String ruleName =
+          rulePath.substring(rulePath.lastIndexOf("/") + 1, rulePath.lastIndexOf("."));
+      ReportQuery rq = new ReportQuery(ruleName, qs.getValue(), profile.get(ruleName));
+      reportQueries.add(rq);
+    }
+    return reportQueries;
   }
 
   /**

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -5,13 +5,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import org.apache.commons.io.FileUtils;
@@ -288,7 +282,8 @@ public class ReportOperation {
       }
       queryString = String.join("\n", lines);
       // Use the query to get violations
-      Set<Violation> violations = getViolations(ioHelper, dataset, queryName, queryString, options);
+      List<Violation> violations =
+          getViolations(ioHelper, dataset, queryName, queryString, options);
       // If violations is not returned properly, the query did not have the correct format
       if (violations == null) {
         throw new Exception(String.format(missingEntityBinding, queryName));
@@ -439,7 +434,8 @@ public class ReportOperation {
       }
       queryString = String.join("\n", lines);
       // Use the query to get violations
-      Set<Violation> violations = getViolations(ioHelper, dataset, queryName, queryString, options);
+      List<Violation> violations =
+          getViolations(ioHelper, dataset, queryName, queryString, options);
       // If violations is not returned properly, the query did not have the correct format
       if (violations == null) {
         throw new Exception(String.format(missingEntityBinding, queryName));
@@ -844,7 +840,7 @@ public class ReportOperation {
    * @return List of Violations
    * @throws IOException on issue parsing query
    */
-  private static Set<Violation> getViolations(
+  private static List<Violation> getViolations(
       IOHelper ioHelper,
       Dataset dataset,
       String queryName,
@@ -908,9 +904,9 @@ public class ReportOperation {
    * @return list of Violation objects
    * @throws Exception on malformed query
    */
-  private static Set<Violation> getViolationsFromResults(
+  private static List<Violation> getViolationsFromResults(
       IOHelper ioHelper, String queryName, ResultSet violationSet, Integer limit) throws Exception {
-    Set<Violation> violations = new HashSet<>();
+    List<Violation> violations = new ArrayList<>();
 
     // Counter for stopping at limit
     int c = 0;

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
@@ -268,11 +268,6 @@ public class Report {
       table.addColumn(c);
     }
 
-    // Sort violations by rule name
-    errorViolations.sort(new rqComparator());
-    warnViolations.sort(new rqComparator());
-    infoViolations.sort(new rqComparator());
-
     addToTable(table, provider, ERROR, errorViolations);
     addToTable(table, provider, WARN, warnViolations);
     addToTable(table, provider, INFO, infoViolations);
@@ -299,12 +294,6 @@ public class Report {
    */
   public String toYAML() {
     ShortFormProvider provider = getProvider();
-
-    // Sort violations by rule name
-    errorViolations.sort(new rqComparator());
-    warnViolations.sort(new rqComparator());
-    infoViolations.sort(new rqComparator());
-
     return yamlHelper(provider, ERROR, errorViolations)
         + yamlHelper(provider, WARN, warnViolations)
         + yamlHelper(provider, INFO, infoViolations);
@@ -548,14 +537,6 @@ public class Report {
       }
     }
     return sb.toString();
-  }
-
-  /** */
-  private class rqComparator implements Comparator<ReportQuery> {
-    @Override
-    public int compare(ReportQuery o1, ReportQuery o2) {
-      return o1.getRuleName().compareTo(o2.getRuleName());
-    }
   }
 
   /**

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/ReportQuery.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/ReportQuery.java
@@ -1,7 +1,6 @@
 package org.obolibrary.robot.checks;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class ReportQuery {
@@ -47,7 +46,7 @@ public class ReportQuery {
    *
    * @param vs list of Violations
    */
-  public void addViolations(List<Violation> vs) {
+  public void addViolations(Set<Violation> vs) {
     violations.addAll(vs);
   }
 

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/ReportQuery.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/ReportQuery.java
@@ -1,7 +1,7 @@
 package org.obolibrary.robot.checks;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 public class ReportQuery {
 
@@ -10,7 +10,7 @@ public class ReportQuery {
   private final String query;
   private final String level;
 
-  private final Set<Violation> violations = new HashSet<>();
+  private final List<Violation> violations = new ArrayList<>();
 
   /**
    * Create a new ReportQuery object.
@@ -46,7 +46,7 @@ public class ReportQuery {
    *
    * @param vs list of Violations
    */
-  public void addViolations(Set<Violation> vs) {
+  public void addViolations(List<Violation> vs) {
     violations.addAll(vs);
   }
 
@@ -91,7 +91,7 @@ public class ReportQuery {
    *
    * @return List of Violations
    */
-  public Set<Violation> getViolations() {
+  public List<Violation> getViolations() {
     return violations;
   }
 }

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/ReportQuery.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/ReportQuery.java
@@ -1,0 +1,98 @@
+package org.obolibrary.robot.checks;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ReportQuery {
+
+  private final String ruleName;
+  private final String ruleURL;
+  private final String query;
+  private final String level;
+
+  private final Set<Violation> violations = new HashSet<>();
+
+  /**
+   * Create a new ReportQuery object.
+   *
+   * @param ruleName String name of rule
+   * @param query String query contents
+   * @param level String violation level
+   */
+  public ReportQuery(String ruleName, String query, String level) {
+    this.ruleName = ruleName;
+    this.ruleURL = null;
+    this.query = query;
+    this.level = level;
+  }
+
+  /**
+   * Create a new ReportQuery object.
+   *
+   * @param ruleName String name of rule
+   * @param ruleURL String link to rule documentation
+   * @param query String query contents
+   * @param level String violation level
+   */
+  public ReportQuery(String ruleName, String ruleURL, String query, String level) {
+    this.ruleName = ruleName;
+    this.ruleURL = ruleURL;
+    this.query = query;
+    this.level = level;
+  }
+
+  /**
+   * Add multiple violations to this ReportQuery.
+   *
+   * @param vs list of Violations
+   */
+  public void addViolations(List<Violation> vs) {
+    violations.addAll(vs);
+  }
+
+  /**
+   * Return the violation level of this ReportQuery.
+   *
+   * @return String level
+   */
+  public String getLevel() {
+    return level;
+  }
+
+  /**
+   * Return the query contents of this ReportQuery.
+   *
+   * @return String SPARQL query contents
+   */
+  public String getQuery() {
+    return query;
+  }
+
+  /**
+   * Return the name of the rule for this ReportQuery.
+   *
+   * @return String rule name
+   */
+  public String getRuleName() {
+    return ruleName;
+  }
+
+  /**
+   * Return the URL for rule documentation (or null) for this ReportQuery.
+   *
+   * @return String rule documentation URL
+   */
+  public String getRuleURL() {
+    return ruleURL;
+  }
+
+  /**
+   * Return the collection of violations for this ReportQuery.
+   *
+   * @return List of Violations
+   */
+  public Set<Violation> getViolations() {
+    return violations;
+  }
+}

--- a/robot-core/src/main/java/org/obolibrary/robot/export/Cell.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/export/Cell.java
@@ -11,12 +11,12 @@ import org.apache.poi.ss.usermodel.IndexedColors;
 public class Cell {
 
   // Column object used to build this cell
-  private Column column;
+  private final Column column;
 
   // List of output values for this cell
-  private List<CellValue> values = new ArrayList<>();
+  private final List<CellValue> values = new ArrayList<>();
 
-  private List<String> displayValues = new ArrayList<>();
+  private final List<String> displayValues = new ArrayList<>();
   private String sortValueString;
 
   // Styles for XLSX output
@@ -26,6 +26,8 @@ public class Cell {
 
   // Styles for HTML output
   private String htmlClass = null;
+  // Option to add a link to a value (separate from rendered entities)
+  private String href = null;
 
   // Comment can appear as an XLSX Comment or an HTML tooltip
   // This is not required and can be returned null
@@ -147,6 +149,15 @@ public class Cell {
   }
 
   /**
+   * Get an href link for the cell or null.
+   *
+   * @return String link or null
+   */
+  public String getHref() {
+    return href;
+  }
+
+  /**
    * Get the font color for this cell in an XLSX workbook.
    *
    * @return IndexedColors value for font
@@ -189,6 +200,15 @@ public class Cell {
    */
   public void setComment(String comment) {
     this.comment = comment;
+  }
+
+  /**
+   * Add a link to this Cell.
+   *
+   * @param href String href link
+   */
+  public void setHref(String href) {
+    this.href = href;
   }
 
   /**

--- a/robot-core/src/main/java/org/obolibrary/robot/export/Row.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/export/Row.java
@@ -249,6 +249,12 @@ public class Row {
         value = String.join(split, values);
         htmlClass = cell.getHTMLClass();
         comment = cell.getComment();
+
+        // Maybe wrap cell in href (separate from rendered entities)
+        String href = cell.getHref();
+        if (href != null) {
+          value = String.format("<a href=\"%s\">%s</a>", href, value);
+        }
       } else {
         value = "";
       }


### PR DESCRIPTION
This is an alternative to #875 that allows us more flexibility in the future. Resolves #871.

- [ ] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

This adds a new `ReportQuery` object that carries the details of the "rules" including rule name, query contents, violation level, a list of the found violations, and an optional URL for documentation. If you are generating an HTML report, the default report queries will have links to their documentation.
