### PR TITLE
Small tweak to verify docs

### DIFF
--- a/docs/verify.md
+++ b/docs/verify.md
@@ -3,7 +3,7 @@
 The `verify` command is used to check an ontology for violations of rules. Each rule is expressed as a SPARQL SELECT query that matches violations of the rule. If the query produces any results, `verify` will exit with an error message that reports the violations. If the ontology conforms to the rule, the query should find no violations, and the `verify` command will succeed.
 
 In the `verify` command, you specify a set of queries using the `--queries` parameter and
-specifying an output directory for the result using the `--output-dir` paramter,
+specify an output directory for the result using the `--output-dir` parameter,
 e.g. `--queries` query-file-1 query-file-2 ... `--output-dir` some-directory
 
 For example:

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -2,10 +2,9 @@
 
 The `verify` command is used to check an ontology for violations of rules. Each rule is expressed as a SPARQL SELECT query that matches violations of the rule. If the query produces any results, `verify` will exit with an error message that reports the violations. If the ontology conforms to the rule, the query should find no violations, and the `verify` command will succeed.
 
-You can use `verify` in two ways:
-
-1. `--query` query-file output-file
-2. `--queries` query-file-1 query-file-2 ... `--output-dir` some-directory
+In the `verify` command, you specify a set of queries using the `--queries` parameter and
+specifying an output directory for the result using the `--output-dir` paramter,
+e.g. `--queries` query-file-1 query-file-2 ... `--output-dir` some-directory
 
 For example:
 
@@ -44,4 +43,4 @@ At least one of the query you specifies returned results. The number of failures
 
 ### Missing Query Error
 
-You must specify a query to execute with `--query` or `--queries`.
+You must specify at least one query to execute with `--queries`.


### PR DESCRIPTION


- [X] `docs/` have been added/updated

The verify docs claimed that you can use verify with the `--query` parameter, which in my experience is not true.

```
robot --catalog catalog-v001.xml verify -i tmp/ncit-neoplasm.owl --query ../sparql/unittest/ncit-cancer.sparql $@
UNKNOWN ARG ERROR unknown command or option: --query
```
