### PR TITLE
Minor error message fix for --check true

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -1747,7 +1747,7 @@ public class IOHelper {
         }
         throw new IOException(String.format(ontologyStorageError, ontologyIRI), e);
       } catch (NullPointerException e) {
-        if (format instanceof OBODocumentFormat) {
+        if (format instanceof OBODocumentFormat && !checkOBO) {
           // Critical OBO structure error
           throw new IOException(
               "OBO STRUCTURE ERROR ontology cannot be saved in OBO format. Please use '--check true' to see cause.");


### PR DESCRIPTION
When you convert to OBO with `--check true` and the writer still throws a null pointer exception, the error message tells you to run with `--check true`. This fixes it so it will only tell you to do that when `--check false`.
