### PR TITLE
884 fix patch

### DIFF
--- a/robot-core/src/main/resources/report_queries/deprecated_class_reference.rq
+++ b/robot-core/src/main/resources/report_queries/deprecated_class_reference.rq
@@ -20,6 +20,7 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
            ?property ?value .
    FILTER ( ?value NOT IN (oboInOwl:ObsoleteClass, owl:Thing) )
   }
+  UNION
   {
    VALUES ?property {
      owl:equivalentClass
@@ -68,11 +69,13 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
      owl:someValuesFrom   
      owl:allValuesFrom
    }
-   ?entity a owl:Class ;
+   ?value a owl:Class ;
           owl:deprecated true .
+   ?e ?x ?rest .
    ?rest a owl:Restriction ;
-         ?property ?entity .
-   FILTER(isBlank(?entity))
+         ?property ?value .
+   FILTER(isBlank(?e))
+   BIND("Use in anonymous expression" as ?entity)
   }
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/deprecated_class_reference.rq
+++ b/robot-core/src/main/resources/report_queries/deprecated_class_reference.rq
@@ -29,7 +29,6 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
    ?entity a owl:Class;
            owl:deprecated true ;
            ?property ?value .
-   FILTER ( ?value != oboInOwl:ObsoleteClass )
   }
   UNION
   {
@@ -75,7 +74,7 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
    ?rest a owl:Restriction ;
          ?property ?value .
    FILTER(isBlank(?e))
-   BIND("Use in anonymous expression" as ?entity)
+   BIND("anonymous expression" as ?entity)
   }
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/deprecated_class_reference.rq
+++ b/robot-core/src/main/resources/report_queries/deprecated_class_reference.rq
@@ -72,7 +72,6 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
           owl:deprecated true .
    ?rest a owl:Restriction ;
          ?property ?entity .
-   BIND("Use in nested expression" as ?entity)
    FILTER(isBlank(?entity))
   }
 }

--- a/robot-core/src/main/resources/report_queries/deprecated_class_reference.rq
+++ b/robot-core/src/main/resources/report_queries/deprecated_class_reference.rq
@@ -20,7 +20,7 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
    ?entity a owl:Class;
            owl:deprecated true ;
            ?property ?value .
-   FILTER ( ?value != oboInOwl:ObsoleteClass )
+   FILTER ( ?value NOT IN (oboInOwl:ObsoleteClass, owl:Thing) )
   }
   UNION
   {
@@ -28,7 +28,7 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
        rdfs:subClassOf
      }
      ?entity a owl:Class;
-             owl:deprecated true .
+             owl:deprecated true .  
      ?value ?property ?entity .
   }
   UNION
@@ -52,6 +52,20 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
    ?entity ?x ?rest .
    ?rest a owl:Restriction ;
          ?property ?value .
+   FILTER(!isBlank(?entity))
+  }
+  UNION
+  {
+   VALUES ?property {
+     owl:someValuesFrom   
+     owl:allValuesFrom
+   }
+   ?entity a owl:Class ;
+          owl:deprecated true .
+   ?rest a owl:Restriction ;
+         ?property ?entity .
+   BIND("Use in nested expression" as ?entity)
+   FILTER(isBlank(?entity))
   }
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/deprecated_class_reference.rq
+++ b/robot-core/src/main/resources/report_queries/deprecated_class_reference.rq
@@ -13,14 +13,22 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 SELECT DISTINCT ?entity ?property ?value WHERE {
   {
    VALUES ?property {
-     owl:equivalentClass
      rdfs:subClassOf
-     owl:disjointWith
    }
    ?entity a owl:Class;
            owl:deprecated true ;
            ?property ?value .
    FILTER ( ?value NOT IN (oboInOwl:ObsoleteClass, owl:Thing) )
+  }
+  {
+   VALUES ?property {
+     owl:equivalentClass
+     owl:disjointWith
+   }
+   ?entity a owl:Class;
+           owl:deprecated true ;
+           ?property ?value .
+   FILTER ( ?value != oboInOwl:ObsoleteClass )
   }
   UNION
   {


### PR DESCRIPTION
Two suggestions @beckyjackson :

1) We should ignore `some-obsolete subclassOf Thing.` this error is so frequent, it will totally pollute the test.
2) In an attempt to reduce spurious diffs over ROBOT report (see https://github.com/ontodev/robot/issues/873) I would suggest to avoid blank nodes in robot report.