### PR TITLE
Update whelk version to fix inferred property assertion generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Output inferred object property assertions using Whelk reasoner, by updating to Whelk 1.1.3. [#1121]
+
 ## [1.9.6] - 2024-05-28
 
 ### Added

--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -280,7 +280,7 @@
     <dependency>
       <groupId>org.geneontology</groupId>
       <artifactId>whelk-owlapi_${scala.version}</artifactId>
-      <version>1.0.4</version>
+      <version>1.1.3</version>
       <exclusions>
         <exclusion>
           <groupId>net.sourceforge.owlapi</groupId>


### PR DESCRIPTION
Resolves #1121.

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

Update to latest whelk version, which works correctly with the PropertyAssertion InferredAxiomGenerator.
