### PR TITLE
dockerfile - fixed pom location error - reduced image size by close to 2/3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,42 @@
-FROM maven:3-openjdk-11-slim
+# Stage 1: Build the application using Maven
+FROM maven:3-openjdk-11-slim AS build
 
+# Create a working directory and set permissions
 RUN useradd -m robot
 RUN mkdir -p /usr/src/app
 RUN chown robot /usr/src/app
 
+WORKDIR /usr/src/app
+
+# Copy the POM and source code to the working directory
 COPY pom.xml /usr/src/app
 COPY robot-command /usr/src/app/robot-command
 COPY robot-core /usr/src/app/robot-core
 COPY robot-maven-plugin /usr/src/app/robot-maven-plugin
-COPY bin/robot /usr/local/bin/
+COPY robot-mock-plugin /usr/src/app/robot-mock-plugin
+
+# Change ownership to robot user
 RUN chown -R robot:robot /usr/src/app
 
+# Use the robot user to run Maven
 USER robot
-WORKDIR /usr/src/app
+
+# Run the Maven build, skipping tests to speed up the process
 RUN mvn install -DskipTests
 
-USER root
-RUN cp bin/robot.jar /usr/local/bin
+# Stage 2: Create a smaller runtime container
+FROM openjdk:11-jre-slim AS runtime
+
+# Create a non-root user and set up a working directory
+RUN useradd -m robot
+RUN mkdir -p /usr/src/app/bin
+RUN chown robot /usr/src/app/bin
+
+# Copy the compiled JAR file from the build stage to the runtime stage
+COPY --from=build /usr/src/app/bin/robot.jar /usr/src/app/bin/robot.jar
+
+# Set robot as the user
 USER robot
-ENTRYPOINT ["robot"]
+
+# Set the entrypoint to run the robot.jar
+ENTRYPOINT ["java", "-jar", "/usr/src/app/bin/robot.jar"]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Other build options:
 - `mvn clean verify` rebuilds the package and runs integration tests against it, with reports in `[module]/target/failsafe-reports`
 - `mvn site` generates Javadoc in `target/site` and `[module]/target/site`
 
-Alternatively, you can use [Docker](https://www.docker.com) with the provided [Dockerfile](Dockerfile) to build and run ROBOT from within a container. First build an image with `docker build --tag robot .` then run ROBOT from the container with the usual command-line arguments: `docker run --rm robot --help`.
+Alternatively, you can use [Docker](https://www.docker.com) with the provided [Dockerfile](Dockerfile) to build and run ROBOT from within a container. First build an image with `docker build --tag robot:latest .` then run ROBOT from the container with the usual command-line arguments: `docker run --rm robot --help`.
 
 
 ## Code Style


### PR DESCRIPTION
Existing Dockerfile did not work. It couldn't find pom files of one of the dependencies. I have updated Dockerfile and verified everything works.

Reasoning: Personally I do not have Java installed on any of my systems. It is very handy to have access to `robot` but not have to rely on local java.  Once you build this robot container using command listed in the main README.md file, you can just run robot from anywhere on windows for example without having java installed. All prerequesites are in docker. I have verified and it works

Below you can see i run java to demonstrate java is not on my windows. But i run `robot` from container and everything works.

![image](https://github.com/user-attachments/assets/ad09fe8f-c570-4565-8323-2c4a3785c129)

Also, I have updated how the container is built. As opposed to storing all the files required to build it, we instead now build in intermediate container. This intermediate container is downloading and building robot.jar.   After that we simply copy robot.jar to new container and discard all the build files. The result is drop from 1.2GB to 490M.  Still huge, but a lot less.

I hope this is useful to somebody.
