### PR TITLE
Use identity-based set for collecting ontologies that may have the same ontology ID, when providing term labels to diffs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix missing labels in [`diff`] output. [#1026]
+
 ## [1.9.0] - 2022-06-16
 
 ### Added

--- a/robot-core/src/main/java/org/obolibrary/robot/DiffOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/DiffOperation.java
@@ -1,5 +1,6 @@
 package org.obolibrary.robot;
 
+import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.*;
@@ -157,7 +158,7 @@ public class DiffOperation {
   private static class DualOntologySetProvider implements OWLOntologySetProvider {
 
     private static final long serialVersionUID = -8942374248162307075L;
-    private final Set<OWLOntology> ontologies = new HashSet<>();
+    private final Set<OWLOntology> ontologies = Sets.newIdentityHashSet();
 
     /**
      * Init a new DualOntologySetProvider for a left and right ontology.

--- a/robot-core/src/test/java/org/obolibrary/robot/DiffOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/DiffOperationTest.java
@@ -1,22 +1,16 @@
 package org.obolibrary.robot;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
+import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLDataFactory;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,5 +79,36 @@ public class DiffOperationTest extends CoreTest {
         IOUtils.toString(
             this.getClass().getResourceAsStream("/simple.diff"), Charset.defaultCharset());
     assertEquals(expected, writer.toString());
+  }
+
+  /**
+   * OWL API ontology equality only compares the ontology ID. This test confirms this and verifies
+   * that we can use an identity-based set for collections of ontologies when needed.
+   *
+   * @throws OWLOntologyCreationException
+   */
+  @Test
+  public void testOntologyEquality() throws OWLOntologyCreationException {
+    OWLDataFactory f = OWLManager.getOWLDataFactory();
+    OWLOntologyManager mgr1 = OWLManager.createOWLOntologyManager();
+    OWLOntologyManager mgr2 = OWLManager.createOWLOntologyManager();
+    OWLClass a = f.getOWLClass(IRI.create("http://example.org/A"));
+    OWLClass b = f.getOWLClass(IRI.create("http://example.org/B"));
+    OWLOntology ont1 =
+        mgr1.createOntology(
+            Collections.singleton(f.getOWLDeclarationAxiom(a)),
+            IRI.create("http://example.org/ontology"));
+    OWLOntology ont2 =
+        mgr2.createOntology(
+            Collections.singleton(f.getOWLDeclarationAxiom(b)),
+            IRI.create("http://example.org/ontology"));
+    Set<OWLOntology> normalSet = new HashSet<>();
+    Set<OWLOntology> identitySet = Sets.newIdentityHashSet();
+    normalSet.add(ont1);
+    normalSet.add(ont2);
+    identitySet.add(ont1);
+    identitySet.add(ont2);
+    assertEquals(1, normalSet.size());
+    assertEquals(2, identitySet.size());
   }
 }


### PR DESCRIPTION
Resolves #1026.

- [ ] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

