### PR TITLE
Fixing no genus query

### DIFF
--- a/docs/report_queries/equivalent_class_axiom_no_genus.md
+++ b/docs/report_queries/equivalent_class_axiom_no_genus.md
@@ -11,9 +11,10 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 SELECT DISTINCT ?entity ?property ?value WHERE {
  ?entity owl:equivalentClass [ rdf:type owl:Restriction ;
                               owl:someValuesFrom ?value ;
-                              owl:onProperty ?property ] .
+                              owl:onProperty ?property1 ] .
   FILTER (!isBlank(?entity))
   FILTER (!isBlank(?value))
+  BIND (if(isIRI(?property1), ?property1, "blank node" ) as ?property)
 }
 ORDER BY ?entity
 

--- a/robot-core/src/main/resources/report_queries/equivalent_class_axiom_no_genus.rq
+++ b/robot-core/src/main/resources/report_queries/equivalent_class_axiom_no_genus.rq
@@ -10,8 +10,9 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 SELECT DISTINCT ?entity ?property ?value WHERE {
  ?entity owl:equivalentClass [ rdf:type owl:Restriction ;
                               owl:someValuesFrom ?value ;
-                              owl:onProperty ?property ] .
+                              owl:onProperty ?property1 ] .
   FILTER (!isBlank(?entity))
   FILTER (!isBlank(?value))
+  BIND (if(isIRI(?property1), ?property1, "blank node" ) as ?property)
 }
 ORDER BY ?entity


### PR DESCRIPTION
Resolves #1048

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

This fixes the http://robot.obolibrary.org/report_queries/equivalent_class_axiom_no_genus in the case the property used is complex.
