### PR TITLE
Tweak `template --errors <path>` behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow Dublin Core "terms" namespace (`http://purl.org/dc/terms/`) for `description` and `title` properties on ontology. [#741]
 - Allow numbers in lowercase_definition check [#866]
 - Blank nodes in [`report`] are now referred to as `blank node` rather than a random identifier [#873]
+- Change behaviour of [`template`] `--errors` option without `--force` [#929]
 
 ### Fixed
 - Fix printing violations in [`report`] [#823]
@@ -276,6 +277,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#929]: https://github.com/ontodev/robot/pull/929
 [#914]: https://github.com/ontodev/robot/pull/914
 [#907]: https://github.com/ontodev/robot/pull/907
 [#902]: https://github.com/ontodev/robot/pull/902

--- a/docs/template.md
+++ b/docs/template.md
@@ -32,13 +32,15 @@ Each template file must be set up in the following format:
 
 The `template` command accepts an optional input ontology, either using the `--input` option or from the previous command in a chain. If an input ontology is given, its `rdfs:label`s will be used when parsing the template. The `--template` or `-t` option specifies the CSV or TSV template file. Multiple templates are allowed, and the order of templates is significant. You can also specify the normal `--prefix` options, the `--output-iri` and `--version-iri`, and the usual `--output` options. See [Merging](#merging) for the three different merge options, and details on how they control the output of the command.
 
-A template may have multiple errors in different rows and columns. By default, `template` will fail on the first error encountered. If you wish to proceed with errors, use `--force true`. This will log all row parse errors to STDERR and attempt to create an ontology anyway. Be aware that the output ontology may be missing axioms.
+A template may have multiple errors in different rows and columns. By default, `template` will fail on the first error encountered. If you wish to proceed with errors, use `--force true`. This will log all row parse errors to STDERR and attempt to create an ontology anyway. Be aware that the output ontology may be missing axioms and ROBOT will complete with a `0` exit code (success).
 
-You can also choose to write errors to a separate table using `--errors <path>`. If the path ends with `csv`, the output will be comma-separated. Otherwise, the output will be tab-separated. Note that `--errors` will only write to the path when `--force true` is provided as well. The errors table contains the following fields:
+You can also choose to write errors to a separate table using `--errors <path>`. If the path ends with `csv`, the output will be comma-separated. Otherwise, the output will be tab-separated. The errors table contains the following fields:
 * **table**: table name (the `--template`)
 * **cell**: A1 notation of cell location (e.g., C3)
 * **rule ID**: the CURIE of the rule (`ROBOT-template:[rule-name]`, which expands to `http://robot.obolibrary.org/template#[rule-name]`)
 * **message**: text description of the violated rule
+
+If `--force true` is not included with `--errors <path>`, ROBOT will exit with a non-zero exit code (failure) and the output file will not be created.
 
 ## Template Strings
 

--- a/robot-command/src/main/java/org/obolibrary/robot/TemplateCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/TemplateCommand.java
@@ -48,7 +48,7 @@ public class TemplateCommand implements Command {
     o.addOption(
         "A", "include-annotations", true, "if true, include ontology annotations from merge input");
     o.addOption("f", "force", true, "if true, do not exit on error");
-    o.addOption("e", "errors", true, "when force=true, write errors to this path (TSV or CSV)");
+    o.addOption("e", "errors", true, "write errors to this path (TSV or CSV)");
 
     options = o;
   }

--- a/robot-core/src/main/java/org/obolibrary/robot/Template.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/Template.java
@@ -367,6 +367,7 @@ public class Template {
    */
   public OWLOntology generateOutputOntology(String outputIRI, boolean force, String errorsPath)
       throws Exception {
+    boolean exitOnException = !force && errorsPath == null;
     // Set to true on first exception
     boolean hasException = false;
 
@@ -376,8 +377,8 @@ public class Template {
       try {
         processRow(row);
       } catch (RowParseException e) {
-        // If force = false, fail on the first exception
-        if (!force) {
+        // Unless specified, fail on the first exception
+        if (exitOnException) {
           throw e;
         }
 
@@ -399,6 +400,10 @@ public class Template {
       if (errorsPath != null) {
         // Write errors to file
         IOHelper.writeTable(errors, errorsPath);
+        // Check if we want to force the output, otherwise exit now (as error)
+        if (!force) {
+          System.exit(1);
+        }
       }
     }
 


### PR DESCRIPTION
Resolves #928

- [x] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

You do not need to include `--force true` when using the `template --errors` option. When using this option and there are errors, ROBOT will create the errors output but not the output ontology. You can still include `--force true` to create the ontology with errors.
