### PR TITLE
Export cmd bugfixes

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
@@ -11,13 +11,9 @@ import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.search.EntitySearcher;
 import org.semanticweb.owlapi.util.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** @author <a href="mailto:rbca.jackson@gmail.com">Becky Jackson</a> */
 public class ExportOperation {
-  /** Logger. */
-  private static final Logger logger = LoggerFactory.getLogger(ExportOperation.class);
 
   /** Namespace for error messages. */
   private static final String NS = "export#";
@@ -728,11 +724,10 @@ public class ExportOperation {
             }
           }
           break;
+          // TODO
         case DATA_HAS_VALUE:
-          logger.warn(t + "is not yet implemented as target of data property" + ce);
+          break;
         default:
-          // This should never happen in valid OWL
-          logger.error("A " + t + " cannot be a target of a data property:" + ce);
           break;
       }
     }
@@ -841,24 +836,24 @@ public class ExportOperation {
             }
           }
           break;
-        case OBJECT_ONE_OF:
-        case OBJECT_UNION_OF:
-        case OBJECT_INTERSECTION_OF:
-        case OBJECT_HAS_SELF:
-        case OBJECT_HAS_VALUE:
-        case OBJECT_COMPLEMENT_OF:
           // TODO
-          logger.warn(t + " is not yet implemented as target of object property:" + ce);
+        case OBJECT_HAS_VALUE:
+          // property value instance
+        case OBJECT_COMPLEMENT_OF:
+          // not ce
+        case OBJECT_HAS_SELF:
+          // property Self
+          // this requires the subject entity to render
+        case OBJECT_ONE_OF:
+          // {instance, instance,...}
+          // this should not occur
+        case OBJECT_UNION_OF:
+          // ce or ce or ce
+          // this should not occur
+        case OBJECT_INTERSECTION_OF:
+          // ce and ce and ce
+          // this should not occur
           break;
-        case OWL_CLASS:
-        case DATA_ALL_VALUES_FROM:
-        case DATA_EXACT_CARDINALITY:
-        case DATA_HAS_VALUE:
-        case DATA_MAX_CARDINALITY:
-        case DATA_MIN_CARDINALITY:
-        case DATA_SOME_VALUES_FROM:
-          // Should never happen in valid OWL
-          logger.error("A " + t + " cannot be a target of an object property:" + ce);
         default:
           break;
       }
@@ -1155,6 +1150,7 @@ public class ExportOperation {
           if (entity.isOWLClass()) {
             Collection<OWLClassExpression> disjoints =
                 EntitySearcher.getDisjointClasses(entity.asOWLClass(), ontology);
+            // remove self-disjoint
             disjoints.remove(entity.asOWLClass());
             row.add(
                 getObjectCell(
@@ -1169,7 +1165,7 @@ public class ExportOperation {
           } else if (entity.isOWLDataProperty()) {
             Collection<OWLDataPropertyExpression> disjoints =
                 EntitySearcher.getDisjointProperties(entity.asOWLDataProperty(), ontology);
-            //remove self-disjoint
+            // remove self-disjoint
             disjoints.remove(entity.asOWLDataProperty());
             row.add(
                 getObjectCell(
@@ -1184,7 +1180,7 @@ public class ExportOperation {
           } else if (entity.isOWLObjectProperty()) {
             Collection<OWLObjectPropertyExpression> disjoints =
                 EntitySearcher.getDisjointProperties(entity.asOWLObjectProperty(), ontology);
-          //remove self-disjoint
+          // remove self-disjoint
             disjoints.remove(entity.asOWLObjectProperty());
             row.add(
                 getObjectCell(

--- a/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
@@ -1180,7 +1180,7 @@ public class ExportOperation {
           } else if (entity.isOWLObjectProperty()) {
             Collection<OWLObjectPropertyExpression> disjoints =
                 EntitySearcher.getDisjointProperties(entity.asOWLObjectProperty(), ontology);
-          // remove self-disjoint
+            // remove self-disjoint
             disjoints.remove(entity.asOWLObjectProperty());
             row.add(
                 getObjectCell(

--- a/robot-core/src/main/java/org/obolibrary/robot/export/Row.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/export/Row.java
@@ -82,8 +82,7 @@ public class Row {
 
       String value;
       String comment = null;
-      CellStyle style = wb.createCellStyle();
-      Font font = wb.createFont();
+
       if (cell != null) {
         List<String> values = cell.getDisplayValues();
         if (values.size() > 1) {
@@ -93,52 +92,65 @@ public class Row {
         }
         value = String.join(split, values);
 
-        // Maybe set styles
-        IndexedColors cellColor = cell.getCellColor();
-        if (violationLevel != null) {
-          switch (violationLevel.toLowerCase()) {
-            case "error":
-              cellColor = IndexedColors.ROSE;
-              break;
-            case "warn":
-              cellColor = IndexedColors.LEMON_CHIFFON;
-              break;
-            case "info":
-              cellColor = IndexedColors.LIGHT_CORNFLOWER_BLUE;
-          }
-        }
-
-        if (cellColor != null) {
-          style.setFillForegroundColor(cellColor.getIndex());
-        }
-
-        FillPatternType cellPattern = cell.getCellPattern();
-        if (cellColor != null && cellPattern == null) {
-          cellPattern = FillPatternType.SOLID_FOREGROUND;
-        }
-        if (cellPattern != null) {
-          style.setFillPattern(cellPattern);
-        }
-
-        IndexedColors fontColor = cell.getFontColor();
-        if (fontColor != null) {
-          font.setColor(fontColor.getIndex());
-        }
-
-        // Maybe get a comment or null
-        comment = cell.getComment();
       } else {
         // Empty value, no styles to set
         value = "";
+        cellIdx++;
+        continue;
       }
 
       // Add value to cell
       xlsxCell.setCellValue(value);
 
-      // Add style to cell
-      style.setFont(font);
+      IndexedColors cellColor = cell.getCellColor();
+      FillPatternType cellPattern = cell.getCellPattern();
+      IndexedColors fontColor = cell.getFontColor();
+
+      if (violationLevel != null) {
+        switch (violationLevel.toLowerCase()) {
+        case "error":
+          cellColor = IndexedColors.ROSE;
+          break;
+        case "warn":
+          cellColor = IndexedColors.LEMON_CHIFFON;
+          break;
+        case "info":
+          cellColor = IndexedColors.LIGHT_CORNFLOWER_BLUE;
+        }
+      }
+
+      CellStyle style = null;
+
+      // only create style if style components are not all null
+      if (cellColor != null || cellPattern != null || fontColor != null) {
+        style = wb.createCellStyle();
+      }
+
+      // Maybe set styles
+
+      if (cellColor != null) {
+        style.setFillForegroundColor(cellColor.getIndex());
+      }
+
+      if (cellColor != null && cellPattern == null) {
+        cellPattern = FillPatternType.SOLID_FOREGROUND;
+      }
+
+      if (cellPattern != null) {
+        style.setFillPattern(cellPattern);
+      }
+
+      if (fontColor != null) {
+        Font font = wb.createFont();
+        font.setColor(fontColor.getIndex());
+        style.setFont(font);
+      }
+
+      // Add style to cell, null is OK
       xlsxCell.setCellStyle(style);
 
+      // Maybe get a comment or null
+      comment = cell.getComment();
       // Maybe add a comment
       if (comment != null) {
         Comment xlsxComment = drawing.createCellComment(anchor);

--- a/robot-core/src/main/java/org/obolibrary/robot/export/Row.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/export/Row.java
@@ -82,7 +82,8 @@ public class Row {
 
       String value;
       String comment = null;
-
+      CellStyle style = null;
+      Font font = null;
       if (cell != null) {
         List<String> values = cell.getDisplayValues();
         if (values.size() > 1) {
@@ -92,65 +93,65 @@ public class Row {
         }
         value = String.join(split, values);
 
+        // Maybe set styles
+        IndexedColors cellColor = cell.getCellColor();
+        if (violationLevel != null) {
+          switch (violationLevel.toLowerCase()) {
+            case "error":
+              cellColor = IndexedColors.ROSE;
+              break;
+            case "warn":
+              cellColor = IndexedColors.LEMON_CHIFFON;
+              break;
+            case "info":
+              cellColor = IndexedColors.LIGHT_CORNFLOWER_BLUE;
+          }
+        }
+
+        if (cellColor != null) {
+          if (style == null) {
+            style = wb.createCellStyle();
+          }
+          style.setFillForegroundColor(cellColor.getIndex());
+        }
+
+        FillPatternType cellPattern = cell.getCellPattern();
+        if (cellColor != null && cellPattern == null) {
+          cellPattern = FillPatternType.SOLID_FOREGROUND;
+        }
+
+        if (cellPattern != null) {
+          if (style == null) {
+            style = wb.createCellStyle();
+          }
+          style.setFillPattern(cellPattern);
+        }
+
+        IndexedColors fontColor = cell.getFontColor();
+        if (fontColor != null) {
+          if (style == null) {
+            style = wb.createCellStyle();
+          }
+          if (font == null) {
+            font = wb.createFont();
+          }
+          font.setColor(fontColor.getIndex());
+          style.setFont(font);
+        }
+
+        // Maybe get a comment or null
+        comment = cell.getComment();
       } else {
         // Empty value, no styles to set
         value = "";
-        cellIdx++;
-        continue;
       }
 
       // Add value to cell
       xlsxCell.setCellValue(value);
 
-      IndexedColors cellColor = cell.getCellColor();
-      FillPatternType cellPattern = cell.getCellPattern();
-      IndexedColors fontColor = cell.getFontColor();
-
-      if (violationLevel != null) {
-        switch (violationLevel.toLowerCase()) {
-        case "error":
-          cellColor = IndexedColors.ROSE;
-          break;
-        case "warn":
-          cellColor = IndexedColors.LEMON_CHIFFON;
-          break;
-        case "info":
-          cellColor = IndexedColors.LIGHT_CORNFLOWER_BLUE;
-        }
-      }
-
-      CellStyle style = null;
-
-      // only create style if style components are not all null
-      if (cellColor != null || cellPattern != null || fontColor != null) {
-        style = wb.createCellStyle();
-      }
-
-      // Maybe set styles
-
-      if (cellColor != null) {
-        style.setFillForegroundColor(cellColor.getIndex());
-      }
-
-      if (cellColor != null && cellPattern == null) {
-        cellPattern = FillPatternType.SOLID_FOREGROUND;
-      }
-
-      if (cellPattern != null) {
-        style.setFillPattern(cellPattern);
-      }
-
-      if (fontColor != null) {
-        Font font = wb.createFont();
-        font.setColor(fontColor.getIndex());
-        style.setFont(font);
-      }
-
       // Add style to cell, null is OK
       xlsxCell.setCellStyle(style);
 
-      // Maybe get a comment or null
-      comment = cell.getComment();
       // Maybe add a comment
       if (comment != null) {
         Comment xlsxComment = drawing.createCellComment(anchor);

--- a/robot-core/src/test/java/org/obolibrary/robot/ExportOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ExportOperationTest.java
@@ -13,7 +13,6 @@ import org.junit.Test;
 import org.obolibrary.robot.export.Table;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.AxiomType;
-import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLObjectProperty;
@@ -103,14 +102,14 @@ public class ExportOperationTest extends CoreTest {
     List<String> columns = Arrays.asList("ID", "SubClass Of [ID]");
     Map<String, String> options = ExportOperation.getDefaultOptions();
     options.put("include", "classes");
-    
+
     // Create the table and render it as a Workbook
     Table t = ExportOperation.createExportTable(ontology, ioHelper, columns, options);
     Workbook wb = t.asWorkbook("|");
 
     // get the first sheet
     Sheet s = wb.getSheetAt(0);
-    
+
     // There should be same number of rows as subclass axioms + 1 for the header row
     assert (s.getLastRowNum() == ontology.getAxiomCount(AxiomType.SUBCLASS_OF) + 1);
   }
@@ -126,7 +125,7 @@ public class ExportOperationTest extends CoreTest {
     IOHelper ioHelper = new IOHelper();
     ioHelper.addPrefix(
         "simple", "https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl#");
-    
+
     // every named header
     List<String> columns =
         Arrays.asList(
@@ -158,26 +157,25 @@ public class ExportOperationTest extends CoreTest {
     assert (s.getLastRowNum() == 3);
 
     // Validate header
-    // should match size and label 
+    // should match size and label
     org.apache.poi.ss.usermodel.Row header = s.getRow(0);
-    
+
     short minColIx = header.getFirstCellNum();
     short maxColIx = header.getLastCellNum();
     int numCol = maxColIx - minColIx;
     // same width
     assert (numCol == columns.size());
-    
+
     // column header labels should match
-    for(short colIx=minColIx; colIx<maxColIx; colIx++) {
-       Cell cell = header.getCell(colIx);
-      if(cell == null) {
+    for (short colIx = minColIx; colIx < maxColIx; colIx++) {
+      Cell cell = header.getCell(colIx);
+      if (cell == null) {
         continue;
       }
       String foundHeader = cell.getStringCellValue();
       String expectedHeader = columns.get(colIx);
       assert (foundHeader.equals(expectedHeader));
     }
-
   }
 
   /**
@@ -196,13 +194,13 @@ public class ExportOperationTest extends CoreTest {
     Set<OWLObjectProperty> properties = ontology.getObjectPropertiesInSignature(Imports.EXCLUDED);
 
     IOHelper ioHelper = new IOHelper();
-    ioHelper.addPrefix(
-        "ax", "https://http://robot.obolibrary.org/export_test/");
-    
+    ioHelper.addPrefix("ax", "https://http://robot.obolibrary.org/export_test/");
+
     // every named header
     List<String> columns = new ArrayList<String>();
-        
-    List<String> hdrLabels = Arrays.asList(
+
+    List<String> hdrLabels =
+        Arrays.asList(
             "ID",
             "LABEL",
             "Type",
@@ -219,13 +217,13 @@ public class ExportOperationTest extends CoreTest {
             "Range");
 
     columns.addAll(hdrLabels);
-    
-    //add all the object properties to the header
-    for(OWLObjectProperty op : properties) {
-     String shrt = ioHelper.getPrefixManager().getShortForm(op.getIRI());
-     columns.add(shrt);
+
+    // add all the object properties to the header
+    for (OWLObjectProperty op : properties) {
+      String shrt = ioHelper.getPrefixManager().getShortForm(op.getIRI());
+      columns.add(shrt);
     }
-    
+
     // export everything
     Map<String, String> options = ExportOperation.getDefaultOptions();
     options.put("include", "classes individuals properties");
@@ -239,25 +237,24 @@ public class ExportOperationTest extends CoreTest {
     assert (s.getLastRowNum() == entityCount);
 
     // Validate header
-    // should match size and label 
+    // should match size and label
     org.apache.poi.ss.usermodel.Row header = s.getRow(0);
-    
+
     short minColIx = header.getFirstCellNum();
     short maxColIx = header.getLastCellNum();
     int numCol = maxColIx - minColIx;
     // should be same width
     assert (numCol == columns.size());
-    
+
     // column header labels should match workbook
-    for(short colIx=minColIx; colIx<maxColIx; colIx++) {
-       Cell cell = header.getCell(colIx);
-      if(cell == null) {
+    for (short colIx = minColIx; colIx < maxColIx; colIx++) {
+      Cell cell = header.getCell(colIx);
+      if (cell == null) {
         continue;
       }
       String foundHeader = cell.getStringCellValue();
       String expectedHeader = columns.get(colIx);
       assert (foundHeader.equals(expectedHeader));
     }
-
   }
 }

--- a/robot-core/src/test/java/org/obolibrary/robot/ExportOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ExportOperationTest.java
@@ -191,20 +191,10 @@ public class ExportOperationTest extends CoreTest {
     Set<OWLEntity> signature = ontology.getSignature();
     // remove datatypes
     signature.removeAll(ontology.getDatatypesInSignature());
-
-    for (OWLEntity s : signature) {
-      System.out.println(s + "|" + s.getEntityType());
-    }
-
     int entityCount = signature.size();
-    Set<IRI> puns = ontology.getPunnedIRIs(Imports.EXCLUDED);
-    for (IRI pun : puns) {
-      Set<OWLEntity> punnedEntities = ontology.getEntitiesInSignature(pun, Imports.EXCLUDED);
-      System.out.println(punnedEntities.size() + " " + punnedEntities.toString());
-    }
 
     Set<OWLObjectProperty> properties = ontology.getObjectPropertiesInSignature(Imports.EXCLUDED);
-    
+
     IOHelper ioHelper = new IOHelper();
     ioHelper.addPrefix(
         "ax", "https://http://robot.obolibrary.org/export_test/");

--- a/robot-core/src/test/java/org/obolibrary/robot/ExportOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ExportOperationTest.java
@@ -8,7 +8,13 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.junit.Test;
 import org.obolibrary.robot.export.Table;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.AxiomType;
+import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
+import org.semanticweb.owlapi.util.DefaultPrefixManager;
 
 /**
  * Tests ExportOperation.
@@ -53,4 +59,82 @@ public class ExportOperationTest extends CoreTest {
     v2 = r2.getCell(1).getStringCellValue();
     assert (v2.equals("simple:test1"));
   }
+
+  /**
+   * Test exporting ontology with > 64,000 exported records.
+   *
+   * @throws Exception on any problem
+   */
+  @Test
+  public void testLargeExcelExport() throws Exception {
+
+    //how many many axioms to create
+    int axiomCount = 64002;
+
+    IOHelper ioHelper = new IOHelper();
+    ioHelper.addPrefix("simple", "https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl#");
+
+    DefaultPrefixManager pfm = ioHelper.getPrefixManager();
+
+    OWLOntologyManager owlm = OWLManager.createOWLOntologyManager();
+    OWLOntology ontology =  owlm.createOntology();
+    
+
+    // add axiomCount subclass axioms to ontology
+    OWLClass superClass = CoreTest.dataFactory.getOWLClass("simple:super", pfm);
+    
+    for (int i = 0; i < axiomCount; i++) {
+      OWLClass subClass = CoreTest.dataFactory.getOWLClass("simple:sub_" + i, pfm);
+      OWLSubClassOfAxiom subAxiom =
+          CoreTest.dataFactory.getOWLSubClassOfAxiom(subClass, superClass);
+      owlm.addAxiom(ontology, subAxiom);
+    }
+
+    // export all the subclasses
+    List<String> columns = Arrays.asList("ID", "SubClass Of [ID]");
+    Map<String, String> options = ExportOperation.getDefaultOptions();
+
+    // Create the table and render it as a Workbook
+    Table t = ExportOperation.createExportTable(ontology, ioHelper, columns, options);
+    Workbook wb = t.asWorkbook("|");
+
+    Sheet s = wb.getSheetAt(0);
+    // There should be same number of rows as subclass axioms + 1 for the header row
+    assert (s.getLastRowNum() == ontology.getAxiomCount(AxiomType.SUBCLASS_OF)+1);
+
+  }
+  
+  /**
+   * Test exporting all named headings.
+   *
+   * @throws Exception on any problem
+   */
+  @Test
+  public void testExportNamedHeadings() throws Exception {
+    OWLOntology ontology = loadOntology("/simple.owl");
+    IOHelper ioHelper = new IOHelper();
+    ioHelper.addPrefix(
+        "simple", "https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl#");
+    List<String> columns = Arrays.asList("ID", "IRI", "CURIE","LABEL", "Type", "SYNONYMS", "SUBCLASSES", "SubClass Of",
+        "SubProperty Of", "Equivalent Class", "Equivalent Property", "Disjoint With", "Domain","Range");
+    Map<String, String> options = ExportOperation.getDefaultOptions();
+
+    // Create the table and render it as a Workbook
+    Table t = ExportOperation.createExportTable(ontology, ioHelper, columns, options);
+    Workbook wb = t.asWorkbook("|");
+
+    Sheet s = wb.getSheetAt(0);
+    // There should be three rows (0, 1, 2)
+    assert (s.getLastRowNum() == 2);
+
+    // Validate header
+    org.apache.poi.ss.usermodel.Row header = s.getRow(0);
+    String v1 = header.getCell(0).getStringCellValue();
+    assert (v1.equals("ID"));
+    String v2 = header.getCell(1).getStringCellValue();
+    assert (v2.equals("IRI"));
+  }
+  
+  
+  
 }

--- a/robot-core/src/test/resources/axioms.owl
+++ b/robot-core/src/test/resources/axioms.owl
@@ -1,0 +1,749 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl"
+     xml:base="https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:export_test="https://http://robot.obolibrary.org/export_test/">
+    <owl:Ontology rdf:about="https://github.com/ontodev/robot/robot-core/src/test/resources/axioms">
+        <rdfs:comment>Test ontology containing:
+ - one of all OWL Axioms
+ - one of all class expressions in a Subclass axiom
+ - 1 GCI
+ - 1 Class-Individual pun
+ - 1 Class-Object property pun
+ - 1 Class-Data property pun
+  -1 Class-Annotation property pun</rdfs:comment>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000034 -->
+
+    <owl:AnnotationProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000034">
+        <rdfs:label xml:lang="en">AnnotationProperty</rdfs:label>
+        <rdfs:range rdf:resource="https://http://robot.obolibrary.org/export_test/c000005"/>
+        <rdfs:domain rdf:resource="https://http://robot.obolibrary.org/export_test/c000004"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000052 -->
+
+    <owl:AnnotationProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000052"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000015 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000015">
+        <owl:equivalentProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000023"/>
+        <rdfs:label xml:lang="en">ObjectProperty1</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000016 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000016">
+        <rdfs:domain rdf:resource="https://http://robot.obolibrary.org/export_test/c000001"/>
+        <rdfs:range rdf:resource="https://http://robot.obolibrary.org/export_test/c000009"/>
+        <rdfs:label xml:lang="en">ObjectProperty2</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000020 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000020">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:label xml:lang="en">FunctionalObjectProperty</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000021 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000021">
+        <owl:inverseOf rdf:resource="https://http://robot.obolibrary.org/export_test/c000025"/>
+        <rdfs:label xml:lang="en">InverseObjectProperty</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000022 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000022">
+        <owl:propertyDisjointWith rdf:resource="https://http://robot.obolibrary.org/export_test/c000026"/>
+        <rdfs:label xml:lang="en">DisjointObjectProperty</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000023 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000023">
+        <rdfs:label xml:lang="en">DuplicateObjectProperty</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000024 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000024">
+        <owl:propertyChainAxiom rdf:parseType="Collection">
+            <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000015"/>
+            <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000016"/>
+        </owl:propertyChainAxiom>
+        <rdfs:label xml:lang="en">ChainedObjectProperty</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000025 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000025">
+        <rdfs:label xml:lang="en">OtherInverseProperty</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000026 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000026">
+        <rdfs:label xml:lang="en">OtherDisjointObjectProperty</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000027 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000027">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+        <rdfs:label xml:lang="en">InverseFunctionalObjectProperty</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000028 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000028">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:label xml:lang="en">TransitiveObjectProperty</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000029 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000029">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
+        <rdfs:label xml:lang="en">SymmetricObjectProperty</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000030 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000030">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AsymmetricProperty"/>
+        <rdfs:label xml:lang="en">AsymmetricObjectProperty</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000031 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000031">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ReflexiveProperty"/>
+        <rdfs:label xml:lang="en">ReflexiveObjectProperty</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000032 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000032">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#IrreflexiveProperty"/>
+        <rdfs:label xml:lang="en">IrreflexiveObjectProperty</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000033 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000033">
+        <rdfs:subPropertyOf rdf:resource="https://http://robot.obolibrary.org/export_test/c000015"/>
+        <rdfs:label xml:lang="en">SubObjectProperty</rdfs:label>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000047 -->
+
+    <owl:ObjectProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000047"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Data properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000011 -->
+
+    <owl:DatatypeProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000011">
+        <owl:equivalentProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000035"/>
+        <owl:propertyDisjointWith rdf:resource="https://http://robot.obolibrary.org/export_test/c000036"/>
+        <rdfs:label xml:lang="en">DataProperty1</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000012 -->
+
+    <owl:DatatypeProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000012">
+        <rdfs:domain rdf:resource="https://http://robot.obolibrary.org/export_test/c000004"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+        <rdfs:label xml:lang="en">DataProperty2</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000035 -->
+
+    <owl:DatatypeProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000035">
+        <rdfs:label xml:lang="en">DuplicateDataProperty</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000036 -->
+
+    <owl:DatatypeProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000036">
+        <rdfs:label xml:lang="en">DisjointDataProperty</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000037 -->
+
+    <owl:DatatypeProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000037">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:label xml:lang="en">FunctionalDataProperty</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000038 -->
+
+    <owl:DatatypeProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000038">
+        <rdfs:subPropertyOf rdf:resource="https://http://robot.obolibrary.org/export_test/c000011"/>
+        <rdfs:label xml:lang="en">SubDataProperty</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000050 -->
+
+    <owl:DatatypeProperty rdf:about="https://http://robot.obolibrary.org/export_test/c000050"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000000 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000000">
+        <rdfs:subClassOf rdf:resource="https://http://robot.obolibrary.org/export_test/c000001"/>
+        <rdfs:label xml:lang="en">Sub</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000001 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000001"/>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000002 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000002">
+        <owl:equivalentClass rdf:resource="https://http://robot.obolibrary.org/export_test/c000003"/>
+        <rdfs:label xml:lang="en">Equivalent1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000003 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000003">
+        <rdfs:label xml:lang="en">Equivalent2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000004 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000004">
+        <owl:disjointWith rdf:resource="https://http://robot.obolibrary.org/export_test/c000005"/>
+        <rdfs:label xml:lang="en">Disjoint1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000005 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000005">
+        <rdfs:label xml:lang="en">Disjoint2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000006 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000006">
+        <owl:disjointUnionOf rdf:parseType="Collection">
+            <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000007"/>
+            <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000008"/>
+        </owl:disjointUnionOf>
+        <rdfs:label xml:lang="en">DisjointUnion1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000007 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000007">
+        <rdfs:label xml:lang="en">DisjointUnion2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000008 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000008">
+        <rdfs:label xml:lang="en">DisjointUnion3</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000009 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000009">
+        <rdfs:label xml:lang="en">ClassAssertionClass</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000039 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000039">
+        <rdfs:label xml:lang="en">GCI1</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000040 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000040">
+        <rdfs:label xml:lang="en">GCI2</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000041 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000041">
+        <rdfs:label xml:lang="en">GCI3</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000042 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000042">
+        <rdfs:label xml:lang="en">GCI4</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000043 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000043">
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:complementOf rdf:resource="https://http://robot.obolibrary.org/export_test/c000039"/>
+            </owl:Class>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000016"/>
+                <owl:someValuesFrom rdf:resource="https://http://robot.obolibrary.org/export_test/c000001"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000016"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:intersectionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000039"/>
+                            <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000040"/>
+                        </owl:intersectionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000016"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:unionOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000041"/>
+                            <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000042"/>
+                        </owl:unionOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000016"/>
+                <owl:someValuesFrom>
+                    <owl:Class>
+                        <owl:oneOf rdf:parseType="Collection">
+                            <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000014"/>
+                            <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000017"/>
+                        </owl:oneOf>
+                    </owl:Class>
+                </owl:someValuesFrom>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000016"/>
+                <owl:allValuesFrom rdf:resource="https://http://robot.obolibrary.org/export_test/c000001"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000016"/>
+                <owl:hasValue rdf:resource="https://http://robot.obolibrary.org/export_test/c000001"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000016"/>
+                <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
+                <owl:onClass rdf:resource="https://http://robot.obolibrary.org/export_test/c000041"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000016"/>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:qualifiedCardinality>
+                <owl:onClass rdf:resource="https://http://robot.obolibrary.org/export_test/c000039"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000016"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:maxQualifiedCardinality>
+                <owl:onClass rdf:resource="https://http://robot.obolibrary.org/export_test/c000040"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000016"/>
+                <owl:hasSelf rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:hasSelf>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000012"/>
+                <owl:someValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000012"/>
+                <owl:allValuesFrom rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000011"/>
+                <owl:hasValue>34</owl:hasValue>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000012"/>
+                <owl:minQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:minQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000038"/>
+                <owl:qualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:qualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:subClassOf>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000038"/>
+                <owl:maxQualifiedCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2</owl:maxQualifiedCardinality>
+                <owl:onDataRange rdf:resource="http://www.w3.org/2001/XMLSchema#int"/>
+            </owl:Restriction>
+        </rdfs:subClassOf>
+        <rdfs:label xml:lang="en">ClassExpressionClass</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000044 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000044"/>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000047 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000047"/>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000049 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000049">
+        <owl:hasKey rdf:parseType="Collection">
+            <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000015"/>
+        </owl:hasKey>
+        <rdfs:label xml:lang="en">ClassWithKey</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000050 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000050"/>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000052 -->
+
+    <owl:Class rdf:about="https://http://robot.obolibrary.org/export_test/c000052"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000001 -->
+
+    <owl:NamedIndividual rdf:about="https://http://robot.obolibrary.org/export_test/c000001"/>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000010 -->
+
+    <owl:NamedIndividual rdf:about="https://http://robot.obolibrary.org/export_test/c000010">
+        <rdf:type rdf:resource="https://http://robot.obolibrary.org/export_test/c000009"/>
+        <owl:sameAs rdf:resource="https://http://robot.obolibrary.org/export_test/c000019"/>
+        <rdfs:label xml:lang="en">ClassAssertionInstance</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000013 -->
+
+    <owl:NamedIndividual rdf:about="https://http://robot.obolibrary.org/export_test/c000013">
+        <export_test:c000011 rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">99</export_test:c000011>
+        <rdfs:label xml:lang="en">DatapropertyAssertionInstance</rdfs:label>
+    </owl:NamedIndividual>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NegativePropertyAssertion"/>
+        <owl:sourceIndividual rdf:resource="https://http://robot.obolibrary.org/export_test/c000013"/>
+        <owl:assertionProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000011"/>
+        <owl:targetValue rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">42</owl:targetValue>
+    </rdf:Description>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000014 -->
+
+    <owl:NamedIndividual rdf:about="https://http://robot.obolibrary.org/export_test/c000014">
+        <export_test:c000015 rdf:resource="https://http://robot.obolibrary.org/export_test/c000017"/>
+        <rdfs:label xml:lang="en">ObjectPropertyAssertionSubject</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000017 -->
+
+    <owl:NamedIndividual rdf:about="https://http://robot.obolibrary.org/export_test/c000017">
+        <rdfs:label xml:lang="en">ObjectPropertyAssertionObject</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000018 -->
+
+    <owl:NamedIndividual rdf:about="https://http://robot.obolibrary.org/export_test/c000018">
+        <rdfs:label xml:lang="en">ObjectPropertyNegativeAssertionObject</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000019 -->
+
+    <owl:NamedIndividual rdf:about="https://http://robot.obolibrary.org/export_test/c000019">
+        <rdfs:label xml:lang="en">DuplicateInstance</rdfs:label>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000044 -->
+
+    <owl:NamedIndividual rdf:about="https://http://robot.obolibrary.org/export_test/c000044"/>
+    
+
+
+    <!-- https://http://robot.obolibrary.org/export_test/c000048 -->
+
+    <owl:NamedIndividual rdf:about="https://http://robot.obolibrary.org/export_test/c000048">
+        <rdfs:label xml:lang="en">ObjectPropertyNegativeAssertionSubject</rdfs:label>
+    </owl:NamedIndividual>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NegativePropertyAssertion"/>
+        <owl:sourceIndividual rdf:resource="https://http://robot.obolibrary.org/export_test/c000048"/>
+        <owl:assertionProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000015"/>
+        <owl:targetIndividual rdf:resource="https://http://robot.obolibrary.org/export_test/c000018"/>
+    </rdf:Description>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotations
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000001">
+        <rdfs:label xml:lang="en">Super</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000044">
+        <rdfs:label xml:lang="en">PunnedClass-Class-Instance</rdfs:label>
+        <rdfs:label xml:lang="en">PunnedInstance-Class-Instance</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000047">
+        <rdfs:label xml:lang="en">PunnedClass-Class-ObjectProperty</rdfs:label>
+        <rdfs:label xml:lang="en">PunnedObjectProperty-Class-ObjectProprty</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000050">
+        <rdfs:label xml:lang="en">PunnedClass-Class-DataProperty</rdfs:label>
+        <rdfs:label xml:lang="en">PunnedDataPoperty-Class-DataProperty</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000052">
+        <rdfs:label xml:lang="en">PunnedAnnotationProperty-Class-AnnotationProperty</rdfs:label>
+        <rdfs:label xml:lang="en">PunnedClass-Class-AnnotationProperty</rdfs:label>
+    </rdf:Description>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // General axioms
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <owl:Class>
+        <owl:intersectionOf rdf:parseType="Collection">
+            <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000039"/>
+            <owl:Restriction>
+                <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000015"/>
+                <owl:someValuesFrom rdf:resource="https://http://robot.obolibrary.org/export_test/c000040"/>
+            </owl:Restriction>
+        </owl:intersectionOf>
+        <rdfs:subClassOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000041"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="https://http://robot.obolibrary.org/export_test/c000016"/>
+                        <owl:someValuesFrom rdf:resource="https://http://robot.obolibrary.org/export_test/c000042"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
+        </rdfs:subClassOf>
+    </owl:Class>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDifferent"/>
+        <owl:distinctMembers rdf:parseType="Collection">
+            <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000013"/>
+            <rdf:Description rdf:about="https://http://robot.obolibrary.org/export_test/c000017"/>
+        </owl:distinctMembers>
+    </rdf:Description>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+


### PR DESCRIPTION
Resolves [#1145, resolves #1144, resolves #1131]

- [x] `docs/` have been added/updated - no doc changes needed
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated - minor changes
 
fixes #1145 - removed case statement looking for "equivalent annotation property", added test exporting all named headers, added test ontology containing one of all OWL axioms and class expressions, plus some puns
fixes #1144 - removed self-disjoint entry in returned entities
fixes #1131 - refactored to avoid creating unnecessary styles and fonts, added matching test