### PR TITLE
Fix typo in multiple_definitions query title

### DIFF
--- a/docs/report_queries/multiple_definitions.md
+++ b/docs/report_queries/multiple_definitions.md
@@ -1,4 +1,4 @@
-# Multiple Defintions
+# Multiple Definitions
 
 **Problem:** An entity has more than one definition or elucidation. This may cause confusion or misuse, and will prevent translation to OBO format (in case of multiple definitions). Excludes deprecated entities.
 


### PR DESCRIPTION
Resolves

- [x] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

Fixex typo in title of report query `multiple_definitions.md`
