### PR TITLE
Exclude deprecated from lowercase_definition check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+- Add missing filter for deprecated in lowercase_definition check [#1220]
+- Bug was fixed that caused logical axioms with axiom annotations not to be processed correctly when merging axiom annotations [#1223]
+
 ## [1.9.7] - 2024-10-30
 
 ### Fixed
 - Output inferred object property assertions using Whelk reasoner, by updating to Whelk 1.1.3. [#1121]
-- Bug was fixed that caused logical axioms with axiom annotations not to be processed correctly when merging axiom annotations [#1223]
 
 ### Changed
 - Update Whelk to 1.2.1 [#1221]
@@ -413,7 +416,9 @@ First official release of ROBOT!
 [`validate`]: http://robot.obolibrary.org/validate
 [`verify`]: http://robot.obolibrary.org/verify
 
+[#1223]: https://github.com/ontodev/robot/pull/1223
 [#1221]: https://github.com/ontodev/robot/pull/1221
+[#1220]: https://github.com/ontodev/robot/issues/1220
 [#1211]: https://github.com/ontodev/robot/pull/1211
 [#1194]: https://github.com/ontodev/robot/pull/1194
 [#1193]: https://github.com/ontodev/robot/pull/1193

--- a/docs/report_queries/lowercase_definition.md
+++ b/docs/report_queries/lowercase_definition.md
@@ -13,8 +13,9 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   VALUES ?property { obo:IAO_0000115
                      obo:IAO_0000600 }
   ?entity ?property ?value .
-  FILTER (!regex(?value, "^[A-Z0-9]"))
+  FILTER NOT EXISTS { ?entity owl:deprecated true }
   FILTER (!isBlank(?entity))
+  FILTER (!regex(?value, "^[A-Z0-9]"))
 }
 ORDER BY ?entity
 ```

--- a/robot-core/src/main/resources/report_queries/lowercase_definition.rq
+++ b/robot-core/src/main/resources/report_queries/lowercase_definition.rq
@@ -12,7 +12,8 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
   VALUES ?property { obo:IAO_0000115
                      obo:IAO_0000600 }
   ?entity ?property ?value .
-  FILTER (!regex(?value, "^[A-Z0-9]"))
+  FILTER NOT EXISTS { ?entity owl:deprecated true }
   FILTER (!isBlank(?entity))
+  FILTER (!regex(?value, "^[A-Z0-9]"))
 }
 ORDER BY ?entity


### PR DESCRIPTION
Fixes #1220

- **Exclude deprecated terms from lowercase_definition check**
- **Update lowercase_definition doc**
- **Update changelog, with fix**

- [X] `docs/` have been added/updated
- [ ] tests have been added/updated
- [X] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [X] `CHANGELOG.md` has been updated
