### PR TITLE
Adding temporary gradle files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/examples/out.owl
 docs/examples/results/
 junk/
 target/
+docs/examples/.gradle/


### PR DESCRIPTION
No related issue, just saw this after testing the latest version of ROBOT locally.