### PR TITLE
Change println to logging in tests

### DIFF
--- a/robot-core/src/test/java/org/obolibrary/robot/CoreTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/CoreTest.java
@@ -11,15 +11,17 @@ import java.net.URISyntaxException;
 import java.util.Set;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Helper methods for core tests. */
 public class CoreTest {
+  /** Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(CoreTest.class);
+
   /** Base IRI string for resources files. */
   protected static String base =
       "https://github.com/" + "ontodev/robot/" + "robot-core/" + "src/test/resources/";
-
-  /** IRI of simple ontology. */
-  protected static IRI simpleIRI = IRI.create(base + "simple.owl");
 
   /** Shared data factory. */
   protected static OWLDataFactory dataFactory = OWLManager.getOWLDataFactory();
@@ -91,7 +93,7 @@ public class CoreTest {
   public void assertIdentical(OWLOntology left, OWLOntology right) throws IOException {
     StringWriter writer = new StringWriter();
     boolean actual = DiffOperation.compare(left, right, writer);
-    System.out.println(writer.toString());
+    logger.debug(writer.toString());
     assertTrue(actual);
     assertEquals("Ontologies are identical\n", writer.toString());
   }

--- a/robot-core/src/test/java/org/obolibrary/robot/DiffOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/DiffOperationTest.java
@@ -17,9 +17,14 @@ import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Tests for DiffOperation. */
 public class DiffOperationTest extends CoreTest {
+  /** Logger. */
+  private static final Logger logger = LoggerFactory.getLogger(DiffOperationTest.class);
+
   /**
    * Compare one ontology to itself.
    *
@@ -52,7 +57,7 @@ public class DiffOperationTest extends CoreTest {
 
     StringWriter writer = new StringWriter();
     boolean actual = DiffOperation.compare(simple, simple1, writer);
-    System.out.println(writer.toString());
+    logger.debug(writer.toString());
     assertFalse(actual);
     String expected =
         IOUtils.toString(
@@ -74,7 +79,7 @@ public class DiffOperationTest extends CoreTest {
     Map<String, String> options = new HashMap<>();
     options.put("labels", "true");
     boolean actual = DiffOperation.compare(simple, elk, new IOHelper(), writer, options);
-    System.out.println(writer.toString());
+    logger.debug(writer.toString());
     assertFalse(actual);
     String expected =
         IOUtils.toString(

--- a/robot-core/src/test/java/org/obolibrary/robot/QuotedEntityCheckerTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/QuotedEntityCheckerTest.java
@@ -73,7 +73,6 @@ public class QuotedEntityCheckerTest extends CoreTest {
     checker.setIOHelper(ioHelper);
     Assert.assertEquals(cls, checker.getOWLClass("GO:XXXX"));
 
-    System.out.println("PARSER");
     ManchesterOWLSyntaxClassExpressionParser parser =
         new ManchesterOWLSyntaxClassExpressionParser(
             dataFactory, checker


### PR DESCRIPTION
Resolves #838

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

I used the debug level on the logger so it doesn't automatically display them unless you tweak the logging properties, but I think that's OK. The tests still show some error messages from unparsed triples, but that might change to warning with #829.
