### PR TITLE
Add check for malformed IRI in IOHelper.createIRI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix behaviour of `--preserve-structure` when using internal or external axiom selectors for [`remove`] or [`filter`] [#816]
 - Fix value rendering for entities in [`report`] [#874]
 
+### Changed
+- Do not allow malformed IRIs to be returned by `IOHelper` [#882]
+
 ## [1.8.1] - 2021-01-27
 
 ### Fixed
@@ -253,6 +256,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#882]: https://github.com/ontodev/robot/pull/882
 [#874]: https://github.com/ontodev/robot/pull/874
 [#858]: https://github.com/ontodev/robot/pull/858
 [#850]: https://github.com/ontodev/robot/pull/850

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -17,6 +17,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.zip.*;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -929,12 +930,24 @@ public class IOHelper {
       return null;
     }
 
-    try {
-      // Check for malformed URL, e.g., a CURIE was returned or the value passed has spaces
-      new URL(iri.toString());
-    } catch (MalformedURLException e) {
-      // Invalid IRI
-      return null;
+    if (iri.toString().startsWith("urn:")) {
+      // A URN is not a valid URL, so we check it with regex
+      Pattern urnPattern =
+          Pattern.compile(
+              "^urn:[a-z0-9][a-z0-9-]{0,31}:([a-z0-9()+,\\-.:=@;$_!*']|%[0-9a-f]{2})+$",
+              Pattern.CASE_INSENSITIVE);
+      if (!urnPattern.matcher(iri.toString()).matches()) {
+        // Not a valid URN (RFC2141)
+        return null;
+      }
+    } else {
+      try {
+        // Check for malformed URL, e.g., a CURIE was returned or the value passed has spaces
+        new URL(iri.toString());
+      } catch (MalformedURLException e) {
+        // Invalid IRI
+        return null;
+      }
     }
 
     return iri;

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -13,6 +13,7 @@ import com.google.common.collect.Sets;
 import com.opencsv.*;
 import java.io.*;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.*;
@@ -928,10 +929,14 @@ public class IOHelper {
       return null;
     }
 
-    if (iri.toString().contains(" ")) {
+    try {
+      // Check for malformed URL, e.g., a CURIE was returned or the value passed has spaces
+      new URL(iri.toString());
+    } catch (MalformedURLException e) {
       // Invalid IRI
       return null;
     }
+
     return iri;
   }
 

--- a/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
@@ -1,6 +1,7 @@
 package org.obolibrary.robot;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import com.github.jsonldjava.core.Context;
 import java.io.ByteArrayInputStream;
@@ -54,6 +55,32 @@ public class IOHelperTest extends CoreTest {
     // Get the context back from IOHelper
     String outputContext = ioh.getContextString();
     assertEquals(inputContext, outputContext);
+  }
+
+  /**
+   * Test creating a series of valid and invalid IRIs from strings.
+   *
+   * @throws IOException on problem creating IOHelper
+   */
+  @Test
+  public void testCreateIRI() throws IOException {
+    IOHelper ioh = new IOHelper();
+
+    // Valid IRIs
+    IRI iri = ioh.createIRI("OBI:0000070");
+    assertEquals(IRI.create("http://purl.obolibrary.org/obo/OBI_0000070"), iri);
+    iri = ioh.createIRI("http://purl.obolibrary.org/obo/obi.owl");
+    assertEquals(IRI.create("http://purl.obolibrary.org/obo/obi.owl"), iri);
+    iri = ioh.createIRI("urn:isbn:0451450523");
+    assertEquals(IRI.create("urn:isbn:0451450523"), iri);
+
+    // Invalid IRIs should always return null
+    iri = ioh.createIRI("EXAMPLE:0000070");
+    assertNull(iri);
+    iri = ioh.createIRI("urn:0451450523");
+    assertNull(iri);
+    iri = ioh.createIRI("This is an example definition.");
+    assertNull(iri);
   }
 
   /**


### PR DESCRIPTION
Resolves #880

- [ ] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

This is a bit more sane than trying to do a regex match for a valid URL. If the output IRI is just a CURIE, this will fail (e.g., undefined prefix when running `template`). If the output IRI has a space it it, this will also fail (which we were just checking for a space before).