### PR TITLE
Skip non-robot columns for axiom annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## Fixed
+- Skip "non-robot" columns in templates for the purposes of axiom annotations [#1216]
 - Add missing filter for deprecated in lowercase_definition check [#1220]
 - Bug was fixed that caused logical axioms with axiom annotations not to be processed correctly when merging axiom annotations [#1223]
 
@@ -419,6 +420,7 @@ First official release of ROBOT!
 [#1223]: https://github.com/ontodev/robot/pull/1223
 [#1221]: https://github.com/ontodev/robot/pull/1221
 [#1220]: https://github.com/ontodev/robot/issues/1220
+[#1216]: https://github.com/ontodev/robot/issues/1216
 [#1211]: https://github.com/ontodev/robot/pull/1211
 [#1194]: https://github.com/ontodev/robot/pull/1194
 [#1193]: https://github.com/ontodev/robot/pull/1193

--- a/robot-core/src/main/java/org/obolibrary/robot/Template.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/Template.java
@@ -2126,6 +2126,11 @@ public class Template {
       } catch (IndexOutOfBoundsException e) {
         break;
       }
+      // Skip columsn with empty templates.
+      // See https://github.com/ontodev/robot/issues/1216
+      if (template.trim().equals("")) {
+        continue;
+      }
       Matcher m = Pattern.compile("^>.*").matcher(template);
       if (m.matches()) {
 

--- a/robot-core/src/test/java/org/obolibrary/robot/TemplateTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/TemplateTest.java
@@ -50,7 +50,7 @@ public class TemplateTest extends CoreTest {
   }
 
   /**
-   * Test a strange case where a sequence .
+   * Test a strange case with no labels and no types.
    *
    * @throws Exception if entities cannot be found
    */
@@ -63,7 +63,7 @@ public class TemplateTest extends CoreTest {
   }
 
   /**
-   * Test a strange case where a sequence .
+   * Test a case with no labels.
    *
    * @throws Exception if entities cannot be found
    */

--- a/robot-core/src/test/resources/template.csv
+++ b/robot-core/src/test/resources/template.csv
@@ -1,5 +1,5 @@
-Label,Label Comment,Nested Comment,See Also,ID,Synonyms,Parent,Parts,Parts Annotation,Equivalent,Eq Annotation
-A rdfs:label,>AL rdfs:comment@en,>>A rdfs:comment,>AI rdfs:seeAlso,ID,A IAO:0000118 SPLIT=|,SC %,SC part_of some %,>A rdfs:comment,EC %,>A rdfs:comment
-skip this row
-test 3,test 3 comment,test 3 comment comment,http://robot.obolibrary.org/,GO:1234,synonym 1|synonym 2,test2,test one,test one comment,,
-test 4,test 4 comment,,,GO:1235,,,,,'test one' and (part_of some (test2 and 'test 3')),test2 and test 3 comment
+Label,Label Comment,Nested Comment,Ignore,See Also,ID,Synonyms,Parent,Parts,Parts Annotation,Equivalent,Eq Annotation
+A rdfs:label,>AL rdfs:comment@en,>>A rdfs:comment,,>AI rdfs:seeAlso,ID,A IAO:0000118 SPLIT=|,SC %,SC part_of some %,>A rdfs:comment,EC %,>A rdfs:comment
+skip this row,,,,,,,,,,,
+test 3,test 3 comment,test 3 comment comment,ignore this,http://robot.obolibrary.org/,GO:1234,synonym 1|synonym 2,test2,test one,test one comment,,
+test 4,test 4 comment,,ignore this,,GO:1235,,,,,'test one' and (part_of some (test2 and 'test 3')),test2 and test 3 comment


### PR DESCRIPTION
Resolves #1216

- [ ] `docs/` have been added/updated
- [X] tests have been added/updated
- [X] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [X] `CHANGELOG.md` has been updated

When looking for `>` annotations to add to the current axiom/annotation ignore columns with empty ROBOT template strings.
