### PR TITLE
Handle error when saving as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix duplicate_label_synonym [#864]
 - Fix value rendering for entities in [`report`] [#874]
 - Fix OBO serialisation issues when using `--check false` [#896]
+- Fix error handling for JSON conversion [#907]
 
 ### Changed
 - Do not allow malformed IRIs to be returned by `IOHelper` [#882]
@@ -266,7 +267,10 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#907]: https://github.com/ontodev/robot/pull/907
+[#896]: https://github.com/ontodev/robot/pull/896
 [#882]: https://github.com/ontodev/robot/pull/882
+[#879]: https://github.com/ontodev/robot/pull/879
 [#874]: https://github.com/ontodev/robot/pull/874
 [#872]: https://github.com/ontodev/robot/pull/872
 [#865]: https://github.com/ontodev/robot/pull/865

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -96,6 +96,17 @@ Some commands ([extract](/extract) and [filter](/filter)) require terms as input
 
 For all commands other than [merge](/merge) and [unmerge](/unmerge), only one `--input` may be specified.
 
+### OBO Graph Error
+
+This error occurs when ROBOT is unable to convert the ontology into an [OBO Graphs](https://github.com/geneontology/obographs) object while saving an ontology in JSON format. This may be due to problematic annotations, so you can create a subset using [filter](/filter) or [remove](/remove) containing only the necessary annotations and save that as JSON, for example (keeping only labels and definitions):
+```
+robot remove --input ont.owl \
+  --select annotation-properties \
+  --exclude-term rdfs:label \
+  --exclude-term IAO:0000115 \
+  --output ont.json
+```
+
 ### OBO Structure Error
 
 When running the [convert](/convert) command, if `--check` is true (default behavior), the [document structure rules](http://owlcollab.github.io/oboformat/doc/obo-syntax.html#4) are strictly enforced. If you are saving an ontology in OBO format from another command, `--check` is always `true`. 

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -96,6 +96,11 @@ public class IOHelper {
   private static final String jsonldContextParseError =
       NS + "JSON-LD CONTEXT PARSE ERROR Could not parse the JSON-LD context.";
 
+  /** Error message when a graph object cannot be created from the ontology using obographs. */
+  private static final String oboGraphError =
+      NS
+          + "OBO GRAPH ERROR Could not convert ontology to OBO Graph (see https://github.com/geneontology/obographs)";
+
   /** Error message when OBO cannot be saved. */
   private static final String oboStructureError =
       NS + "OBO STRUCTURE ERROR Ontology does not conform to OBO structure rules:\n%s";
@@ -1708,7 +1713,12 @@ public class IOHelper {
 
     if (format instanceof OboGraphJsonDocumentFormat) {
       FromOwl fromOwl = new FromOwl();
-      GraphDocument gd = fromOwl.generateGraphDocument(ontology);
+      GraphDocument gd;
+      try {
+        gd = fromOwl.generateGraphDocument(ontology);
+      } catch (Exception e) {
+        throw new IOException(oboGraphError);
+      }
       File outfile = new File(ontologyIRI.toURI());
       ObjectMapper mapper = new ObjectMapper();
       mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);


### PR DESCRIPTION
Resolves #906

- [x] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

### OBO Graph Error

This error occurs when ROBOT is unable to convert the ontology into an [OBO Graphs](https://github.com/geneontology/obographs) object while saving an ontology in JSON format. This may be due to problematic annotations, so you can create a subset using [filter](/filter) or [remove](/remove) containing only the necessary annotations and save that as JSON, for example (keeping only labels and definitions):
```
robot remove --input ont.owl \
  --select annotation-properties \
  --exclude-term rdfs:label \
  --exclude-term IAO:0000115 \
  --output ont.json
```
