### PR TITLE
Fixing the invalid xref check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [`merge`] and 'annotate' operations '--annotate-defined-by' excludes reserved OWL 2 vocabularies [#1171]
 - Handle IRIs that are not entities in export [#1168]
 - Fix integration tests [#1181]
+- Invalid Xrefs test has been fixed to recognise invalid CURIEs correctly [#1127]
 
 ## [1.9.5] - 2023-09-20
 

--- a/docs/examples/report.tsv
+++ b/docs/examples/report.tsv
@@ -2,6 +2,8 @@ Level	Rule Name	Subject	Property	Value
 ERROR	missing_ontology_description	http://purl.obolibrary.org/obo/uberon.owl	dc:description	
 ERROR	missing_ontology_license	http://purl.obolibrary.org/obo/uberon.owl	dc:license	
 ERROR	missing_ontology_title	http://purl.obolibrary.org/obo/uberon.owl	dc:title	
+WARN	invalid_xref	BFO:0000051	oboInOwl:hasDbXref	BFO-:0000051
+WARN	invalid_xref	BFO:0000062	oboInOwl:hasDbXref	:0000062
 WARN	missing_definition	BFO:0000050	IAO:0000115	
 WARN	missing_definition	BFO:0000051	IAO:0000115	
 WARN	missing_definition	BFO:0000063	IAO:0000115	

--- a/docs/examples/uberon_fragment.owl
+++ b/docs/examples/uberon_fragment.owl
@@ -262,7 +262,7 @@
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000051">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_part</rdfs:label>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000051</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO-:0000051</oboInOwl:hasDbXref>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_part</oboInOwl:id>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_part</oboInOwl:shorthand>
         <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uberon</oboInOwl:hasOBONamespace>
@@ -276,7 +276,7 @@
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000062">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">preceded_by</rdfs:label>
-        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000062</oboInOwl:hasDbXref>
+        <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">:0000062</oboInOwl:hasDbXref>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">X preceded_by Y iff: end(Y) before_or_simultaneous_with start(X)</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">is preceded by</oboInOwl:hasExactSynonym>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">preceded_by</oboInOwl:shorthand>

--- a/docs/report_queries/invalid_xref.md
+++ b/docs/report_queries/invalid_xref.md
@@ -11,7 +11,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT DISTINCT ?entity ?property ?value WHERE {
   VALUES ?property {oboInOwl:hasDbXref}
   ?entity ?property ?value .
-  FILTER (!regex(?value, "^[a-z|A-Z|_|\\-|0-9]*:(?!$)\\S*$"))
+  FILTER (!regex(?value, "^[A-Za-z_][A-Za-z0-9_.-]*[A-Za-z0-9_]:[^\\s]+$"))
   FILTER (!isBlank(?entity))
 }
 ORDER BY ?entity

--- a/robot-core/src/main/resources/report_queries/invalid_xref.rq
+++ b/robot-core/src/main/resources/report_queries/invalid_xref.rq
@@ -10,7 +10,7 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 SELECT DISTINCT ?entity ?property ?value WHERE {
   VALUES ?property {oboInOwl:hasDbXref}
   ?entity ?property ?value .
-  FILTER (!regex(?value, "^[a-z|A-Z|_|\\-|0-9]*:(?!$)\\S*$"))
+  FILTER (!regex(?value, "^[A-Za-z_][A-Za-z0-9_.-]*[A-Za-z0-9_]:[^\\s]+$"))
   FILTER (!isBlank(?entity))
 }
 ORDER BY ?entity


### PR DESCRIPTION
Resolves #1127 

- [X] `docs/` have been added/updated
- [x] tests have been added/updated
- [X] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [X] `CHANGELOG.md` has been updated

This PR fixing the regular expression used to recognise XREFs. I tested it in the https://regex101.com/ sandbox:

![image](https://github.com/ontodev/robot/assets/7070631/90f10191-e8e4-4e74-a56c-0403580e8a07)


- Match the prefix:
    - `^[A-Za-z_]`: Starts with an alphabet letter (either uppercase or lowercase) or an underscore.
    - `[A-Za-z0-9_.-]*`: Followed by any number (including zero) of alphanumeric characters, underscores, periods, or hyphens.
    - `[A-Za-z0-9_]`: Ends the first part with an alphanumeric character or an underscore.
- `:`: Contains a colon separating the prefix from the reference.
- `[^\\s]+$`: Matches the reference, which comprises 1 or more characters that are not whitespace (including spaces, tabs, and newlines).
