### PR TITLE
Fix creation of equivalent class axioms from template

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/Template.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/Template.java
@@ -977,15 +977,20 @@ public class Template {
       throws Exception {
     Set<OWLAnnotation> axiomAnnotations = new HashSet<>();
     Set<OWLClassExpression> expressions = new HashSet<>();
-    expressions.add(cls);
     for (int column : expressionColumns.keySet()) {
       // Maybe get an annotation on the expression (all annotations will be on the one intersection)
       axiomAnnotations.addAll(maybeGetAxiomAnnotations(row, column));
       // Add all expressions to the set of expressions
       expressions.addAll(expressionColumns.get(column));
     }
-    // Create the axiom as an intersection of the provided expressions
-    axioms.add(dataFactory.getOWLEquivalentClassesAxiom(expressions, axiomAnnotations));
+    if (expressions.size() == 1) {
+      // Add a single equivalent class axiom between class & expression
+      axioms.add(dataFactory.getOWLEquivalentClassesAxiom(cls, expressions.iterator().next()));
+    } else if (expressions.size() > 1) {
+      // Create the axiom as an intersection of the provided expressions (including the class)
+      expressions.add(cls);
+      axioms.add(dataFactory.getOWLEquivalentClassesAxiom(expressions, axiomAnnotations));
+    }
   }
 
   /**
@@ -1009,9 +1014,17 @@ public class Template {
       // Add all expressions to the set of expressions
       expressions.addAll(expressionColumns.get(column));
     }
-    // Create the axiom as an intersection of the provided expressions
-    OWLObjectIntersectionOf intersection = dataFactory.getOWLObjectIntersectionOf(expressions);
-    axioms.add(dataFactory.getOWLEquivalentClassesAxiom(cls, intersection, axiomAnnotations));
+
+    if (expressions.size() == 1) {
+      // Create a single equivalent class axiom (no intersection)
+      axioms.add(
+          dataFactory.getOWLEquivalentClassesAxiom(
+              cls, expressions.iterator().next(), axiomAnnotations));
+    } else if (expressions.size() > 1) {
+      // Create the axiom as an intersection of the provided expressions
+      OWLObjectIntersectionOf intersection = dataFactory.getOWLObjectIntersectionOf(expressions);
+      axioms.add(dataFactory.getOWLEquivalentClassesAxiom(cls, intersection, axiomAnnotations));
+    }
   }
 
   /**

--- a/robot-core/src/test/java/org/obolibrary/robot/TemplateTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/TemplateTest.java
@@ -46,7 +46,7 @@ public class TemplateTest extends CoreTest {
 
     Template t = new Template(path, rows, simpleParts);
     OWLOntology template = t.generateOutputOntology("http://test.com/template.owl", false, null);
-    assertIdentical("/template.owl", template);
+    assertIdentical("/legacy-template.owl", template);
   }
 
   /**

--- a/robot-core/src/test/resources/legacy-template.owl
+++ b/robot-core/src/test/resources/legacy-template.owl
@@ -89,6 +89,29 @@
     </Class>
     <Axiom>
         <annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_1235"/>
+        <annotatedProperty rdf:resource="http://www.w3.org/2002/07/owl#equivalentClass"/>
+        <annotatedTarget>
+            <Class>
+                <intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl#test1"/>
+                    <Restriction>
+                        <onProperty rdf:resource="https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl#part_of"/>
+                        <someValuesFrom>
+                            <Class>
+                                <intersectionOf rdf:parseType="Collection">
+                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GO_1234"/>
+                                    <rdf:Description rdf:about="https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl#test2"/>
+                                </intersectionOf>
+                            </Class>
+                        </someValuesFrom>
+                    </Restriction>
+                </intersectionOf>
+            </Class>
+        </annotatedTarget>
+        <rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test2 and test 3 comment</rdfs:comment>
+    </Axiom>
+    <Axiom>
+        <annotatedSource rdf:resource="http://purl.obolibrary.org/obo/GO_1235"/>
         <annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
         <annotatedTarget rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test 4</annotatedTarget>
         <rdfs:comment xml:lang="en">test 4 comment</rdfs:comment>


### PR DESCRIPTION
- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

Currently, template creates an intersection for all equivalent class assertions, even if there is only one equivalent expression. Intersections should only be used for 2+ expressions. See: https://github.com/obi-ontology/obi/issues/1500