### PR TITLE
Fix Guava dependency for obographs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>28.2-jre</version>
+    </dependency>
+    <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-api</artifactId>
       <version>4.5.6</version>

--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -218,11 +218,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.geneontology.obographs</groupId>
-      <artifactId>obographs-core</artifactId>
-      <version>0.3.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>2.12.2</version>

--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -74,6 +74,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>28.2-jre</version>
+    </dependency>
+    <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-api</artifactId>
       <version>4.5.6</version>
@@ -211,6 +216,11 @@
           <artifactId>owlapi-distribution</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.geneontology.obographs</groupId>
+      <artifactId>obographs-core</artifactId>
+      <version>0.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Resolves #1009 

- [X] `docs/` have been added/updated
- [X] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

The problem was that other dependencies (OWL API-related) determined that the correct Google Guava version is an ancient one (18.0). This caused the JAR packaging to prefer that (probably because it was earlier in the POM file). 

In this PR, we explicitly include obographs-core as per recommendation in #1009 but we also add a fixed import to Guava.

I don't know if this is the right way to do this, I am too far out of Java land now. But I didn't want to search through 20 depencies to add exclusions. If there is a better way, great!
