### PR TITLE
[#1070] downgrading SnakeYaml to 1.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Downgrade SnakeYaml to 1.31 [#1070]
 
 ## [1.9.1] - 2022-10-28
 

--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -183,7 +183,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.32</version>
+      <version>1.31</version>
     </dependency>
     <dependency>
       <groupId>com.opencsv</groupId>

--- a/robot-core/src/test/java/org/obolibrary/robot/ReportOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ReportOperationTest.java
@@ -1,17 +1,25 @@
 package org.obolibrary.robot;
 
-import java.io.*;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
-import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.*;
 import org.yaml.snakeyaml.error.YAMLException;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 
 /** Tests for the ReportOperation. */
 public class ReportOperationTest extends CoreTest {
+
+  private static final String oboInOwl = "http://www.geneontology.org/formats/oboInOwl#";
+  private static final String obo = "http://purl.obolibrary.org/obo/";
 
   /** Test report produces correct JSON. */
   @Test
@@ -40,6 +48,42 @@ public class ReportOperationTest extends CoreTest {
       final String expectedOutput =
           IOUtils.toString(expected, StandardCharsets.UTF_8.name()).trim();
       Assert.assertEquals(expectedOutput, output);
+    } catch (YAMLException e) {
+      e.printStackTrace();
+      Assert.fail();
+    }
+  }
+
+  private OWLOntology generateOntologyWithLotsOfViolations() throws OWLOntologyCreationException {
+    final OWLOntologyManager m = OWLManager.createOWLOntologyManager();
+    final OWLDataFactory f = m.getOWLDataFactory();
+    final OWLOntology o = m.createOntology(IRI.create(URI.create("https://example.org/o")));
+
+    final OWLAnnotationProperty pLabel = f.getRDFSLabel();
+    final OWLAnnotationProperty pHasExactSynonym = f.getOWLAnnotationProperty(IRI.create(oboInOwl + "hasExactSynonym"));
+    final OWLAnnotationProperty pHasRelatedSynonym = f.getOWLAnnotationProperty(IRI.create(oboInOwl + "hasRelatedSynonym"));
+    final OWLAnnotationProperty pIAO_0000115 = f.getOWLAnnotationProperty(IRI.create(obo + "IAO_0000115"));
+
+    for (int i = 0; i < 5000; i++) {
+      final IRI iriC = IRI.create("https://example.org/o/a" + i);
+      m.addAxiom(o, f.getOWLAnnotationAssertionAxiom(pLabel, iriC, f.getOWLLiteral(" X\tX")));
+      m.addAxiom(o, f.getOWLAnnotationAssertionAxiom(pLabel, iriC, f.getOWLLiteral("obsolete X\tX")));
+      m.addAxiom(o, f.getOWLAnnotationAssertionAxiom(pHasExactSynonym, iriC, f.getOWLLiteral(" X\tX")));
+      m.addAxiom(o, f.getOWLAnnotationAssertionAxiom(pHasRelatedSynonym, iriC, f.getOWLLiteral(" X\tX")));
+      m.addAxiom(o, f.getOWLAnnotationAssertionAxiom(pIAO_0000115, iriC, f.getOWLLiteral("x")));
+    }
+    return o;
+  }
+
+  // disabling, as the test takes a few minutes to run
+  // @Test
+  public void testReportProducesCorrectOutput() throws Exception {
+    try {
+      final IOHelper iohelper = new IOHelper();
+      final File outputFile =
+        File.createTempFile("1070-codepoint-defaults-output", ".json");
+      final OWLOntology o = generateOntologyWithLotsOfViolations();
+      ReportOperation.report(o, iohelper, outputFile.toString(), Collections.emptyMap());
     } catch (YAMLException e) {
       e.printStackTrace();
       Assert.fail();


### PR DESCRIPTION
Resolves [#1070]

- [x] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated