### PR TITLE
Sort report violations by rule name (within level)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Sort [`report`] violations by rule name within level [#955]
 
 ## [1.8.3] - 2021-12-16
 
 ### Changed
 - Replace `log4j` with `logback` [#948] [#953]
-- Sort [`report`] violations by rule name within level [#955]
 
 ### Fixed
 - Fix custom [`report`] queries [#944]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Replace `log4j` with `logback` [#948] [#953]
+- Sort [`report`] violations by rule name within level [#955]
 
 ### Fixed
 - Fix custom [`report`] queries [#944]
@@ -293,6 +294,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#955]: https://github.com/ontodev/robot/pull/955
 [#953]: https://github.com/ontodev/robot/pull/953
 [#951]: https://github.com/ontodev/robot/pull/951
 [#948]: https://github.com/ontodev/robot/pull/948

--- a/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/checks/Report.java
@@ -98,6 +98,20 @@ public class Report {
   /** Map of rules and the violations for ERROR level. */
   @Deprecated public Map<String, List<Violation>> error = new HashMap<>();
 
+  /** Comparator for sorting a list of Report Queries alphabetically by their rule name. */
+  static class ReportQueryComparator implements Comparator<ReportQuery> {
+    /**
+     * Compare two Report Query objects by their rule name.
+     *
+     * @param rq1 Report Query 1
+     * @param rq2 Report Query 2
+     * @return int for sorting
+     */
+    public int compare(ReportQuery rq1, ReportQuery rq2) {
+      return rq1.getRuleName().compareTo(rq2.getRuleName());
+    }
+  }
+
   /**
    * Create a new report object without an ontology or predefined IOHelper.
    *
@@ -289,6 +303,11 @@ public class Report {
       table.addColumn(c);
     }
 
+    // Sort results
+    errorViolations.sort(new ReportQueryComparator());
+    warnViolations.sort(new ReportQueryComparator());
+    infoViolations.sort(new ReportQueryComparator());
+
     addToTable(table, provider, ERROR, errorViolations);
     addToTable(table, provider, WARN, warnViolations);
     addToTable(table, provider, INFO, infoViolations);
@@ -314,6 +333,12 @@ public class Report {
    * @return YAML string
    */
   public String toYAML() {
+    // Sort results
+    errorViolations.sort(new ReportQueryComparator());
+    warnViolations.sort(new ReportQueryComparator());
+    infoViolations.sort(new ReportQueryComparator());
+
+    // Create YAML
     ShortFormProvider provider = getProvider();
     return yamlHelper(provider, ERROR, errorViolations)
         + yamlHelper(provider, WARN, warnViolations)
@@ -561,34 +586,6 @@ public class Report {
   }
 
   /**
-   * Given a rule name, it's reporting level, and a list of the violations from the ontology, add
-   * the violations to the correct map.
-   *
-   * @param ruleName name of rule
-   * @param level reporting level of rule
-   * @param violations list of violations from this rule
-   * @deprecated violations should be added to their appropriate ReportQuery object
-   */
-  @Deprecated
-  public void addViolations(String ruleName, String level, List<Violation> violations) {
-    logger.debug("violation found: " + ruleName);
-    if (INFO.equals(level)) {
-      info.put(ruleName, violations);
-      infoCount += violations.size();
-      infoCountByRule.put(ruleName, violations.size());
-    } else if (WARN.equals(level)) {
-      warn.put(ruleName, violations);
-      warnCount += violations.size();
-      warnCountByRule.put(ruleName, violations.size());
-    } else if (ERROR.equals(level)) {
-      error.put(ruleName, violations);
-      errorCount += violations.size();
-      errorCountByRule.put(ruleName, violations.size());
-    }
-    // Otherwise do nothing
-  }
-
-  /**
    * Given a rule name, return the violation count for that rule. Throw exception if rule does not
    * exists.
    *
@@ -646,6 +643,34 @@ public class Report {
     }
 
     return iris;
+  }
+
+  /**
+   * Given a rule name, it's reporting level, and a list of the violations from the ontology, add
+   * the violations to the correct map.
+   *
+   * @param ruleName name of rule
+   * @param level reporting level of rule
+   * @param violations list of violations from this rule
+   * @deprecated violations should be added to their appropriate ReportQuery object
+   */
+  @Deprecated
+  public void addViolations(String ruleName, String level, List<Violation> violations) {
+    logger.debug("violation found: " + ruleName);
+    if (INFO.equals(level)) {
+      info.put(ruleName, violations);
+      infoCount += violations.size();
+      infoCountByRule.put(ruleName, violations.size());
+    } else if (WARN.equals(level)) {
+      warn.put(ruleName, violations);
+      warnCount += violations.size();
+      warnCountByRule.put(ruleName, violations.size());
+    } else if (ERROR.equals(level)) {
+      error.put(ruleName, violations);
+      errorCount += violations.size();
+      errorCountByRule.put(ruleName, violations.size());
+    }
+    // Otherwise do nothing
   }
 
   /**


### PR DESCRIPTION
Resolves #954

- [x] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

Add a sorting step while generating the report output that sorts each level of violations by rule name. This should ensure that the output is in a consistent order each time.
