### PR TITLE
Add better error handling for checking OBO files

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -1745,7 +1745,16 @@ public class IOHelper {
             throw new IOException(String.format(invalidElementError, element));
           }
         }
-        throw new IOException(String.format(ontologyStorageError, ontologyIRI.toString()), e);
+        throw new IOException(String.format(ontologyStorageError, ontologyIRI), e);
+      } catch (NullPointerException e) {
+        if (format instanceof OBODocumentFormat) {
+          // Critical OBO structure error
+          throw new IOException(
+              "OBO STRUCTURE ERROR ontology cannot be saved in OBO format. Please use '--check true' to see cause.");
+        } else {
+          // Unknown null pointer exception
+          throw new IOException(String.format(ontologyStorageError, ontologyIRI), e);
+        }
       }
     }
   }


### PR DESCRIPTION
Resolves #959

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated
