### PR TITLE
Move all Scala dependencies to 2.13.

### DIFF
--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -13,7 +13,7 @@
   <description>Core library for ROBOT: Library for working with OWL ontologies, especially Open Biological and Biomedical Ontologes (OBO).</description>
 
   <properties>
-    <scala.version>2.12</scala.version>
+    <scala.version>2.13</scala.version>
   </properties>
 
   <build>


### PR DESCRIPTION
Changing from Scala 2.12 to 2.13. Dependencies are published for both, but 2.12 is getting old and I will stop publishing for it in the future. Should be a transparent change.