### PR TITLE
Clarify format of terms.txt file

### DIFF
--- a/docs/extract.md
+++ b/docs/extract.md
@@ -18,7 +18,9 @@ The reuse of ontology terms creates links between data, making the ontology and 
         --term-file uberon_module.txt \
         --output results/uberon_module.owl
 
-See <a href="/examples/uberon_module.txt" target="_blank">`uberon_module.txt`</a> for an example of a term file. Terms should be listed line by line, and comments can be included with `#`. Individual terms can be specified with `--term` followed by the CURIE.
+See <a href="/examples/uberon_module.txt" target="_blank">`uberon_module.txt`</a> for an example of a term file. Terms should be listed line by line in either CURIE form or full IRI, and comments can be included with one or more whitespace characters after the term followed by `#` and then the comment.
+
+Alternatively, individual terms can be specified with `--term` followed by the CURIE (or full URI).
 
 The `--method` options fall into two groups: Syntactic Locality Module Extractor (SLME) and Minimum Information to Reference an External Ontology Term (MIREOT).
 


### PR DESCRIPTION
This is documentation so I don't think the below applies

Resolves [#ISSUE, resolves #ISSUE]

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

[DESCRIPTION, mentioning relevant #ISSUE]
