### PR TITLE
Fixes robot-core Junit test failures due to line ending differences

### DIFF
--- a/robot-core/src/test/java/org/obolibrary/robot/DiffOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/DiffOperationTest.java
@@ -55,7 +55,8 @@ public class DiffOperationTest extends CoreTest {
     assertFalse(actual);
     String expected =
         IOUtils.toString(
-            this.getClass().getResourceAsStream("/simple1.diff"), Charset.defaultCharset());
+                this.getClass().getResourceAsStream("/simple1.diff"), Charset.defaultCharset())
+            .replaceAll("\r\n", "\n");
     assertEquals(expected, writer.toString());
   }
 
@@ -77,7 +78,8 @@ public class DiffOperationTest extends CoreTest {
     assertFalse(actual);
     String expected =
         IOUtils.toString(
-            this.getClass().getResourceAsStream("/simple.diff"), Charset.defaultCharset());
+                this.getClass().getResourceAsStream("/simple.diff"), Charset.defaultCharset())
+            .replaceAll("\r\n", "\n");
     assertEquals(expected, writer.toString());
   }
 

--- a/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/IOHelperTest.java
@@ -53,7 +53,7 @@ public class IOHelperTest extends CoreTest {
     ioh.addPrefixes(context);
 
     // Get the context back from IOHelper
-    String outputContext = ioh.getContextString();
+    String outputContext = ioh.getContextString().replaceAll("\r\n", "\n");
     assertEquals(inputContext, outputContext);
   }
 
@@ -166,7 +166,7 @@ public class IOHelperTest extends CoreTest {
 
     String json =
         "{\n" + "  \"@context\" : {\n" + "    \"foo\" : \"http://example.com#\"\n" + "  }\n" + "}";
-    assertEquals("Check JSON-LD", json, ioh.getContextString());
+    assertEquals("Check JSON-LD", json, ioh.getContextString().replaceAll("\r\n", "\n"));
 
     ioh.addPrefix("bar: http://example.com#");
     expected.put("bar", "http://example.com#");

--- a/robot-core/src/test/java/org/obolibrary/robot/ReportOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ReportOperationTest.java
@@ -48,12 +48,14 @@ public class ReportOperationTest extends CoreTest {
           File.createTempFile("1016-report-json-failure-output", "." + extension);
       ReportOperation.report(ontology, iohelper, outputFile.toString(), Collections.emptyMap());
       final String output =
-          IOUtils.toString(new FileInputStream(outputFile), Charset.defaultCharset()).trim();
+          IOUtils.toString(new FileInputStream(outputFile), Charset.defaultCharset())
+              .trim()
+              .replaceAll("\r\n", "\n");
       final InputStream expected =
           getClass().getResourceAsStream("/1016-report-json-failure/output." + extension);
       assert expected != null;
       final String expectedOutput =
-          IOUtils.toString(expected, StandardCharsets.UTF_8.name()).trim();
+          IOUtils.toString(expected, StandardCharsets.UTF_8.name()).trim().replaceAll("\r\n", "\n");
       Assert.assertEquals(expectedOutput, output);
     } catch (YAMLException e) {
       e.printStackTrace();


### PR DESCRIPTION
Resolves [#1146]

- [x] `docs/` have been added/updated - no doc changes needed
- [x] tests have been added/updated - fixes existing test
- [x] `mvn verify` says all tests pass - on Windows and *nix
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated - minor code change, no change to log

[DESCRIPTION, fixes #1146 by replacing Windows line endings with \n in failing tests. ]
