### PR TITLE
annotate-defined-by parameter excludes datatypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - '--annotate-with-source true' does not work with extract --method subset [#1160]
 - Fix how Template adds entities to the QuotedEntityChecker [#1104]
+- [`merge`] and 'annotate' operations '--annotate-defined-by' excludes reserved OWL 2 vocabularies [#1171]
 
 ## [1.9.5] - 2023-09-20
 
@@ -380,6 +381,7 @@ First official release of ROBOT!
 [`template`]: http://robot.obolibrary.org/template
 [`validate`]: http://robot.obolibrary.org/validate
 
+[#1171]: https://github.com/ontodev/robot/pull/1171
 [#1160]: https://github.com/ontodev/robot/pull/1160
 [#1148]: https://github.com/ontodev/robot/pull/1148
 [#1135]: https://github.com/ontodev/robot/pull/1135

--- a/docs/examples/example2_defined_by.owl
+++ b/docs/examples/example2_defined_by.owl
@@ -107,33 +107,7 @@
     <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#wasDerivedFrom">
         <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/examples/edit.owl"/>
     </owl:AnnotationProperty>
-    
 
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Datatypes
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    
-
-
-    <!-- http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral -->
-
-    <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">
-        <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/examples/edit.owl"/>
-    </rdf:Description>
-    
-
-
-    <!-- http://www.w3.org/2001/XMLSchema#string -->
-
-    <rdf:Description rdf:about="http://www.w3.org/2001/XMLSchema#string">
-        <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/examples/edit.owl"/>
-    </rdf:Description>
     
 
 

--- a/docs/examples/example2_defined_by.owl
+++ b/docs/examples/example2_defined_by.owl
@@ -78,30 +78,6 @@
     
 
 
-    <!-- http://www.w3.org/2000/01/rdf-schema#comment -->
-
-    <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#comment">
-        <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/examples/edit.owl"/>
-    </rdf:Description>
-    
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#isDefinedBy -->
-
-    <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#isDefinedBy">
-        <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/examples/edit.owl"/>
-    </rdf:Description>
-    
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#label -->
-
-    <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
-        <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/examples/edit.owl"/>
-    </rdf:Description>
-    
-
-
     <!-- http://www.w3.org/ns/prov#wasDerivedFrom -->
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#wasDerivedFrom">
@@ -258,18 +234,6 @@
         <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/examples/edit.owl"/>
         <rdfs:label>dummy individal 5</rdfs:label>
     </owl:NamedIndividual>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Annotations
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral"/>
 </rdf:RDF>
 
 

--- a/docs/examples/merged_defined_by.owl
+++ b/docs/examples/merged_defined_by.owl
@@ -107,25 +107,7 @@
     <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#wasDerivedFrom">
         <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/examples/edit.owl"/>
     </owl:AnnotationProperty>
-    
 
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Datatypes
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    
-
-
-    <!-- http://www.w3.org/2001/XMLSchema#string -->
-
-    <rdf:Description rdf:about="http://www.w3.org/2001/XMLSchema#string">
-        <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/examples/edit.owl"/>
-    </rdf:Description>
     
 
 

--- a/docs/examples/merged_defined_by.owl
+++ b/docs/examples/merged_defined_by.owl
@@ -78,30 +78,6 @@
     
 
 
-    <!-- http://www.w3.org/2000/01/rdf-schema#comment -->
-
-    <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#comment">
-        <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/examples/edit.owl"/>
-    </rdf:Description>
-    
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#isDefinedBy -->
-
-    <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#isDefinedBy">
-        <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/examples/edit.owl"/>
-    </rdf:Description>
-    
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#label -->
-
-    <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
-        <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/examples/edit.owl"/>
-    </rdf:Description>
-    
-
-
     <!-- http://www.w3.org/ns/prov#wasDerivedFrom -->
 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#wasDerivedFrom">

--- a/docs/merge.md
+++ b/docs/merge.md
@@ -36,17 +36,15 @@ It’s also possible to annotate the imported or merged ontology axioms with the
 
   * `--annotate-derived-from true`: annotates all axioms with the source's version IRI if it exists, else with the ontology IRI, using `prov:wasDerivedFrom`. If the axiom already has an annotation using this property (`prov:wasDerivedFrom`), the existing annotation will be kept and no new annotation will be added.
 
-```
     robot merge --catalog catalog.xml \
       --input imports-nucleus.owl \
       --annotate-derived-from true \
       --output results/merged_derived_from.owl
-```
       
   * `--annotate-defined-by true`: annotates all entities (class, data, annotation, object property and named individual declaration axioms) with the source's IRI using `rdfs:isDefinedBy`. If the term already has an annotation using this property (`rdfs:isDefinedBy`), the existing annotation will be kept and no new annotation will be added.
 
-```
     robot merge --input example2.owl --input merge.owl \
       --annotate-defined-by true \
       --output results/merged_defined_by.owl
-```
+
+`--annotate-defined-by` excludes entities from the reserved OWL 2 vocabularies (RDF, RDFS, XSD and OWL).

--- a/docs/merge.md
+++ b/docs/merge.md
@@ -36,13 +36,17 @@ It’s also possible to annotate the imported or merged ontology axioms with the
 
   * `--annotate-derived-from true`: annotates all axioms with the source's version IRI if it exists, else with the ontology IRI, using `prov:wasDerivedFrom`. If the axiom already has an annotation using this property (`prov:wasDerivedFrom`), the existing annotation will be kept and no new annotation will be added.
 
+```
     robot merge --catalog catalog.xml \
       --input imports-nucleus.owl \
       --annotate-derived-from true \
       --output results/merged_derived_from.owl
+```
       
   * `--annotate-defined-by true`: annotates all entities (class, data, annotation, object property and named individual declaration axioms) with the source's IRI using `rdfs:isDefinedBy`. If the term already has an annotation using this property (`rdfs:isDefinedBy`), the existing annotation will be kept and no new annotation will be added.
 
+```
     robot merge --input example2.owl --input merge.owl \
       --annotate-defined-by true \
       --output results/merged_defined_by.owl
+```

--- a/robot-command/src/main/java/org/obolibrary/robot/AnnotateCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/AnnotateCommand.java
@@ -318,7 +318,9 @@ public class AnnotateCommand implements Command {
         OWLAnnotationProperty rdfsIsDefinedBy =
             ontology.getOWLOntologyManager().getOWLDataFactory().getRDFSIsDefinedBy();
         for (OWLEntity owlEntity : ontology.getSignature()) {
-          OntologyHelper.addEntityAnnotation(ontology, owlEntity, rdfsIsDefinedBy, ontIRI, false);
+          if (!(owlEntity.isOWLDatatype() && owlEntity.asOWLDatatype().isBuiltIn())) {
+            OntologyHelper.addEntityAnnotation(ontology, owlEntity, rdfsIsDefinedBy, ontIRI, false);
+          }
         }
       }
     }

--- a/robot-command/src/main/java/org/obolibrary/robot/AnnotateCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/AnnotateCommand.java
@@ -318,7 +318,7 @@ public class AnnotateCommand implements Command {
         OWLAnnotationProperty rdfsIsDefinedBy =
             ontology.getOWLOntologyManager().getOWLDataFactory().getRDFSIsDefinedBy();
         for (OWLEntity owlEntity : ontology.getSignature()) {
-          if (!(owlEntity.isOWLDatatype() && owlEntity.asOWLDatatype().isBuiltIn())) {
+          if (!owlEntity.getIRI().isReservedVocabulary()) {
             OntologyHelper.addEntityAnnotation(ontology, owlEntity, rdfsIsDefinedBy, ontIRI, false);
           }
         }

--- a/robot-core/src/main/java/org/obolibrary/robot/MergeOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/MergeOperation.java
@@ -363,8 +363,10 @@ public class MergeOperation {
       OWLAnnotationProperty rdfsIsDefinedBy =
           targetOntology.getOWLOntologyManager().getOWLDataFactory().getRDFSIsDefinedBy();
       for (OWLEntity owlEntity : sourceOntology.getSignature(includeImportsClosure)) {
-        OntologyHelper.addEntityAnnotation(
-            targetOntology, owlEntity, rdfsIsDefinedBy, ontIRI, false);
+        if (!(owlEntity.isOWLDatatype() && owlEntity.asOWLDatatype().isBuiltIn())) {
+          OntologyHelper.addEntityAnnotation(
+              targetOntology, owlEntity, rdfsIsDefinedBy, ontIRI, false);
+        }
       }
     }
   }

--- a/robot-core/src/main/java/org/obolibrary/robot/MergeOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/MergeOperation.java
@@ -363,7 +363,7 @@ public class MergeOperation {
       OWLAnnotationProperty rdfsIsDefinedBy =
           targetOntology.getOWLOntologyManager().getOWLDataFactory().getRDFSIsDefinedBy();
       for (OWLEntity owlEntity : sourceOntology.getSignature(includeImportsClosure)) {
-        if (!(owlEntity.isOWLDatatype() && owlEntity.asOWLDatatype().isBuiltIn())) {
+        if (!owlEntity.getIRI().isReservedVocabulary()) {
           OntologyHelper.addEntityAnnotation(
               targetOntology, owlEntity, rdfsIsDefinedBy, ontIRI, false);
         }

--- a/robot-core/src/test/java/org/obolibrary/robot/MergeOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/MergeOperationTest.java
@@ -101,9 +101,9 @@ public class MergeOperationTest extends CoreTest {
     assertEquals(5, simple.getAxiomCount());
     OWLOntology merged = MergeOperation.merge(ontologies, false, false, true, false);
 
-    assertEquals(8, merged.getAxiomCount());
+    assertEquals(7, merged.getAxiomCount());
     OWLOntology expected = loadOntology("/simple_defined_by.owl");
-    assertEquals(8, expected.getAxiomCount());
+    assertEquals(7, expected.getAxiomCount());
     assertIdentical(expected, merged);
   }
 }

--- a/robot-core/src/test/java/org/obolibrary/robot/MergeOperationTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/MergeOperationTest.java
@@ -101,9 +101,9 @@ public class MergeOperationTest extends CoreTest {
     assertEquals(5, simple.getAxiomCount());
     OWLOntology merged = MergeOperation.merge(ontologies, false, false, true, false);
 
-    assertEquals(9, merged.getAxiomCount());
+    assertEquals(8, merged.getAxiomCount());
     OWLOntology expected = loadOntology("/simple_defined_by.owl");
-    assertEquals(9, expected.getAxiomCount());
+    assertEquals(8, expected.getAxiomCount());
     assertIdentical(expected, merged);
   }
 }

--- a/robot-core/src/test/resources/simple_defined_by.owl
+++ b/robot-core/src/test/resources/simple_defined_by.owl
@@ -27,24 +27,6 @@
         <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl"/>
     </rdf:Description>
     
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Datatypes
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    
-
-
-    <!-- http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral -->
-
-    <rdf:Description rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral">
-        <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl"/>
-    </rdf:Description>
     
 
 

--- a/robot-core/src/test/resources/simple_defined_by.owl
+++ b/robot-core/src/test/resources/simple_defined_by.owl
@@ -8,25 +8,6 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
     <owl:Ontology rdf:about="https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl"/>
     
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Annotation properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    
-
-
-    <!-- http://www.w3.org/2000/01/rdf-schema#label -->
-
-    <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
-        <rdfs:isDefinedBy rdf:resource="https://github.com/ontodev/robot/robot-core/src/test/resources/simple.owl"/>
-    </rdf:Description>
-    
     
 
 


### PR DESCRIPTION
Resolves [#1163, resolves #1163]

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

This pull request introduces checks to prevent annotation of entities with `rdfs:isDefinedBy` when their namespace is a OWL 2 reserved vocabulary (RDF, RDFS, XSD or OWL).

The implementation impacts `robot merge --annotate-defined-by` and `robot annotate --annotate-defined-by` parameters.
