### PR TITLE
Treat raw IRI as an OWLClass in logical template cells

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
@@ -992,11 +992,13 @@ public class TemplateHelper {
         // This allows class labels with single quotes
         expr = checker.getOWLClass(content, false);
         if (expr == null) {
-          // If not found by label, is it just an IRI?
-          IRI iri = IRI.create(content);
-          if (iri != null) {
-            // If so, create a new class for this IRI.
-            expr = checker.getOWLClass(content, true);
+          // If not found by label, is it just an HTTP IRI?
+          if (content.startsWith("http")) {
+            IRI iri = IRI.create(content);
+            if (iri != null) {
+              // If so, create a new class for this IRI.
+              expr = checker.getOWLClass(content, true);
+            }
           }
         }
       }

--- a/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/TemplateHelper.java
@@ -991,6 +991,14 @@ public class TemplateHelper {
         // If we have a checker, try to get the class by label
         // This allows class labels with single quotes
         expr = checker.getOWLClass(content, false);
+        if (expr == null) {
+          // If not found by label, is it just an IRI?
+          IRI iri = IRI.create(content);
+          if (iri != null) {
+            // If so, create a new class for this IRI.
+            expr = checker.getOWLClass(content, true);
+          }
+        }
       }
       if (expr == null) {
         // If not found by label, try to parse

--- a/robot-core/src/test/java/org/obolibrary/robot/TemplateHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/TemplateHelperTest.java
@@ -150,7 +150,7 @@ public class TemplateHelperTest extends CoreTest {
       assertEquals(exprMatch.toString(), expr.toString());
     }
 
-    // Check raw IRI
+    // Check raw HTTP IRI
     value = "http://purl.obolibrary.org/obo/UBERON_0000467";
     expressions = TemplateHelper.getClassExpressions("", parser, template, value, 0, 0);
     if (expressions.size() != 1) {
@@ -158,6 +158,14 @@ public class TemplateHelperTest extends CoreTest {
     }
     for (OWLClassExpression expr : expressions) {
       assertEquals(exprMatch.toString(), expr.toString());
+    }
+
+    // Check that undeclared prefix fails
+    try {
+      value = "UNKNOWN:1234";
+      expressions = TemplateHelper.getClassExpressions("", parser, template, value, 0, 0);
+      fail("CURIE with undeclared prefix should not be parsed as Manchester expression");
+    } catch (Exception e) {
     }
 
     // Check that gibberish fails

--- a/robot-core/src/test/java/org/obolibrary/robot/TemplateHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/TemplateHelperTest.java
@@ -128,6 +128,7 @@ public class TemplateHelperTest extends CoreTest {
     ManchesterOWLSyntaxClassExpressionParser parser =
         new ManchesterOWLSyntaxClassExpressionParser(dataFactory, checker);
 
+    // Check CURIE
     String template = "C part_of some %";
     String value = "obo:UBERON_0000467";
     Set<OWLClassExpression> expressions =
@@ -147,6 +148,24 @@ public class TemplateHelperTest extends CoreTest {
     }
     for (OWLClassExpression expr : expressions) {
       assertEquals(exprMatch.toString(), expr.toString());
+    }
+
+    // Check raw IRI
+    value = "http://purl.obolibrary.org/obo/UBERON_0000467";
+    expressions = TemplateHelper.getClassExpressions("", parser, template, value, 0, 0);
+    if (expressions.size() != 1) {
+      fail(String.format("Expected exactly 1 expression, got %d", expressions.size()));
+    }
+    for (OWLClassExpression expr : expressions) {
+      assertEquals(exprMatch.toString(), expr.toString());
+    }
+
+    // Check that gibberish fails
+    try {
+      value = "http.purl.obolibrary.org/obo/UBERON_0000467";
+      expressions = TemplateHelper.getClassExpressions("", parser, template, value, 0, 0);
+      fail("Gibberish value should not be parsed as Manchester expression");
+    } catch (Exception e) {
     }
   }
 


### PR DESCRIPTION
When ROBOT expects to see a class label or CURIE in a template cell, and it sees a raw IRI instead, interpret it as an OWLClass.

- [X] tests have been added/updated
- [X] `mvn verify` says all tests pass
- [ ] `CHANGELOG.md` has been updated

This is in response to a report on Slack.