### PR TITLE
Handle IRIs that are not entities in export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - '--annotate-with-source true' does not work with extract --method subset [#1160]
 - Fix how Template adds entities to the QuotedEntityChecker [#1104]
+- Handle IRIs that are not entities in export [#1168]
 
 ## [1.9.5] - 2023-09-20
 
@@ -380,6 +381,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#1168]: https://github.com/ontodev/robot/pull/1168
 [#1160]: https://github.com/ontodev/robot/pull/1160
 [#1148]: https://github.com/ontodev/robot/pull/1148
 [#1135]: https://github.com/ontodev/robot/pull/1135

--- a/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ExportOperation.java
@@ -496,8 +496,12 @@ public class ExportOperation {
           IRI iri = a.getValue().asIRI().orNull();
           if (iri != null) {
             Set<OWLEntity> entities = ontology.getEntitiesInSignature(iri);
-            for (OWLEntity e : entities) {
-              values.add(OntologyHelper.renderManchester(e, provider, rt));
+            if (entities.size() > 0) {
+              for (OWLEntity e : entities) {
+                values.add(OntologyHelper.renderManchester(e, provider, rt));
+              }
+            } else {
+              values.add(iri.toString());
             }
           }
         } else {

--- a/robot-core/src/test/java/org/obolibrary/robot/ExportOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ExportOperationTest.java
@@ -2,6 +2,7 @@ package org.obolibrary.robot;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -30,6 +31,23 @@ import org.semanticweb.owlapi.util.DefaultPrefixManager;
  * @author <a href="mailto:rbca.jackson@gmail.com">Becky Jackson</a>
  */
 public class ExportOperationTest extends CoreTest {
+
+  /**
+   * Utility method to write XLSX file for debugging.
+   *
+   * @param workbook Workfbook to write
+   * @param path Path (string) to save to, under `robot-core/`
+   */
+  void writeXLSX(Workbook workbook, String path) {
+    try {
+      System.out.println("Writing result to robot-core/" + path);
+      FileOutputStream out = new FileOutputStream(path);
+      workbook.write(out);
+      out.close();
+    } catch (Exception ex) {
+      System.out.println("Error writing workbook: " + ex);
+    }
+  }
 
   /**
    * Test exporting simple.owl to XLSX.
@@ -154,16 +172,6 @@ public class ExportOperationTest extends CoreTest {
     // Create the table and render it as a Workbook
     Table t = ExportOperation.createExportTable(ontology, ioHelper, columns, options);
     Workbook wb = t.asWorkbook("|");
-
-    // Write test.xlsx for debugging
-    // try {
-    //   System.out.println("Writing result to robot-core/test.xlsx");
-    //   FileOutputStream out = new FileOutputStream("test.xlsx");
-    //   wb.write(out);
-    //   out.close();
-    // } catch (Exception ex) {
-    //   System.out.println("Error: " + ex);
-    // }
 
     Sheet s = wb.getSheetAt(0);
     assertEquals(s.getLastRowNum(), 4);

--- a/robot-core/src/test/java/org/obolibrary/robot/ExportOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/ExportOperationTest.java
@@ -1,5 +1,7 @@
 package org.obolibrary.robot;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -121,7 +123,7 @@ public class ExportOperationTest extends CoreTest {
    */
   @Test
   public void testExportNamedHeadingsSimple() throws Exception {
-    OWLOntology ontology = loadOntology("/simple.owl");
+    OWLOntology ontology = loadOntology("/simple_defined_by.owl");
     IOHelper ioHelper = new IOHelper();
     ioHelper.addPrefix(
         "simple", "https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl#");
@@ -135,6 +137,7 @@ public class ExportOperationTest extends CoreTest {
             "CURIE",
             "Type",
             "SYNONYMS",
+            "rdfs:isDefinedBy",
             "SUBCLASSES",
             "SubClass Of",
             "SubProperty Of",
@@ -152,9 +155,18 @@ public class ExportOperationTest extends CoreTest {
     Table t = ExportOperation.createExportTable(ontology, ioHelper, columns, options);
     Workbook wb = t.asWorkbook("|");
 
+    // Write test.xlsx for debugging
+    // try {
+    //   System.out.println("Writing result to robot-core/test.xlsx");
+    //   FileOutputStream out = new FileOutputStream("test.xlsx");
+    //   wb.write(out);
+    //   out.close();
+    // } catch (Exception ex) {
+    //   System.out.println("Error: " + ex);
+    // }
+
     Sheet s = wb.getSheetAt(0);
-    // There should be three rows (0, 1, 2)
-    assert (s.getLastRowNum() == 3);
+    assertEquals(s.getLastRowNum(), 4);
 
     // Validate header
     // should match size and label
@@ -176,6 +188,11 @@ public class ExportOperationTest extends CoreTest {
       String expectedHeader = columns.get(colIx);
       assert (foundHeader.equals(expectedHeader));
     }
+
+    // rdfs:isDefinedBy should work
+    assertEquals(
+        s.getRow(4).getCell(6).getStringCellValue(),
+        "https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl");
   }
 
   /**


### PR DESCRIPTION
Resolves #1165

- [ ] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated
