### PR TITLE
Preserve prefixes from loaded ontology.

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -859,6 +859,14 @@ public class IOHelper {
       saveCompressedOntology(data, ontologyIRI);
       return ontology;
     }
+    OWLDocumentFormat previousFormat = ontology.getOWLOntologyManager().getOntologyFormat(ontology);
+    if (format.isPrefixOWLOntologyFormat()
+        && previousFormat != null
+        && previousFormat.isPrefixOWLOntologyFormat()) {
+      format
+          .asPrefixOWLOntologyFormat()
+          .setPrefixManager(previousFormat.asPrefixOWLOntologyFormat());
+    }
     // If not compressed, just save the file as-is
     if (addPrefixes != null && !addPrefixes.isEmpty()) {
       addPrefixes(format, addPrefixes);

--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -863,9 +863,11 @@ public class IOHelper {
     if (format.isPrefixOWLOntologyFormat()
         && previousFormat != null
         && previousFormat.isPrefixOWLOntologyFormat()) {
+      String defaultNamespace = format.asPrefixOWLOntologyFormat().getDefaultPrefix();
       format
           .asPrefixOWLOntologyFormat()
-          .setPrefixManager(previousFormat.asPrefixOWLOntologyFormat());
+          .copyPrefixesFrom(previousFormat.asPrefixOWLOntologyFormat());
+      format.asPrefixOWLOntologyFormat().setDefaultPrefix(defaultNamespace);
     }
     // If not compressed, just save the file as-is
     if (addPrefixes != null && !addPrefixes.isEmpty()) {

--- a/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
@@ -190,6 +190,37 @@ public class IOHelperTest extends CoreTest {
   }
 
   /**
+   * Test that original prefixes are preserved when saving.
+   *
+   * @throws IOException on file problem
+   */
+  @Test
+  public void testPrefixConservation() throws IOException {
+    OWLOntology ontology = loadOntology("/simple.owl");
+    String origNamespace =
+        ontology
+            .getOWLOntologyManager()
+            .getOntologyFormat(ontology)
+            .asPrefixOWLOntologyFormat()
+            .getPrefix("obo:");
+
+    File tempFile = File.createTempFile("simple-roundtrip", ".owl");
+    tempFile.deleteOnExit();
+    IOHelper ioHelper = new IOHelper();
+    ioHelper.saveOntology(ontology, new RDFXMLDocumentFormat(), tempFile);
+
+    OWLOntology ontology2 = ioHelper.loadOntology(tempFile.getPath());
+    String savedNamespace =
+        ontology2
+            .getOWLOntologyManager()
+            .getOntologyFormat(ontology2)
+            .asPrefixOWLOntologyFormat()
+            .getPrefix("obo:");
+
+    assertEquals(origNamespace, savedNamespace);
+  }
+
+  /**
    * Test getting terms from strings.
    *
    * @throws IOException on file problem


### PR DESCRIPTION
Resolves #1101.

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

This change gets the document format used to load the ontology, and sets it as the prefix manager for the document format being used to save the ontology.
