### PR TITLE
Improve disambiguation of properties in QuotedEntityChecker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## Fixed
+- Improve disambiguation of properties in QuotedEntityChecker [#1226]
 - Skip "non-robot" columns in templates for the purposes of axiom annotations [#1216]
 - Add missing filter for deprecated in lowercase_definition check [#1220]
 - Bug was fixed that caused logical axioms with axiom annotations not to be processed correctly when merging axiom annotations [#1223]
@@ -417,6 +418,7 @@ First official release of ROBOT!
 [`validate`]: http://robot.obolibrary.org/validate
 [`verify`]: http://robot.obolibrary.org/verify
 
+[#1226]: https://github.com/ontodev/robot/pull/1226
 [#1223]: https://github.com/ontodev/robot/pull/1223
 [#1221]: https://github.com/ontodev/robot/pull/1221
 [#1220]: https://github.com/ontodev/robot/issues/1220

--- a/robot-core/src/main/java/org/obolibrary/robot/QuotedEntityChecker.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/QuotedEntityChecker.java
@@ -392,15 +392,22 @@ public class QuotedEntityChecker implements OWLEntityChecker {
     if (iri != null) {
       return dataFactory.getOWLDataProperty(iri);
     }
-    // prevent punning
-    if (!objectProperties.containsKey(name)) {
-      if (ioHelper != null) {
-        iri = ioHelper.createIRI(name);
-        if (iri != null) {
-          OWLDataProperty owlDataProperty = dataFactory.getOWLDataProperty(iri);
-          dataProperties.put(name, iri);
-          return owlDataProperty;
-        }
+    if (ioHelper != null) {
+      // When the Manchester parser sees "R some X"
+      // it can't tell whether R is a DataProperty or an ObjectProperty,
+      // so it tries getOWLDataProperty() first,
+      // then getOWLObjectProperty().
+      // We have to check that this name is not an ObjectProperty
+      // before we create a new DataProperty.
+      // We check both the name and the IRI.
+      iri = ioHelper.createIRI(name);
+      if (objectProperties.containsKey(name) || objectProperties.containsValue(iri)) {
+        return null;
+      }
+      if (iri != null) {
+        OWLDataProperty owlDataProperty = dataFactory.getOWLDataProperty(iri);
+        dataProperties.put(name, iri);
+        return owlDataProperty;
       }
     }
     return null;
@@ -473,15 +480,21 @@ public class QuotedEntityChecker implements OWLEntityChecker {
     if (iri != null) {
       return dataFactory.getOWLObjectProperty(iri);
     }
-    // prevent punning
-    if (!dataProperties.containsKey(name)) {
-      if (ioHelper != null) {
-        iri = ioHelper.createIRI(name);
-        if (iri != null) {
-          OWLObjectProperty owlObjectProperty = dataFactory.getOWLObjectProperty(iri);
-          objectProperties.put(name, iri);
-          return owlObjectProperty;
-        }
+    if (ioHelper != null) {
+      // When the Manchester parser sees "R some X"
+      // it can't tell whether R is a DataProperty or an ObjectProperty,
+      // so it tries getOWLDataProperty() first,
+      // then getOWLObjectProperty().
+      // To be safe, we first check that this name is not a DataProperty.
+      // We check both the name and the IRI.
+      iri = ioHelper.createIRI(name);
+      if (dataProperties.containsKey(name) || dataProperties.containsValue(iri)) {
+        return null;
+      }
+      if (iri != null) {
+        OWLObjectProperty owlObjectProperty = dataFactory.getOWLObjectProperty(iri);
+        objectProperties.put(name, iri);
+        return owlObjectProperty;
       }
     }
     return null;


### PR DESCRIPTION
Addresses #1203, at least partially.

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [ ] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated
