### PR TITLE
Fail on bad equivalent-classes-allowed option in reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow numbers in lowercase_definition check [#866]
 - Blank nodes in [`report`] are now referred to as `blank node` rather than a random identifier [#873]
 - Change behaviour of [`template`] `--errors` option without `--force` [#929]
+- Fail hard on bad [`reason`] `--equivalent-classes-allowed` argument [#938]
 
 ### Fixed
 - Fix printing violations in [`report`] [#823]
@@ -278,6 +279,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#938]: https://github.com/ontodev/robot/pull/938
 [#929]: https://github.com/ontodev/robot/pull/929
 [#924]: https://github.com/ontodev/robot/issues/924
 [#914]: https://github.com/ontodev/robot/pull/914

--- a/docs/reason.md
+++ b/docs/reason.md
@@ -130,15 +130,18 @@ robot reason --input unreasoned.owl
 
 ## Error Messages
 
-### Create Ontology Error
-
-You must select between `--create-new-ontology-with-annotations` (`-m`) and `--create-new-ontology` (`-n`). Both cannot be passed in as `true` to one reason command, as they have opposite results.
-
 ### Axiom Generator Error
 
 The input for the `--axiom-generators` option must be one or more space-separated valid axiom generators, [listed above](#axiom-generators).
+
+### Create Ontology Error
+
+You must select between `--create-new-ontology-with-annotations` (`-m`) and `--create-new-ontology` (`-n`). Both cannot be passed in as `true` to one reason command, as they have opposite results.
 
 ### Equivalent Class Axiom Error
 
 ROBOT has been configured to not allow one-to-one equivalent classes (`--equivalent-classes-allowed none` or `--equivalent-classes-allowed asserted-only`) and one or more equivalency has been detected. Either remove the axiom(s) causing the equivalence axiom(s), or run `reason` with `--equivalent-classes-allowed none`. [More details here](#equivalent-class-axioms).
 
+### Equivalent Classes Option Error
+
+The argument for `--equivalent-classes-allowed` must be one of: `true`, `false`, `all`, `none`, or `asserted-only`. See [Equivalent Class Axioms](#equivalent-class-axioms) for more details.

--- a/robot-command/src/main/java/org/obolibrary/robot/ReasonCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ReasonCommand.java
@@ -1,5 +1,6 @@
 package org.obolibrary.robot;
 
+import java.util.Arrays;
 import java.util.Map;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
@@ -25,6 +26,11 @@ public class ReasonCommand implements Command {
       NS
           + "CREATE ONTOLOGY ERROR 'create-new-ontology' and 'create-new-ontology-with-annotations'"
           + " cannot both be set to true.";
+
+  private static final String equivalentClassesOptionError =
+      NS
+          + "EQUIVALENT CLASSES OPTION ERROR 'equivalent-classes-allowed' value %s must be one of: "
+          + "true, false, all, none, asserted-only";
 
   /** Store the command-line options for the command. */
   private Options options;
@@ -158,6 +164,8 @@ public class ReasonCommand implements Command {
       return null;
     }
 
+    // Validate equivalent-classes-allowed options with sets of options
+
     if (state == null) {
       state = new CommandState();
     }
@@ -177,6 +185,10 @@ public class ReasonCommand implements Command {
     if (reasonerOptions.get("create-new-ontology-with-annotations").equalsIgnoreCase("true")
         && reasonerOptions.get("create-new-ontology").equalsIgnoreCase("true")) {
       throw new IllegalArgumentException(createOntologyError);
+    }
+    String eqClassOpt = reasonerOptions.get("equivalent-classes-allowed");
+    if (!Arrays.asList("true", "false", "all", "none", "asserted-only").contains(eqClassOpt)) {
+      throw new IllegalArgumentException(String.format(equivalentClassesOptionError, eqClassOpt));
     }
     ReasonOperation.reason(ontology, reasonerFactory, reasonerOptions);
 


### PR DESCRIPTION
Resolves #936

- [x] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated
