### PR TITLE
refactor unsat object-checking to leverage object hierarchy, for reasoners that support that

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Speed up unsatisfiable object-property check on certain reasoners including HermiT [#1100]
+
 ## [1.9.3] - 2023-02-16
 
 ### Added

--- a/robot-core/src/main/java/org/obolibrary/robot/ReasonerHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReasonerHelper.java
@@ -90,13 +90,9 @@ public class ReasonerHelper {
       reasoner.flush();
 
       if (unsatisfiableProbeClasses.size() > 0) {
-        logger.error(
-            "There are {} unsatisfiable properties in the ontology.",
-            unsatisfiableProbeClasses.size());
         for (OWLClass cls : unsatisfiableProbeClasses) {
           OWLObjectProperty unsatP = probeFor.get(cls);
           unsatObjectProps.add(unsatP);
-          logger.error("    unsatisfiable property: " + unsatP.getIRI());
         }
       }
     }

--- a/robot-core/src/main/java/org/obolibrary/robot/ReasonerHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReasonerHelper.java
@@ -13,6 +13,7 @@ import org.obolibrary.robot.reason.InferredSubClassAxiomGeneratorIncludingIndire
 import org.obolibrary.robot.reason.InferredSubObjectPropertyAxiomGeneratorIncludingIndirect;
 import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.model.parameters.Imports;
+import org.semanticweb.owlapi.reasoner.InferenceType;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 import org.semanticweb.owlapi.util.*;
 import org.slf4j.Logger;
@@ -35,6 +36,72 @@ public class ReasonerHelper {
 
   /** Logger. */
   private static final Logger logger = LoggerFactory.getLogger(ReasonerHelper.class);
+
+  /**
+   * Check an ontology for unsatisfiable object properties.
+   *
+   * @param reasoner OWLReasoner being used.
+   * @return A set of unsatisfiable OWLObjectProperty objects (will be empty if none are found).
+   */
+  public static Set<OWLObjectProperty> getUnsatisfiableObjectProperties(OWLReasoner reasoner) {
+    Set<OWLObjectProperty> unsatObjectProps = new HashSet<>();
+
+    if (reasoner
+        .getPrecomputableInferenceTypes()
+        .contains(InferenceType.OBJECT_PROPERTY_HIERARCHY)) {
+      // Fast object-unsat check
+      logger.info(
+          "Object-property precomputation is supported; using that to find unsatisfiable object properties...");
+      reasoner.precomputeInferences(InferenceType.OBJECT_PROPERTY_HIERARCHY);
+      Set<OWLObjectPropertyExpression> unsatObjPropExps =
+          reasoner.getBottomObjectPropertyNode().getEntitiesMinusBottom();
+      for (OWLObjectPropertyExpression uOPE : unsatObjPropExps) {
+        if (uOPE.isNamed()) {
+          unsatObjectProps.add(uOPE.asOWLObjectProperty());
+        }
+      }
+    } else {
+      // Have to do this the slow way
+      OWLOntology ont = reasoner.getRootOntology();
+      OWLOntologyManager manager = ont.getOWLOntologyManager();
+      OWLDataFactory dataFactory = manager.getOWLDataFactory();
+      OWLClass thing = dataFactory.getOWLThing();
+      Set<OWLAxiom> tempAxioms = new HashSet<>();
+      Map<OWLClass, OWLObjectProperty> probeFor = new HashMap<>();
+
+      for (OWLObjectProperty p : ont.getObjectPropertiesInSignature(Imports.INCLUDED)) {
+        UUID uuid = UUID.randomUUID();
+        IRI probeIRI = IRI.create(p.getIRI().toString() + "-" + uuid.toString());
+        OWLClass probe = dataFactory.getOWLClass(probeIRI);
+        probeFor.put(probe, p);
+        tempAxioms.add(dataFactory.getOWLDeclarationAxiom(probe));
+        tempAxioms.add(
+            dataFactory.getOWLSubClassOfAxiom(
+                probe, dataFactory.getOWLObjectSomeValuesFrom(p, thing)));
+      }
+      manager.addAxioms(ont, tempAxioms);
+      reasoner.flush();
+
+      Set<OWLClass> unsatisfiableProbeClasses =
+          reasoner.getUnsatisfiableClasses().getEntitiesMinusBottom();
+
+      // leave no trace
+      manager.removeAxioms(ont, tempAxioms);
+      reasoner.flush();
+
+      if (unsatisfiableProbeClasses.size() > 0) {
+        logger.error(
+            "There are {} unsatisfiable properties in the ontology.",
+            unsatisfiableProbeClasses.size());
+        for (OWLClass cls : unsatisfiableProbeClasses) {
+          OWLObjectProperty unsatP = probeFor.get(cls);
+          unsatObjectProps.add(unsatP);
+          logger.error("    unsatisfiable property: " + unsatP.getIRI());
+        }
+      }
+    }
+    return unsatObjectProps;
+  }
 
   /**
    * Validates ontology.
@@ -118,40 +185,14 @@ public class ReasonerHelper {
       throw new IncoherentTBoxException(unsatisfiableClasses);
     }
 
-    // TODO: can this be done by checking for equivalence to bottomObjectProperty?
     logger.info("Checking for unsatisfiable object properties...");
 
-    Set<OWLAxiom> tempAxioms = new HashSet<>();
-    Map<OWLClass, OWLObjectProperty> probeFor = new HashMap<>();
-    for (OWLObjectProperty p : ont.getObjectPropertiesInSignature(Imports.INCLUDED)) {
-      UUID uuid = UUID.randomUUID();
-      IRI probeIRI = IRI.create(p.getIRI().toString() + "-" + uuid.toString());
-      OWLClass probe = dataFactory.getOWLClass(probeIRI);
-      probeFor.put(probe, p);
-      tempAxioms.add(dataFactory.getOWLDeclarationAxiom(probe));
-      tempAxioms.add(
-          dataFactory.getOWLSubClassOfAxiom(
-              probe, dataFactory.getOWLObjectSomeValuesFrom(p, thing)));
-    }
-    manager.addAxioms(ont, tempAxioms);
-    reasoner.flush();
+    Set<OWLObjectProperty> unsatPs = getUnsatisfiableObjectProperties(reasoner);
 
-    Set<OWLClass> unsatisfiableProbeClasses =
-        reasoner.getUnsatisfiableClasses().getEntitiesMinus(nothing);
-
-    // leave no trace
-    manager.removeAxioms(ont, tempAxioms);
-    reasoner.flush();
-
-    if (unsatisfiableProbeClasses.size() > 0) {
-      logger.error(
-          "There are {} unsatisfiable properties in the ontology.",
-          unsatisfiableProbeClasses.size());
-      Set<OWLObjectProperty> unsatPs = new HashSet<>();
-      for (OWLClass cls : unsatisfiableProbeClasses) {
-        OWLObjectProperty unsatP = probeFor.get(cls);
-        unsatPs.add(unsatP);
-        logger.error("    unsatisfiable property: " + unsatP.getIRI());
+    if (unsatPs.size() > 0) {
+      logger.error("There are {} unsatisfiable properties in the ontology.", unsatPs.size());
+      for (OWLObjectProperty p : unsatPs) {
+        logger.error("    unsatisfiable property: " + p.getIRI());
       }
       throw new IncoherentRBoxException(unsatPs);
     }

--- a/robot-core/src/test/java/org/obolibrary/robot/ReasonerHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ReasonerHelperTest.java
@@ -3,6 +3,8 @@ package org.obolibrary.robot;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import org.junit.Test;
 import org.obolibrary.robot.exceptions.IncoherentRBoxException;
@@ -34,16 +36,21 @@ public class ReasonerHelperTest extends CoreTest {
   public void testIncoherentRBox()
       throws IOException, IncoherentTBoxException, InconsistentOntologyException {
     OWLOntology ontology = loadOntology("/incoherent-rbox.owl");
-    OWLReasonerFactory reasonerFactory = new org.semanticweb.elk.owlapi.ElkReasonerFactory();
-    OWLReasoner reasoner = reasonerFactory.createReasoner(ontology);
-    boolean isCaughtException = false;
-    try {
-      ReasonerHelper.validate(reasoner);
+    List<OWLReasonerFactory> factories =
+        Arrays.asList(
+            new org.semanticweb.elk.owlapi.ElkReasonerFactory(),
+            new org.semanticweb.HermiT.ReasonerFactory());
+    for (OWLReasonerFactory reasonerFactory : factories) {
+      OWLReasoner reasoner = reasonerFactory.createReasoner(ontology);
+      boolean isCaughtException = false;
+      try {
+        ReasonerHelper.validate(reasoner);
 
-    } catch (IncoherentRBoxException e) {
-      isCaughtException = true;
+      } catch (IncoherentRBoxException e) {
+        isCaughtException = true;
+      }
+      assertTrue(isCaughtException);
     }
-    assertTrue(isCaughtException);
   }
 
   /**
@@ -57,16 +64,21 @@ public class ReasonerHelperTest extends CoreTest {
   public void testIncoherentTBox()
       throws IOException, InconsistentOntologyException, IncoherentRBoxException {
     OWLOntology ontology = loadOntology("/incoherent-tbox.owl");
-    OWLReasonerFactory reasonerFactory = new org.semanticweb.elk.owlapi.ElkReasonerFactory();
-    OWLReasoner reasoner = reasonerFactory.createReasoner(ontology);
-    boolean isCaughtException = false;
-    try {
-      ReasonerHelper.validate(reasoner);
+    List<OWLReasonerFactory> factories =
+        Arrays.asList(
+            new org.semanticweb.elk.owlapi.ElkReasonerFactory(),
+            new org.semanticweb.HermiT.ReasonerFactory());
+    for (OWLReasonerFactory reasonerFactory : factories) {
+      OWLReasoner reasoner = reasonerFactory.createReasoner(ontology);
+      boolean isCaughtException = false;
+      try {
+        ReasonerHelper.validate(reasoner);
 
-    } catch (IncoherentTBoxException e) {
-      isCaughtException = true;
+      } catch (IncoherentTBoxException e) {
+        isCaughtException = true;
+      }
+      assertTrue(isCaughtException);
     }
-    assertTrue(isCaughtException);
   }
 
   /**


### PR DESCRIPTION
 
**Resolves #1096**

- [ ] `docs/` have been added/updated - N/A
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

## Summary
Here, I've modified the way the reasoner validate step checks for unsatisfiable object properties.

Before, an algorithm was implemented (by @cmungall in https://github.com/ontodev/robot/pull/133) that was needed for reasoners (like Elk) that don't support computation of the object-property hierarchy.  That method is maintained here, but wrapped in a new method `ReasonerHelper.getUnsatisfiableObjectProperties()`, which uses the old technique only for reasoners that don't report that they can pre-compute the object-property hierarchy.

Reasoners that **can** pre-compute that hierarchy use a new simpler technique: computation of the object-property hierarchy, followed by checking of the bottom node for any named object-properties other than the OWL bottomObjectProperty - those are unsatisfiable.

Regardless of the technique used, the method returns the unsatisfiable properties to the main validate() method, where they are reported as before.

## Testing
I've updated the tests for unsat properties (added as part of https://github.com/ontodev/robot/pull/133) to check behavior under the HermiT and Elk reasoners, as representative examples of reasoners that use each of the two main branches of `getUnsatisfiableObjectProperties()` (before, the tests only covered use of Elk).