### PR TITLE
Fix docs on missing_subset_declaration.rq

### DIFF
--- a/docs/report_queries/missing_subset_declaration.md
+++ b/docs/report_queries/missing_subset_declaration.md
@@ -4,7 +4,6 @@
 
 **Solution:** Make the subset a child of oboInOwl:SubsetProperty.
 
-
 ```sparql
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>

--- a/docs/report_queries/missing_subset_declaration.md
+++ b/docs/report_queries/missing_subset_declaration.md
@@ -1,8 +1,9 @@
 # Missing Subset Declaration
 
-**Problem:** A subset is used in an annotation, but is not properly declared as a child of oboInOwl:SubsetProperty. This can cause problems with conversions to OBO format.
+**Problem:** A subset is used in an annotation (via oboInOwl:inSubset), but is not properly declared as a child of oboInOwl:SubsetProperty. This can cause problems with conversions to OBO format, and should be avoided as all subsets should have metadata.
 
 **Solution:** Make the subset a child of oboInOwl:SubsetProperty.
+
 
 ```sparql
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/robot-core/src/main/resources/report_queries/missing_subset_declaration.rq
+++ b/robot-core/src/main/resources/report_queries/missing_subset_declaration.rq
@@ -1,6 +1,6 @@
 # # Missing Subset Declaration
 #
-# **Problem:** A synonym type is used in an annotation, but is not properly declared as a child of oboInOwl:SynonymTypeProperty. This can cause problems with conversions to OBO format.
+# **Problem:** A subset is used in an annotation (via inSubset), but is not properly declared as a child of oboInOwl:SubsetProperty. This can cause problems with conversions to OBO format, and should be avoided as all subsets should have metadata
 #
 # **Solution:** Make the synonym type a child of oboInOwl:SubsetProperty.
 

--- a/robot-core/src/main/resources/report_queries/missing_subset_declaration.rq
+++ b/robot-core/src/main/resources/report_queries/missing_subset_declaration.rq
@@ -2,7 +2,7 @@
 #
 # **Problem:** A subset is used in an annotation (via oboInOwl:inSubset), but is not properly declared as a child of oboInOwl:SubsetProperty. This can cause problems with conversions to OBO format, and should be avoided as all subsets should have metadata.
 #
-# **Solution:** Make the synonym type a child of oboInOwl:SubsetProperty.
+# **Solution:** Make the subset a child of oboInOwl:SubsetProperty.
 
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>

--- a/robot-core/src/main/resources/report_queries/missing_subset_declaration.rq
+++ b/robot-core/src/main/resources/report_queries/missing_subset_declaration.rq
@@ -1,6 +1,6 @@
 # # Missing Subset Declaration
 #
-# **Problem:** A subset is used in an annotation (via inSubset), but is not properly declared as a child of oboInOwl:SubsetProperty. This can cause problems with conversions to OBO format, and should be avoided as all subsets should have metadata
+# **Problem:** A subset is used in an annotation (via oboInOwl:inSubset), but is not properly declared as a child of oboInOwl:SubsetProperty. This can cause problems with conversions to OBO format, and should be avoided as all subsets should have metadata.
 #
 # **Solution:** Make the synonym type a child of oboInOwl:SubsetProperty.
 


### PR DESCRIPTION
The previous docs were copypastad without modification

Resolves [#ISSUE, resolves #ISSUE]

- [x] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

[DESCRIPTION, mentioning relevant #ISSUE]
