### PR TITLE
Add a test case for conservation of prefixes.

### DIFF
--- a/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
@@ -190,6 +190,37 @@ public class IOHelperTest extends CoreTest {
   }
 
   /**
+   * Test that original prefixes are preserved when saving.
+   *
+   * @throws IOException on file problem
+   */
+  @Test
+  public void testPrefixConservation() throws IOException {
+    OWLOntology ontology = loadOntology("/simple.owl");
+    String origNamespace =
+        ontology
+            .getOWLOntologyManager()
+            .getOntologyFormat(ontology)
+            .asPrefixOWLOntologyFormat()
+            .getPrefix("obo:");
+
+    File tempFile = File.createTempFile("simple-roundtrip", ".owl");
+    tempFile.deleteOnExit();
+    IOHelper ioHelper = new IOHelper();
+    ioHelper.saveOntology(ontology, new RDFXMLDocumentFormat(), tempFile);
+
+    OWLOntology ontology2 = ioHelper.loadOntology(tempFile.getPath());
+    String savedNamespace =
+        ontology2
+            .getOWLOntologyManager()
+            .getOntologyFormat(ontology2)
+            .asPrefixOWLOntologyFormat()
+            .getPrefix("obo:");
+
+    assertEquals(origNamespace, savedNamespace);
+  }
+
+  /**
    * Test getting terms from strings.
    *
    * @throws IOException on file problem


### PR DESCRIPTION
Add a test to #1106 to ensure that prefixes initially present in an ontology are preserved when the ontology is saved through IOHelper.

- [ ] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated
