### PR TITLE
Restore and update japicmp plugin

### DIFF
--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -31,6 +31,44 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- Ensure backward compatibility -->
+      <plugin>
+        <groupId>com.github.siom79.japicmp</groupId>
+        <artifactId>japicmp-maven-plugin</artifactId>
+        <version>0.15.4</version>
+        <configuration>
+          <oldVersion>
+            <dependency>
+              <groupId>${project.groupId}</groupId>
+              <artifactId>${project.artifactId}</artifactId>
+              <version>1.8.3</version> <!-- japicmp target -->
+              <type>jar</type>
+            </dependency>
+          </oldVersion>
+          <newVersion>
+            <file>
+              <path>${project.build.directory}/${project.artifactId}-${project.version}.${project.packaging}</path>
+            </file>
+          </newVersion>
+          <parameter>
+            <!-- see documentation: http://siom79.github.io/japicmp/MavenPlugin.html -->
+            <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+            <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+            <!-- include on breaking changes
+            <excludes></excludes>
+            -->
+          </parameter>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>cmp</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
We use `japicmp-maven-plugin` to ensure backwards compatibility of the public methods in `robot-core`. It seemed to give false negatives on PR #932, so we temporarily disabled it. This PR adds the plugin back in and updates to the latest version.
