### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: mvn verify
       - name: Upload Artifact
         if: ${{ matrix.java == 11 }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: robot.jar 
           path: bin/robot.jar


### PR DESCRIPTION
v2 is no longer working, so our GitHub Actions are failing. See https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
