### PR TITLE
Update whelk version to latest

### DIFF
--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -280,7 +280,7 @@
     <dependency>
       <groupId>org.geneontology</groupId>
       <artifactId>whelk-owlapi_${scala.version}</artifactId>
-      <version>1.1.3</version>
+      <version>1.2.1</version>
       <exclusions>
         <exclusion>
           <groupId>net.sourceforge.owlapi</groupId>


### PR DESCRIPTION
This version of whelk adds ObjectPropertyRange for OWL EL and complete support for OWL RL (minus data properties).