### PR TITLE
Fix input patterns with parent directories in merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix behaviour of `--preserve-structure` when using internal or external axiom selectors for [`remove`] or [`filter`] [#816]
 - Fix duplicate_label_synonym [#864]
 - Fix value rendering for entities in [`report`] [#874]
+- Fix `merge --inputs` patterns with parent directories [#899]
 
 ### Changed
 - Do not allow malformed IRIs to be returned by `IOHelper` [#882]
@@ -265,6 +266,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#899]: https://github.com/ontodev/robot/pull/899
 [#882]: https://github.com/ontodev/robot/pull/882
 [#874]: https://github.com/ontodev/robot/pull/874
 [#872]: https://github.com/ontodev/robot/pull/872

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
@@ -1032,11 +1032,24 @@ public class CommandLineHelper {
     if (!pattern.contains("*") && !pattern.contains("?")) {
       throw new IllegalArgumentException(wildcardError);
     }
-    FileFilter fileFilter = new WildcardFileFilter(pattern);
-    File[] files = new File(".").listFiles(fileFilter);
+    // Get the parent directory path
+    File filePattern = new File(pattern);
+    String dir = filePattern.getParent();
+    if (dir == null) {
+      dir = ".";
+    }
+    // Make sure this directory exists
+    if (!new File(dir).isDirectory()) {
+      // Warn user, but continue (empty input checked later)
+      logger.error("'{}' is not a valid directory for --inputs pattern", dir);
+      return new File[] {};
+    }
+    FileFilter fileFilter = new WildcardFileFilter(filePattern.getName());
+    File[] files = new File(dir).listFiles(fileFilter);
     if (files == null || files.length < 1) {
       // Warn user, but continue (empty input checked later)
       logger.error("No files match pattern: {}", pattern);
+      return new File[] {};
     }
     return files;
   }


### PR DESCRIPTION
Resolves #898

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated
