### PR TITLE
Update Elk to 0.6.0 in pom.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--enforce-obo-format`, `--exclude-named-classes` and `--include-subclass-of` features to relax command [#1060, #1183]
 - Updated obographs to [version 0.3.1](https://github.com/geneontology/obographs/releases/tag/v0.3.1)
 - Updated OWL API to 3.5.29. This includes a major update to OBO Format which now supports [IDSPACE declarations](https://github.com/owlcs/owlapi/pull/1102) (non-OBO Foundry prefixes).
+- Updated Elk to version 0.6.0, see [here](https://github.com/liveontologies/elk-reasoner/issues/48#issuecomment-2130090254).
 
 ### Fixed
 - '--annotate-with-source true' does not work with extract --method subset [#1160]

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
     </dependency>
     <dependency>
       <groupId>io.github.liveontologies</groupId>
-      <artifactId>elk-distribution-owlapi</artifactId>
+      <artifactId>elk-owlapi</artifactId>
       <version>0.6.0</version>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -217,10 +217,6 @@
       <version>0.6.0</version>
       <exclusions>
         <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>net.sourceforge.owlapi</groupId>
           <artifactId>owlapi-apibinding</artifactId>
         </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -212,9 +212,9 @@
       <version>2.0.13</version>
     </dependency>
     <dependency>
-      <groupId>au.csiro</groupId>
-      <artifactId>elk-owlapi4</artifactId>
-      <version>0.5.0</version>
+      <groupId>io.github.liveontologies</groupId>
+      <artifactId>elk-distribution-owlapi</artifactId>
+      <version>0.6.0</version>
       <exclusions>
         <exclusion>
           <groupId>log4j</groupId>


### PR DESCRIPTION
This PR adds and updated version of the Elk reasoner to ROBOT, see https://github.com/liveontologies/elk-reasoner/issues/48#issuecomment-2130090254.

- [ ] `docs/` have been added/updated (NA)
- [ ] tests have been added/updated (Note needed)
- [X] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [X] `CHANGELOG.md` has been updated


