### PR TITLE
Update OWLAPI to version 4.5.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `duplicate_exact_syonym` [`report`] query to be case-insensitive and ignore synoyms annotated as abbreviation or acronym synonym types [#1179]
 - Extend `--drop-axiom-annotations` option to support value-specific removal of axiom annotations [#1193]
 - Add `--enforce-obo-format`, `--exclude-named-classes` and `--include-subclass-of` features to relax command [#1060, #1183]
+- Updated OWL API to 3.5.28. This includes a major update to OBO Format which now supports [IDSPACE declarations](https://github.com/owlcs/owlapi/pull/1102) (non-OBO Foundry prefixes).
 
 ### Fixed
 - '--annotate-with-source true' does not work with extract --method subset [#1160]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `duplicate_exact_syonym` [`report`] query to be case-insensitive and ignore synoyms annotated as abbreviation or acronym synonym types [#1179]
 - Extend `--drop-axiom-annotations` option to support value-specific removal of axiom annotations [#1193]
 - Add `--enforce-obo-format`, `--exclude-named-classes` and `--include-subclass-of` features to relax command [#1060, #1183]
-- Updated OWL API to 3.5.28. This includes a major update to OBO Format which now supports [IDSPACE declarations](https://github.com/owlcs/owlapi/pull/1102) (non-OBO Foundry prefixes).
+- Updated OWL API to 3.5.29. This includes a major update to OBO Format which now supports [IDSPACE declarations](https://github.com/owlcs/owlapi/pull/1102) (non-OBO Foundry prefixes).
 
 ### Fixed
 - '--annotate-with-source true' does not work with extract --method subset [#1160]

--- a/docs/examples/annotated.obo
+++ b/docs/examples/annotated.obo
@@ -1,5 +1,7 @@
 format-version: 1.2
 data-version: https://github.com/ontodev/robot/examples/annotated-1.owl
+idspace: foaf http://xmlns.com/foaf/0.1/ 
+idspace: oboInOwl http://www.geneontology.org/formats/oboInOwl# 
 remark: Comment
 remark: Comment from annotations.ttl file.
 ontology: https://github.com/ontodev/robot/examples/annotated.owl
@@ -378,8 +380,8 @@ xref: XAO:0000165
 is_a: UBERON:0001851 ! cortex
 intersection_of: UBERON:0001851 ! cortex
 intersection_of: part_of UBERON:0002369 ! adrenal gland
-property_value: depicted:by http://upload.wikimedia.org/wikipedia/commons/5/5c/Gray1185.png
-property_value: depicted:by http://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Gray1185.png/200px-Gray1185.png
+property_value: foaf:depicted_by http://upload.wikimedia.org/wikipedia/commons/5/5c/Gray1185.png
+property_value: foaf:depicted_by http://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Gray1185.png/200px-Gray1185.png
 property_value: homology_notes "All craniates have groups of cells homologous to the mammalian adrenocortical and chromaffin tissues (medulla), but they are scattered in and near the kidneys in fishes. (...) The cortical and chromaffin tissues come together to form adrenal glands in tetrapods.[well established][VHOG]" xsd:string
 property_value: taxon_notes "Kardong states that mammals are the first to have distinct cortext and medulla, but this contradicts XAO" xsd:string
 
@@ -470,7 +472,7 @@ is_a: UBERON:0002530 ! gland
 intersection_of: UBERON:0002530 ! gland
 intersection_of: part_of UBERON:0000949 ! endocrine system
 relationship: part_of UBERON:0000949 ! endocrine system
-property_value: depicted:by http://upload.wikimedia.org/wikipedia/commons/d/da/Illu_endocrine_system.png
+property_value: foaf:depicted_by http://upload.wikimedia.org/wikipedia/commons/d/da/Illu_endocrine_system.png
 
 [Term]
 id: UBERON:0002369
@@ -515,9 +517,9 @@ xref: XAO:0000164
 is_a: UBERON:0006858 ! adrenal/interrenal gland
 relationship: part_of UBERON:0000916 ! abdomen
 relationship: part_of UBERON:0000949 ! endocrine system
-property_value: depicted:by http://upload.wikimedia.org/wikipedia/commons/9/9d/Illu_endocrine_system_New.png
-property_value: depicted:by http://upload.wikimedia.org/wikipedia/commons/thumb/c/c6/Illu_endocrine_system.jpg/200px-Illu_endocrine_system.jpg
 property_value: external_definition "Anatomical structure which is found on the surface of the kidney and secretes various hormones including epinephrine, norephinephrine, aldosterone, corticosterone, and cortisol.[AAO]" xsd:string
+property_value: foaf:depicted_by http://upload.wikimedia.org/wikipedia/commons/9/9d/Illu_endocrine_system_New.png
+property_value: foaf:depicted_by http://upload.wikimedia.org/wikipedia/commons/thumb/c/c6/Illu_endocrine_system.jpg/200px-Illu_endocrine_system.jpg
 property_value: function_notes "suprarenal cortex manufactures corticosteroids; suprarenal medulla manufactures epinephrine and norepinephrine; suprarenal medulla receives preganglionic sympathetic innervation from the greater thoracic splanchnic n." xsd:string
 property_value: homology_notes "All craniates have groups of cells homologous to the mammalian adrenocortical and chromaffin tissues, but they are scattered in and near the kidneys in fishes. (...) The cortical and chromaffin tissues come together to form adrenal glands in tetrapods.[well established][VHOG]" xsd:string
 property_value: taxon_notes "The origin of the adrenal gland is still controversial. It is thought to share the same origin as the kidney and gonads, derived from coelomic epithelium of the urogenital ridge and/or the underlying mesenchyme (Keegan and Hammer, 2002; Morohashi, 1997). We follow Kardong and state homology at the level of the cortex and medulla rather than gland as a whole" xsd:string
@@ -572,7 +574,7 @@ xref: OpenCyc:Mx4rwP3vyJwpEbGdrcN5Y29ycA
 xref: UMLS:C1285092
 xref: WikipediaCategory:Glands
 is_a: UBERON:0000062 ! organ
-property_value: depicted:by http://upload.wikimedia.org/wikipedia/commons/a/a1/Gray1026.png
+property_value: foaf:depicted_by http://upload.wikimedia.org/wikipedia/commons/a/a1/Gray1026.png
 property_value: has_relational_adjective "glandular" xsd:string
 
 [Term]

--- a/docs/examples/example.obo
+++ b/docs/examples/example.obo
@@ -1,4 +1,6 @@
 format-version: 1.2
+idspace: foaf http://xmlns.com/foaf/0.1/ 
+idspace: oboInOwl http://www.geneontology.org/formats/oboInOwl# 
 remark: Comment from annotations.ttl file.
 ontology: https://github.com/ontodev/robot/examples/edit.owl
 owl-axioms: Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\nPrefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)\nPrefix(xml:=<http://www.w3.org/XML/1998/namespace>)\nPrefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\nPrefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)\n\n\nOntology(\nDeclaration(Class(<http://purl.obolibrary.org/obo/UBERON_0001062>))\n############################\n#   Classes\n############################\n\n# Class: <http://purl.obolibrary.org/obo/UBERON_0001062> (<http://purl.obolibrary.org/obo/UBERON_0001062>)\n\nSubClassOf(<http://purl.obolibrary.org/obo/UBERON_0001062> owl:Thing)\n\n\n)
@@ -377,8 +379,8 @@ xref: XAO:0000165
 is_a: UBERON:0001851 ! cortex
 intersection_of: UBERON:0001851 ! cortex
 intersection_of: part_of UBERON:0002369 ! adrenal gland
-property_value: depicted:by http://upload.wikimedia.org/wikipedia/commons/5/5c/Gray1185.png
-property_value: depicted:by http://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Gray1185.png/200px-Gray1185.png
+property_value: foaf:depicted_by http://upload.wikimedia.org/wikipedia/commons/5/5c/Gray1185.png
+property_value: foaf:depicted_by http://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Gray1185.png/200px-Gray1185.png
 property_value: homology_notes "All craniates have groups of cells homologous to the mammalian adrenocortical and chromaffin tissues (medulla), but they are scattered in and near the kidneys in fishes. (...) The cortical and chromaffin tissues come together to form adrenal glands in tetrapods.[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0001481", ontology="VHOG", source="http://bgee.unil.ch/", source="ISBN:978-0030223693 Liem KF, Bemis WE, Walker WF, Grande L, Functional Anatomy of the Vertebrates: An Evolutionary Perspective (2001) p.518 and Figure 15-9"}
 property_value: taxon_notes "Kardong states that mammals are the first to have distinct cortext and medulla, but this contradicts XAO" xsd:string
 
@@ -469,7 +471,7 @@ is_a: UBERON:0002530 ! gland
 intersection_of: UBERON:0002530 ! gland
 intersection_of: part_of UBERON:0000949 ! endocrine system
 relationship: part_of UBERON:0000949 ! endocrine system
-property_value: depicted:by http://upload.wikimedia.org/wikipedia/commons/d/da/Illu_endocrine_system.png
+property_value: foaf:depicted_by http://upload.wikimedia.org/wikipedia/commons/d/da/Illu_endocrine_system.png
 
 [Term]
 id: UBERON:0002369
@@ -514,9 +516,9 @@ xref: XAO:0000164
 is_a: UBERON:0006858 ! adrenal/interrenal gland
 relationship: part_of UBERON:0000916 ! abdomen
 relationship: part_of UBERON:0000949 ! endocrine system
-property_value: depicted:by http://upload.wikimedia.org/wikipedia/commons/9/9d/Illu_endocrine_system_New.png
-property_value: depicted:by http://upload.wikimedia.org/wikipedia/commons/thumb/c/c6/Illu_endocrine_system.jpg/200px-Illu_endocrine_system.jpg
 property_value: external_definition "Anatomical structure which is found on the surface of the kidney and secretes various hormones including epinephrine, norephinephrine, aldosterone, corticosterone, and cortisol.[AAO]" xsd:string {date_retrieved="2012-06-20", external_class="AAO:0010551", ontology="AAO", source="AAO:BJB"}
+property_value: foaf:depicted_by http://upload.wikimedia.org/wikipedia/commons/9/9d/Illu_endocrine_system_New.png
+property_value: foaf:depicted_by http://upload.wikimedia.org/wikipedia/commons/thumb/c/c6/Illu_endocrine_system.jpg/200px-Illu_endocrine_system.jpg
 property_value: function_notes "suprarenal cortex manufactures corticosteroids; suprarenal medulla manufactures epinephrine and norepinephrine; suprarenal medulla receives preganglionic sympathetic innervation from the greater thoracic splanchnic n." xsd:string
 property_value: homology_notes "All craniates have groups of cells homologous to the mammalian adrenocortical and chromaffin tissues, but they are scattered in and near the kidneys in fishes. (...) The cortical and chromaffin tissues come together to form adrenal glands in tetrapods.[well established][VHOG]" xsd:string {date_retrieved="2012-09-17", external_class="VHOG:0001141", ontology="VHOG", source="http://bgee.unil.ch/", source="ISBN:978-0030223693 Liem KF, Bemis WE, Walker WF, Grande L, Functional Anatomy of the Vertebrates: An Evolutionary Perspective (2001) p.518 and Figure 15-9"}
 property_value: taxon_notes "The origin of the adrenal gland is still controversial. It is thought to share the same origin as the kidney and gonads, derived from coelomic epithelium of the urogenital ridge and/or the underlying mesenchyme (Keegan and Hammer, 2002; Morohashi, 1997). We follow Kardong and state homology at the level of the cortex and medulla rather than gland as a whole" xsd:string
@@ -572,7 +574,7 @@ xref: OpenCyc:Mx4rwP3vyJwpEbGdrcN5Y29ycA
 xref: UMLS:C1285092 {source="ncithesaurus:Gland"}
 xref: WikipediaCategory:Glands
 is_a: UBERON:0000062 ! organ
-property_value: depicted:by http://upload.wikimedia.org/wikipedia/commons/a/a1/Gray1026.png
+property_value: foaf:depicted_by http://upload.wikimedia.org/wikipedia/commons/a/a1/Gray1026.png
 property_value: has_relational_adjective "glandular" xsd:string
 
 [Term]

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
-      <version>1.7.32</version>
+      <version>2.0.11</version>
     </dependency>
     <dependency>
       <groupId>au.csiro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
-      <version>2.0.11</version>
+      <version>1.7.32</version>
     </dependency>
     <dependency>
       <groupId>au.csiro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -204,12 +204,12 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.3.0</version>
+      <version>1.5.6</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
-      <version>2.0.11</version>
+      <version>2.0.13</version>
     </dependency>
     <dependency>
       <groupId>au.csiro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-api</artifactId>
-      <version>4.5.26</version>
+      <version>4.5.28</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -177,7 +177,7 @@
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-apibinding</artifactId>
-      <version>4.5.26</version>
+      <version>4.5.28</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -188,7 +188,7 @@
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-rio</artifactId>
-      <version>4.5.26</version>
+      <version>4.5.28</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -204,12 +204,12 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.13</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
-      <version>1.7.32</version>
+      <version>2.0.11</version>
     </dependency>
     <dependency>
       <groupId>au.csiro</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-api</artifactId>
-      <version>4.5.28</version>
+      <version>4.5.29</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -177,7 +177,7 @@
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-apibinding</artifactId>
-      <version>4.5.28</version>
+      <version>4.5.29</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -188,7 +188,7 @@
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-rio</artifactId>
-      <version>4.5.28</version>
+      <version>4.5.29</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>

--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-api</artifactId>
-      <version>4.5.28</version>
+      <version>4.5.29</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-apibinding</artifactId>
-      <version>4.5.28</version>
+      <version>4.5.29</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-rio</artifactId>
-      <version>4.5.28</version>
+      <version>4.5.29</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>

--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-api</artifactId>
-      <version>4.5.26</version>
+      <version>4.5.28</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-apibinding</artifactId>
-      <version>4.5.26</version>
+      <version>4.5.28</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-rio</artifactId>
-      <version>4.5.26</version>
+      <version>4.5.28</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Update OWLAPI to version 4.5.28

- [ ] `docs/` have been added/updated
- [X] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [X] `CHANGELOG.md` has been updated

