### PR TITLE
Update link to Java download

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ R.C. Jackson, J.P. Balhoff, E. Douglass, N.L. Harris, C.J. Mungall, and J.A. Ove
 
 ## 1. Getting Started
 
-The command-line tool is packaged a Java JAR file and can be run via the `robot` shell script. Before getting started, make sure you have [Java 11 or later](https://www.java.com/en/download/) installed. Check by entering `java -version` on the command line.
+The command-line tool is packaged a Java JAR file and can be run via the `robot` shell script. Before getting started, make sure you have [Java 11 or later](https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html) installed. Check by entering `java -version` on the command line.
 
 ### Mac & Linux
 


### PR DESCRIPTION
Fixes #1064

Update like to Java, pointing to Java 11 instead of Java 8.
