### PR TITLE
Fix Issue: SPLIT fails with owl:NamedIndividual #924

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `deprecated_class_reference` [`report`] query [#902]
 - Fix error handling for JSON conversion [#907]
 - Fix handling of property chains when removing/filtering base axioms in [#914]
+- Fix SPLIT unpacking in named individuals in [`template`] [#924]
 
 ### Changed
 - Do not allow malformed IRIs to be returned by `IOHelper` [#882]
@@ -276,6 +277,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#924]: https://github.com/ontodev/robot/issues/924
 [#914]: https://github.com/ontodev/robot/pull/914
 [#907]: https://github.com/ontodev/robot/pull/907
 [#902]: https://github.com/ontodev/robot/pull/902

--- a/robot-core/src/main/java/org/obolibrary/robot/Template.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/Template.java
@@ -1881,6 +1881,10 @@ public class Template {
 
       // Handle annotations
       if (template.startsWith("A") || template.startsWith("LABEL")) {
+        if (split != null) {
+          // Add the split back on for getAnnotations
+          template = template + " SPLIT=" + split;
+        }
         // Add the annotations to the individual
         Set<OWLAnnotation> annotations = getAnnotations(template, value, row, column);
         for (OWLAnnotation annotation : annotations) {

--- a/robot-core/src/test/java/org/obolibrary/robot/TemplateTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/TemplateTest.java
@@ -157,7 +157,7 @@ public class TemplateTest extends CoreTest {
         TemplateHelper.tryParse("test", checker, parser, label, 0, 0).asOWLClass();
     assert actualClass.getIRI().toString().equals(expectedClass.getIRI().toString());
   }
-  
+
   /**
    * Test named individual with split property.
    *
@@ -165,11 +165,11 @@ public class TemplateTest extends CoreTest {
    */
   @Test
   public void testNamedIndividualSplit() throws Exception {
-	Map<String, String> options = TemplateOperation.getDefaultOptions();
-	IOHelper ioHelper = new IOHelper();
-	ioHelper.addPrefix("ex", "http://example.com/");
-	
-	Map<String, List<List<String>>> tables = new LinkedHashMap<>();
+    Map<String, String> options = TemplateOperation.getDefaultOptions();
+    IOHelper ioHelper = new IOHelper();
+    ioHelper.addPrefix("ex", "http://example.com/");
+
+    Map<String, List<List<String>>> tables = new LinkedHashMap<>();
     String path = "/template-individual-split.csv";
     tables.put(path, TemplateHelper.readCSV(this.getClass().getResourceAsStream(path)));
 
@@ -177,8 +177,13 @@ public class TemplateTest extends CoreTest {
 
     assertEquals("Count individuals", 1, ontology.getIndividualsInSignature().size());
     OWLNamedIndividual namedIndividual = ontology.getIndividualsInSignature().iterator().next();
-    assertEquals("Count annotation properties", 1, ontology.getAnnotationPropertiesInSignature().size());
-    OWLAnnotationProperty annotationProperty = ontology.getAnnotationPropertiesInSignature().iterator().next();
-    assertEquals("Count data properties of individual", 2, EntitySearcher.getAnnotationObjects(namedIndividual, ontology, annotationProperty).size());
+    assertEquals(
+        "Count annotation properties", 1, ontology.getAnnotationPropertiesInSignature().size());
+    OWLAnnotationProperty annotationProperty =
+        ontology.getAnnotationPropertiesInSignature().iterator().next();
+    assertEquals(
+        "Count annotation properties of individual",
+        2,
+        EntitySearcher.getAnnotationObjects(namedIndividual, ontology, annotationProperty).size());
   }
 }

--- a/robot-core/src/test/java/org/obolibrary/robot/TemplateTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/TemplateTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.manchestersyntax.parser.ManchesterOWLSyntaxClassExpressionParser;
 import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.search.EntitySearcher;
 
 /**
  * Tests Template class and class methods.
@@ -155,5 +156,29 @@ public class TemplateTest extends CoreTest {
     OWLClass actualClass =
         TemplateHelper.tryParse("test", checker, parser, label, 0, 0).asOWLClass();
     assert actualClass.getIRI().toString().equals(expectedClass.getIRI().toString());
+  }
+  
+  /**
+   * Test named individual with split property.
+   *
+   * @throws Exception if entities cannot be found
+   */
+  @Test
+  public void testNamedIndividualSplit() throws Exception {
+	Map<String, String> options = TemplateOperation.getDefaultOptions();
+	IOHelper ioHelper = new IOHelper();
+	ioHelper.addPrefix("ex", "http://example.com/");
+	
+	Map<String, List<List<String>>> tables = new LinkedHashMap<>();
+    String path = "/template-individual-split.csv";
+    tables.put(path, TemplateHelper.readCSV(this.getClass().getResourceAsStream(path)));
+
+    OWLOntology ontology = TemplateOperation.template(null, ioHelper, tables, options);
+
+    assertEquals("Count individuals", 1, ontology.getIndividualsInSignature().size());
+    OWLNamedIndividual namedIndividual = ontology.getIndividualsInSignature().iterator().next();
+    assertEquals("Count annotation properties", 1, ontology.getAnnotationPropertiesInSignature().size());
+    OWLAnnotationProperty annotationProperty = ontology.getAnnotationPropertiesInSignature().iterator().next();
+    assertEquals("Count data properties of individual", 2, EntitySearcher.getAnnotationObjects(namedIndividual, ontology, annotationProperty).size());
   }
 }

--- a/robot-core/src/test/resources/template-individual-split.csv
+++ b/robot-core/src/test/resources/template-individual-split.csv
@@ -1,0 +1,3 @@
+ID,Entity Type,Synonyms
+ID,TYPE,A IAO:0000118 SPLIT=|
+ex:indv_1,owl:NamedIndividual,synonym 1|synonym 2


### PR DESCRIPTION
Resolves [#924]

- [No] `docs/` have been added/updated
- [OK] tests have been added/updated
- [OK] `mvn verify` says all tests pass
- [OK] `mvn site` says all JavaDocs correct
- [OK] `CHANGELOG.md` has been updated

Split command was not working properly with owl:NamedIndividual, since SPLIT definitions were deleted from the template while creating individual axioms. 'If check' implemented to add SPLIT definition back, while adding annotation axioms to the individual.  
