### PR TITLE
Include line separator when reading queries from Jar resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add missing filter for deprecated in lowercase_definition check [#1220]
 - Bug was fixed that caused logical axioms with axiom annotations not to be processed correctly when merging axiom annotations [#1223]
 - Correctly merge unannotated and annotated duplicated axioms [#1239]
+- Fix reading of default queries from embedded Jar resources [#1212]
 
 ## [1.9.7] - 2024-10-30
 

--- a/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReportOperation.java
@@ -766,6 +766,7 @@ public class ReportOperation {
                 String chr;
                 while ((chr = br.readLine()) != null) {
                   sb.append(chr);
+                  sb.append('\n');
                 }
               }
               // Remove the headers


### PR DESCRIPTION
Resolves [#1212]

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

When we read a default query string from a resource embedded within the Jar file, we need to make sure to explicitly include a line separator between each line (the line terminator is *not* included in the value returned by `BufferedReader#readLine()`). Otherwise the entire query is stored as a single line, which prevents its from being analyzed correctly by the SPARQL parser.