### PR TITLE
replace spaces in tsv examples with tabs

### DIFF
--- a/docs/rename.md
+++ b/docs/rename.md
@@ -54,8 +54,8 @@ The mappings for renaming should be specified with the `--mappings` (for full re
 For a full rename (you can use prefixes as long as they are defined by the defaults, `--prefix`, or `--add-prefix`):
 
 ```tsv
-Old IRI New IRI
-obo:BFO_0000051 fb:BFO_1234567
+Old IRI	New IRI
+obo:BFO_0000051	fb:BFO_1234567
 ```
 
 If you also want to update the `rdfs:label` of the term you replaced, you can add a third column with the new label value (note that this removes *all* old label annotations):
@@ -68,8 +68,8 @@ obo:BFO_0000051	fb:BFO_1234567	foo bar
 For a prefix rename:
 
 ```tsv
-Old Base  New Base
-http://purl.obolibrary.org/obo/ http://foo.bar/
+Old Base	New Base
+http://purl.obolibrary.org/obo/	http://foo.bar/
 ```
 
 The `rename` command expects the first line to contain headers.


### PR DESCRIPTION
Resolves …

- [x] `docs/` have been added/updated
- ~~[ ] tests have been added/updated~~ (not applicable)
- ~~[ ] `mvn verify` says all tests pass~~ (not applicable)
- ~~[ ] `mvn site` says all JavaDocs correct~~ (not applicable)
- ~~[ ] `CHANGELOG.md` has been updated~~ (not applicable)

This PR replace spaces used as column separators in example TSVs with tabs to make the examples functional.
