### PR TITLE
Set 10 minute timeout on CI action

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         java: [11, 15, 17]


### PR DESCRIPTION
We had some jobs run for 6+ hours recently, which is wasteful. If they don't finish in 10 minutes something is wrong, so I'm trying to set a timeout.