### PR TITLE
Replace slf4j-log4j12 with logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,9 +196,9 @@
       <version>4.13.1</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.30</version>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.7</version>
     </dependency>
     <dependency>
       <groupId>org.semanticweb.elk</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -201,10 +201,27 @@
       <version>1.2.7</version>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <version>1.7.32</version>
+    </dependency>
+    <dependency>
       <groupId>org.semanticweb.elk</groupId>
       <artifactId>elk-owlapi</artifactId>
       <version>0.4.3</version>
       <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>net.sourceforge.owlapi</groupId>
           <artifactId>owlapi-apibinding</artifactId>

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineHelper.java
@@ -1,5 +1,7 @@
 package org.obolibrary.robot;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import com.github.jsonldjava.core.Context;
 import java.io.*;
 import java.net.URI;
@@ -21,14 +23,13 @@ import org.geneontology.whelk.owlapi.WhelkOWLReasonerFactory;
 import org.semanticweb.elk.owlapi.ElkReasonerFactory;
 import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.reasoner.OWLReasonerFactory;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.manchester.cs.jfact.JFactFactory;
 
 /** Convenience methods for working with command line options. */
 public class CommandLineHelper {
   /** Logger. */
-  private static final Logger logger = LoggerFactory.getLogger(CommandLineHelper.class);
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(CommandLineHelper.class);
 
   /** Namespace for general input error messages. */
   private static final String NS = "errors#";
@@ -935,18 +936,18 @@ public class CommandLineHelper {
     CommandLineParser parser = new DefaultParser();
     CommandLine line = parser.parse(options, args, stopAtNonOption);
 
-    String level;
+    Level level;
     if (line.hasOption("very-very-verbose")) {
-      level = "DEBUG";
+      level = Level.DEBUG;
     } else if (line.hasOption("very-verbose")) {
-      level = "INFO";
+      level = Level.INFO;
     } else if (line.hasOption("verbose")) {
-      level = "WARN";
+      level = Level.WARN;
     } else {
-      level = "ERROR";
+      level = Level.ERROR;
     }
-    org.apache.log4j.Logger root = org.apache.log4j.Logger.getRootLogger();
-    root.setLevel(org.apache.log4j.Level.toLevel(level));
+    Logger root = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+    root.setLevel(level);
 
     if (hasFlagOrCommand(line, "help")) {
       printHelp(usage, options);

--- a/robot-command/src/main/resources/log4j.properties
+++ b/robot-command/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-#log4j.appender.console.layout.ConversionPattern=%-5p %m%n
-log4j.appender.console.layout.ConversionPattern=%d %-5p %c - %m%n
-log4j.logger.org.obolibrary.obo2owl=off
-log4j.logger.user=DEBUG
-log4j.rootLogger=ERROR, console

--- a/robot-command/src/main/resources/logback.xml
+++ b/robot-command/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d %-5p %c - %m%n</pattern>
+    </encoder>
+  </appender>
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+  <logger name="user" level="DEBUG"/>
+  <logger name="org.semanticweb.elk" level="off"/>
+  <logger name="org.obolibrary.obo2owl" level="off"/>
+  <root level="ERROR">
+    <appender-ref ref="console"/>
+  </root>
+</configuration>

--- a/robot-core/src/main/resources/log4j.properties
+++ b/robot-core/src/main/resources/log4j.properties
@@ -1,7 +1,0 @@
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%-5p %m%n
-#log4j.appender.console.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
-log4j.logger.org.obolibrary.obo2owl=off
-log4j.logger.user=DEBUG
-log4j.rootLogger=ERROR, console

--- a/robot-core/src/main/resources/logback.xml
+++ b/robot-core/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-5p %m%n</pattern>
+    </encoder>
+  </appender>
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+  <logger name="user" level="DEBUG"/>
+  <logger name="org.semanticweb.elk" level="off"/>
+  <logger name="org.obolibrary.obo2owl" level="off"/>
+  <root level="ERROR">
+    <appender-ref ref="console"/>
+  </root>
+</configuration>


### PR DESCRIPTION
- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

ROBOT uses `slf4j-log4j12 1.7.30` for logging, which pulls in `log4j 1.2.17`. Log4j 1.2.17 is no longer supported, and has known vulnerabilities: <https://logging.apache.org/log4j/1.2/index.html>. I would like to try replacing it with `logback-classic 1.2.7`.
