### PR TITLE
Fix getting level for custom report queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix custom [`report`] queries [#944]
+
 ## [1.8.2] - 2021-12-02
 
 ### Added
@@ -283,6 +286,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#944]: https://github.com/ontodev/robot/pull/944
 [#938]: https://github.com/ontodev/robot/pull/938
 [#929]: https://github.com/ontodev/robot/pull/929
 [#924]: https://github.com/ontodev/robot/issues/924

--- a/docs/examples/missing-contributor.sparql
+++ b/docs/examples/missing-contributor.sparql
@@ -1,0 +1,11 @@
+PREFIX dc: <http://purl.org/dc/elements/1.1/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+  ?entity a owl:Ontology .
+  FILTER NOT EXISTS {
+    ?entity dc:contributor ?value .
+  }
+  BIND(dc:contributor as ?property)
+}

--- a/docs/examples/my-profile.txt
+++ b/docs/examples/my-profile.txt
@@ -1,0 +1,5 @@
+WARN	annotation_whitespace
+ERROR	invalid_xref
+ERROR	label_formatting
+INFO	file:missing-contributor.sparql
+ERROR	multiple_labels

--- a/docs/report.md
+++ b/docs/report.md
@@ -100,12 +100,12 @@ INFO	deprecated_class
 ```
 
 `report` allows the user to define their own profile to configure different logging levels and include their own QC queries with the `--profile` option:
-<!-- DO NOT TEST -->
-```
-robot report --input edit.owl \
-  --profile my-profile.txt \
-  --output my-report.tsv
-```
+
+
+    robot report --input edit.owl \
+      --profile my-profile.txt \
+      --output my-report.tsv
+
 
 For all default queries, include the query name shown above. If you do not wish to include a default query in your report, simply omit it from your profile. Any queries not named in the profile will not be run. Furthermore, your own queries can be included by providing the desired logging level followed by the absolute or relative path.
 Note that in order for the queries to be included in the report, they _must_ return exactly three variables: `?entity ?property ?value`.

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -641,7 +641,7 @@ public class ReportOperation {
       String rulePath = qs.getKey();
       String ruleName =
           rulePath.substring(rulePath.lastIndexOf("/") + 1, rulePath.lastIndexOf("."));
-      ReportQuery rq = new ReportQuery(ruleName, qs.getValue(), profile.get(ruleName));
+      ReportQuery rq = new ReportQuery(ruleName, qs.getValue(), profile.get(rulePath));
       reportQueries.add(rq);
     }
     return reportQueries;


### PR DESCRIPTION
Resolves #943

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated
