### PR TITLE
Update owl-diff dependency for stable ordering and to avoid large string creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## Fixed
+- Update owl-diff dependency for stable ordering and to avoid large string creation [#1227]
 - Improve disambiguation of properties in QuotedEntityChecker [#1226]
 - Skip "non-robot" columns in templates for the purposes of axiom annotations [#1216]
 - Add missing filter for deprecated in lowercase_definition check [#1220]

--- a/robot-command/src/main/java/org/obolibrary/robot/DiffCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/DiffCommand.java
@@ -161,7 +161,6 @@ public class DiffCommand implements Command {
     options.put("format", CommandLineHelper.getDefaultValue(line, "format", "plain"));
 
     DiffOperation.compare(leftOntology, rightOntology, ioHelper, writer, options);
-    writer.flush();
     writer.close();
 
     return state;

--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -269,7 +269,7 @@
     <dependency>
       <groupId>org.geneontology</groupId>
       <artifactId>owl-diff_${scala.version}</artifactId>
-      <version>1.2.2</version>
+      <version>1.3.0</version>
       <exclusions>
         <exclusion>
           <groupId>net.sourceforge.owlapi</groupId>

--- a/robot-core/src/main/java/org/obolibrary/robot/DiffOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/DiffOperation.java
@@ -123,7 +123,7 @@ public class DiffOperation {
 
     switch (format) {
       case "plain":
-        writer.write(BasicDiffRenderer.renderPlain(diff));
+        BasicDiffRenderer.renderPlainWriter(diff, writer);
         break;
       case "pretty":
         DefaultPrefixManager pm = ioHelper.getPrefixManager();
@@ -137,15 +137,15 @@ public class DiffOperation {
         OBOShortenerShortFormProvider iriProvider = new OBOShortenerShortFormProvider(pm);
         DoubleShortFormProvider doubleProvider =
             new DoubleShortFormProvider(iriProvider, labelProvider);
-        writer.write(BasicDiffRenderer.render(diff, doubleProvider));
+        BasicDiffRenderer.renderWriter(diff, doubleProvider, writer);
         break;
       case "markdown":
         Differ.GroupedDiff groupedForMarkdown = Differ.groupedDiff(diff);
-        writer.write(MarkdownGroupedDiffRenderer.render(groupedForMarkdown, ontologyProvider));
+        MarkdownGroupedDiffRenderer.renderWriter(groupedForMarkdown, ontologyProvider, writer);
         break;
       case "html":
         Differ.GroupedDiff groupedForHTML = Differ.groupedDiff(diff);
-        writer.write(HTMLDiffRenderer.render(groupedForHTML, ontologyProvider));
+        HTMLDiffRenderer.renderWriter(groupedForHTML, ontologyProvider, writer);
         break;
       default:
         throw new IOException("Unknown diff format: " + format);


### PR DESCRIPTION
Resolves #1192. owl-diff now accepts a Writer or OutputStream so it can avoid creating a huge string. Also, the ordering of output should be consistent.

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

