### PR TITLE
Adding custom plugins to ROBOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for pluggable commands [#1119]
+
 ## [1.9.4] - 2023-05-23
 
 ### Changed
@@ -365,6 +368,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#1119]: https://github.com/ontodev/robot/pull/1119
 [#1100]: https://github.com/ontodev/robot/pull/1100
 [#1091]: https://github.com/ontodev/robot/issues/1091
 [#1089]: https://github.com/ontodev/robot/issues/1089

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -27,6 +27,7 @@
           <a href="/chaining">chaining commands</a><br>
           <a href="/global">global options</a><br>
           <a href="/make">makefile</a><br>
+          <a href="/plugins">plugins</a><br>
           - - - - - - - - - -<br>
           <a href="/annotate">annotate</a><br>
           <a href="/collapse">collapse</a><br>

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,36 @@
+# Plugins
+
+The set of ROBOT commands can be extended locally with plugins. A ROBOT plugin is a Java archive file (`.jar`) providing one or more supplementary commands (hereafter called "pluggable commands").
+
+## Using plugins
+
+ROBOT searches for plugins in the following locations:
+
+* the `.robot/plugins` directory in the current user's home directory;
+* the directory specified by the Java system property `robot.pluginsdir`, if such a property is set;
+* the directory specified by the environment variable `ROBOT_PLUGINS_DIRECTORY`, if such a variable is set in the environment.
+
+Installing a plugin is therefore simply a matter of either
+
+* placing the Jar file into your `~/.robot/plugins` directory, or
+* placing the Jar file into any directory and making sure ROBOT knows to search that directory, by setting the `robot.pluginsdir` system property or the `ROBOT_DIRECTORY_PLUGINS` environment variable accordingly.
+
+Importantly, the basename of the Jar file (without the `.jar` extension) within the directory will become part of the name of any pluggable command provided by the plugin. For example, if the file is named `myplugin.jar` and it provides a command called `mycommand`, that command will be available under the name `myplugin:mycommand`. Because of that:
+
+* the name of the Jar file **must** be in lowercase only;
+* the name **should** be kept short and simple.
+
+Once the plugin is installed, any pluggable command it provides is immediately available to ROBOT. You can check by calling `robot` without any argument to get it to print the full list of available commands, which will include the commands provided by installed plugins, if any.
+
+## Creating plugins
+
+A pluggable command, just like any other ROBOT command, is a Java class that implements the `org.obolibrary.robot.Command` interface. A plugin is Java archive file that contains at least:
+
+* the compiled Java code ("bytecode") for at least one class implementing the `org.obolibrary.robot.Command` interface, and
+* a `META-INF/services/org.obolibrary.robot.Command` file that list all implementations of that interface available in the archive (one per line).
+
+For example, if the command `mycommand` is implemented in a class named `MyCommand` in the package `org.example.myplugin`, the `META-INF/services/org.obolibrary.robot.Command` file must contain a single line `org.example.myplugin.MyCommand`.
+
+In addition to the class implementing the command itself, the archive must also provide any additional classes that may be required for the command to work. This must include classes from any external dependency, unless that dependency also happens to be a dependency of ROBOT itself (for example, there is no need for the archive to contain a copy of the classes of the OWL API, since they are already present in the standard distribution of ROBOT).
+
+A more detailed walkthrough of how to create a plugin is available [here](https://incenp.org/notes/2023/writing-robot-plugins.html).

--- a/robot-command/src/main/java/org/obolibrary/robot/CommandLineInterface.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/CommandLineInterface.java
@@ -46,6 +46,10 @@ public class CommandLineInterface {
     m.addCommand("unmerge", new UnmergeCommand());
     m.addCommand("validate-profile", new ValidateProfileCommand());
     m.addCommand("verify", new VerifyCommand());
+
+    PluginManager pm = new PluginManager();
+    pm.addPluggableCommands(m);
+
     return m;
   }
 

--- a/robot-command/src/main/java/org/obolibrary/robot/PluginManager.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/PluginManager.java
@@ -1,0 +1,96 @@
+package org.obolibrary.robot;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.HashMap;
+import java.util.ServiceLoader;
+
+/**
+ * Pluggable commands loader.
+ *
+ * @author <a href="mailto:dgouttegattat@incenp.org">Damien Goutte-Gattat</a>
+ */
+public class PluginManager {
+  private HashMap<String, URL> jars = null;
+
+  /**
+   * Find pluggable commands and add them to a CommandManager.
+   *
+   * @param cm the command manager to add commands to
+   */
+  public void addPluggableCommands(CommandManager cm) {
+    if (jars == null) {
+      findPlugins();
+    }
+
+    loadPlugin(cm, null, "");
+    for (String pluginBasename : jars.keySet()) {
+      loadPlugin(cm, jars.get(pluginBasename), pluginBasename + ":");
+    }
+  }
+
+  /**
+   * Load pluggable commands from a Jar file.
+   *
+   * @param cm the command manager to add commands to
+   * @param jarFile the Jar file to load commands from; if null, will attempt to find pluggable
+   *     commands in the system class path
+   * @param prefix a string to prepend to the name of each pluggable command when adding them to the
+   *     command manager
+   */
+  private void loadPlugin(CommandManager cm, URL jarFile, String prefix) {
+    ClassLoader classLoader =
+        jarFile != null
+            ? URLClassLoader.newInstance(new URL[] {jarFile})
+            : URLClassLoader.getSystemClassLoader();
+
+    ServiceLoader<Command> serviceLoader = ServiceLoader.load(Command.class, classLoader);
+    for (Command pluggableCommand : serviceLoader) {
+      cm.addCommand(prefix + pluggableCommand.getName(), pluggableCommand);
+    }
+  }
+
+  /**
+   * Detect Jar files in a set of directories. If a Jar file with the same basename is found in more
+   * than one directory, the last one found takes precedence.
+   */
+  private void findPlugins() {
+    String[] pluginsDirectories = {
+      System.getProperty("robot.pluginsdir"),
+      System.getenv("ROBOT_PLUGINS_DIRECTORY"),
+      new File(System.getProperty("user.home"), ".robot/plugins").getPath()
+    };
+    FilenameFilter jarFilter =
+        new FilenameFilter() {
+          @Override
+          public boolean accept(File file, String name) {
+            return name.endsWith(".jar");
+          }
+        };
+
+    jars = new HashMap<String, URL>();
+
+    for (String directoryName : pluginsDirectories) {
+      if (directoryName == null || directoryName.length() == 0) {
+        continue;
+      }
+
+      File directory = new File(directoryName);
+      if (directory.isDirectory()) {
+        for (File jarFile : directory.listFiles(jarFilter)) {
+          try {
+            String basename = jarFile.getName();
+            basename = basename.substring(0, basename.length() - 4);
+            jars.put(basename, jarFile.toURI().toURL());
+          } catch (MalformedURLException e) {
+            // This should never happen: the URL is constructed by the Java Class Library
+            // from a real filename, it should never be malformed.
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the possibility of using _pluggable commands_, or commands that are not part of the built-in set of commands but are instead provided by third-party plugins.

# Rationale

Reasons to enable the use of plugins include:

* fast prototyping and testing of possible future built-in commands (a new command could be first distributed as a plugin, without requiring a ROBOT release, before being ultimately co-opted to become a built-in command);
* allowing the creation and use of “niche” commands that someone may need, but that have a scope too narrow to warrant being included a built-in commands;
* lowering the bar for using Java to create specialized OBO manipulation tools (by delegating command line parsing and I/O operations to ROBOT, and focusing instead solely on the task at hand);
* simplifying and improving complex pipelines that currently require alternating between ROBOT and other tools, if those other tools could be replaced by ROBOT (pluggable) commands.

# Proposed behaviour

This PR implements the following behaviour:

At startup, after the built-in commands have been registered to the `org.obolibrary.robot.CommandManager`, ROBOT looks for Jar files in a pre-defined set of directories:

* the directory specified by the `robot.pluginsdir` Java system property, if any;
* the directory specified by the `ROBOT_PLUGINS_DIRECTORY` environment variable, if any;
* the calling user’s `~/.robot/plugins` directory.

In each Jar file found in those directories, ROBOT looks for a [service provider](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) for the `org.obolibrary.robot.Command` interface – that is, it looks for a resource file named `META-INF/services/org.obolibrary.robot.Command`, containing a list of classes implementing that interface. If such a service is found in a Jar file, the corresponding classes (i.e. the commands) are added to the set of commands recognized by the `CommandManager`.

To avoid clashes between command names (e.g. a plugin providing a command with the same name as a built-in command, or two plugins providing two commands with the same name), the basename of the Jar file that provides a command is prepended to the actual command name (as returned by the `org.obolibrary.robot.Command#getName()` method) when the command is added to the `CommandManager`. For example, if the file `foo.jar` provides a command named `bar`, that command will be registered under the name `foo:bar` – that’s how it will be listed in ROBOT’s help message, and how it will need to be invoked on the command line.

# How to create a plugin

Developers wishing to create a plugin have to:

1) Write a class implementing the `org.obolibrary.robot.Command` interface, for each command they wish to create, the same way the built-in commands are implemented.

2) Package the compiled Java classes in a Jar file.

3) Add to that Jar file a `META-INF/services/org.obolibrary.robot.Command` file, containing a list of all the fully qualified class names representing the commands they wish to “expose” to ROBOT.

# Examples

My [robot-plugins](https://git.incenp.org/damien/robot-plugins) repository contains an example of a plugin providing two pluggable commands: `hello`, a pure “proof-of-concept” command (it does nothing useful except injecting a silly annotation into the current ontology), and `merge-species`, a re-implementation of owltools’s `--merge-species-ontology` command.

Another example is available in my [ocelliless](https://github.com/gouttegd/ocelliless) repository, where a ROBOT command version of the `ocelliless` tool exists in the [as-robot-plugin](https://github.com/gouttegd/ocelliless/tree/as-robot-plugin) branch.

- [x] `docs/` have been added/updated 
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated
