### PR TITLE
Add support for exporting domain and range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Checking for empty strings in addition to missing ones in `missing_label.rq` [#1017]
+- Add "domain" and "range" support to export [#1061]
 
 ### Fixed
 - Fix missing labels in [`diff`] output. [#1026]
@@ -323,6 +324,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#1061]: https://github.com/ontodev/robot/issues/1061
 [#1009]: https://github.com/ontodev/robot/issues/1009
 [#979]: https://github.com/ontodev/robot/pull/979
 [#978]: https://github.com/ontodev/robot/pull/978

--- a/docs/export.md
+++ b/docs/export.md
@@ -61,6 +61,8 @@ Various `--header` types are supported:
 	* `Equivalent Property`: creates an "Equivalent Properties" column based on `owl:equivalentProperty`
 	* `Disjoint With`: creates a "Disjoint With" column based on `owl:disjointWith`
 	* `Type`: creates an "Instance Of" column based on `rdf:type` for named individuals or the OWL EntityType for all others (e.g., `Class`)
+  * `Domain`: creates a "Domain" column based on `rdfs:domain`
+  * `Range`: creates a "Range" column based on `rdfs:range`
 * **Property CURIES**: you can always reference a property by the short form of the unique identifier (e.g. `oboInOwl:hasDbXref`). Any prefix used [must be defined](global#prefixes).
 * **Property Labels**: as long as a property label is defined in the input ontology, you can reference a property by label (e.g. `database_cross_reference`). This label will also be used as the column header.
 


### PR DESCRIPTION
Resolves #1025

- [x] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

I generalized `classExpressionsToString` and `getClassCell` to handle all OWL Objects (including IRIs) to support this without adding extra code. The same code can be used for properties, so that was replaced.
