### PR TITLE
Attempt 1: replacing DLExpressivity by DLExpressivityChecker

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/metrics/OntologyMetrics.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/metrics/OntologyMetrics.java
@@ -8,7 +8,6 @@ import org.obolibrary.robot.IOHelper;
 import org.obolibrary.robot.providers.CURIEShortFormProvider;
 import org.semanticweb.owlapi.metrics.AbstractOWLMetric;
 import org.semanticweb.owlapi.metrics.AverageAssertedNamedSuperclassCount;
-import org.semanticweb.owlapi.metrics.DLExpressivity;
 import org.semanticweb.owlapi.metrics.GCICount;
 import org.semanticweb.owlapi.metrics.HiddenGCICount;
 import org.semanticweb.owlapi.metrics.MaximumNumberOfNamedSuperclasses;
@@ -991,10 +990,15 @@ public class OntologyMetrics {
   }
 
   private String getExpressivity(boolean included) {
-    DLExpressivity dl = new DLExpressivity(getOntology());
-    dl.setImportsClosureUsed(included);
-    dl.setOntology(getOntology());
-    return dl.getValue();
+    Set<OWLOntology> onts = new HashSet<>();
+    if (included) {
+      onts.addAll(getOntology().getImportsClosure());
+    } else {
+      onts.add(getOntology());
+    }
+    DLExpressivityChecker checker = new DLExpressivityChecker(onts);
+    System.err.println(checker.getDescriptionLogicName());
+    return checker.getDescriptionLogicName();
   }
 
   // this is highly unpleasant and I wish we had a NoSQL DB or even just a


### PR DESCRIPTION
This is try to sort out the problem that the previous solution shows gibberish expressivity levels:

"expressivity": "RRESTRCUCINTUNIVRESTREROIF(D)". But it does not work..

Resolves [#ISSUE, resolves #ISSUE]

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [ ] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

[DESCRIPTION, mentioning relevant #ISSUE]
