### PR TITLE
Include SubObjectPropertyOf axioms when reducing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add missing filter for deprecated in lowercase_definition check [#1220]
 - Bug was fixed that caused logical axioms with axiom annotations not to be processed correctly when merging axiom annotations [#1223]
 - Correctly merge unannotated and annotated duplicated axioms [#1239]
+- Subproperties being ignored when evaluating redundancy in `reduce` [#1014], [#1208]
 
 ## [1.9.7] - 2024-10-30
 

--- a/docs/examples/reduced-redundant-over-subproperties.ofn
+++ b/docs/examples/reduced-redundant-over-subproperties.ofn
@@ -1,0 +1,40 @@
+Prefix(:=<http://purl.obolibrary.org/obo/test.owl#>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://purl.obolibrary.org/obo/test.owl>
+
+Declaration(Class(<http://purl.obolibrary.org/obo/Kupffer_cell>))
+Declaration(Class(<http://purl.obolibrary.org/obo/liver>))
+Declaration(Class(<http://purl.obolibrary.org/obo/liver_lobule>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/located_in>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/overlaps>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/part_of>))
+############################
+#   Object Properties
+############################
+
+# Object Property: <http://purl.obolibrary.org/obo/part_of> (<http://purl.obolibrary.org/obo/part_of>)
+
+SubObjectPropertyOf(<http://purl.obolibrary.org/obo/part_of> <http://purl.obolibrary.org/obo/overlaps>)
+
+
+############################
+#   Classes
+############################
+
+# Class: <http://purl.obolibrary.org/obo/Kupffer_cell> (<http://purl.obolibrary.org/obo/Kupffer_cell>)
+
+SubClassOf(<http://purl.obolibrary.org/obo/Kupffer_cell> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/located_in> <http://purl.obolibrary.org/obo/liver_lobule>))
+
+# Class: <http://purl.obolibrary.org/obo/liver_lobule> (<http://purl.obolibrary.org/obo/liver_lobule>)
+
+SubClassOf(<http://purl.obolibrary.org/obo/liver_lobule> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/part_of> <http://purl.obolibrary.org/obo/liver>))
+
+
+SubObjectPropertyOf(ObjectPropertyChain(<http://purl.obolibrary.org/obo/located_in> <http://purl.obolibrary.org/obo/part_of>) <http://purl.obolibrary.org/obo/located_in>)
+)

--- a/docs/examples/redundant-over-subproperties.ofn
+++ b/docs/examples/redundant-over-subproperties.ofn
@@ -1,0 +1,42 @@
+Prefix(:=<http://purl.obolibrary.org/obo/test.owl#>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://purl.obolibrary.org/obo/test.owl>
+
+Declaration(Class(<http://purl.obolibrary.org/obo/Kupffer_cell>))
+Declaration(Class(<http://purl.obolibrary.org/obo/liver>))
+Declaration(Class(<http://purl.obolibrary.org/obo/liver_lobule>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/located_in>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/overlaps>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/part_of>))
+############################
+#   Object Properties
+############################
+
+# Object Property: <http://purl.obolibrary.org/obo/part_of> (<http://purl.obolibrary.org/obo/part_of>)
+
+SubObjectPropertyOf(<http://purl.obolibrary.org/obo/part_of> <http://purl.obolibrary.org/obo/overlaps>)
+
+
+############################
+#   Classes
+############################
+
+# Class: <http://purl.obolibrary.org/obo/Kupffer_cell> (<http://purl.obolibrary.org/obo/Kupffer_cell>)
+
+SubClassOf(<http://purl.obolibrary.org/obo/Kupffer_cell> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/located_in> <http://purl.obolibrary.org/obo/liver>))
+SubClassOf(<http://purl.obolibrary.org/obo/Kupffer_cell> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/located_in> <http://purl.obolibrary.org/obo/liver_lobule>))
+
+# Class: <http://purl.obolibrary.org/obo/liver_lobule> (<http://purl.obolibrary.org/obo/liver_lobule>)
+
+SubClassOf(<http://purl.obolibrary.org/obo/liver_lobule> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/overlaps> <http://purl.obolibrary.org/obo/liver>))
+SubClassOf(<http://purl.obolibrary.org/obo/liver_lobule> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/part_of> <http://purl.obolibrary.org/obo/liver>))
+
+
+SubObjectPropertyOf(ObjectPropertyChain(<http://purl.obolibrary.org/obo/located_in> <http://purl.obolibrary.org/obo/part_of>) <http://purl.obolibrary.org/obo/located_in>)
+)

--- a/docs/reduce.md
+++ b/docs/reduce.md
@@ -16,3 +16,22 @@ Available options for `reduce`:
 
 Reciprocal subclass axioms (e.g. `A SubClassOf B`, `B SubClassOf A`), entailing equivalence between `A` and `B`, may be removed by `reduce`. In this case it is important to
 assert an equivalence axiom (`A EquivalentTo B`) using the `reason` command before running reduce.
+
+### Subproperties and property chains
+
+For backwards compatibility reasons, by default subObjectPropertyOf axioms are ignored when evaluating the redundancy of subClassOf axioms. This means that, given the following example:
+
+```
+C SubClassOf P some D
+C SubClassOf Q some D
+P SubObjectPropertyOf Q
+```
+
+the first subClassOf axiom would by default _not_ be considered redundant and therefore _not_ be removed.
+
+To force the `reduce` command to factor in subproperties (including property chains) when evaluating redundancy, use the `--include-subproperties` option:
+
+    robot reduce --reasoner ELK \
+      --input redundant-over-subproperties.ofn \
+      --include-subproperties true \
+      --output results/reduced-redundant-over-subproperties.ofn

--- a/robot-command/src/main/java/org/obolibrary/robot/ReduceCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/ReduceCommand.java
@@ -31,6 +31,11 @@ public class ReduceCommand implements Command {
         "preserve annotated axioms when removing redundant subclass axioms");
     o.addOption(
         "c", "named-classes-only", true, "only reduce subclass axioms between named classes");
+    o.addOption(
+        "s",
+        "include-subproperties",
+        true,
+        "take subproperties into account to evaluate redundancy");
     o.addOption("i", "input", true, "reduce ontology from a file");
     o.addOption("I", "input-iri", true, "reduce ontology from an IRI");
     o.addOption("o", "output", true, "save reduceed ontology to a file");

--- a/robot-core/src/main/java/org/obolibrary/robot/ReduceOperation.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/ReduceOperation.java
@@ -108,9 +108,13 @@ public class ReduceOperation {
 
     // we treat an axiom as redundant if its is redundant within the
     // subClassOf graph, including OP characteristic axioms (e.g. transitivity)
+    // and subproperty axioms
     OWLOntology subOntology = manager.createOntology();
     for (OWLAxiom a : ontology.getAxioms(Imports.INCLUDED)) {
-      if (a instanceof OWLSubClassOfAxiom || a instanceof OWLObjectPropertyCharacteristicAxiom) {
+      if (a instanceof OWLSubClassOfAxiom
+          || a instanceof OWLObjectPropertyCharacteristicAxiom
+          || a instanceof OWLSubObjectPropertyOfAxiom
+          || a instanceof OWLSubPropertyChainOfAxiom) {
         manager.addAxiom(subOntology, a);
       }
     }


### PR DESCRIPTION
Resolves [#1014, #1208]

- [x] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

This PR amends the _Reduce_ code to include `SubObjectPropertyOf` and `SubPropertyChainOf` axioms in the graph used to evaluate redundant axioms.

By including `SubObjectPropertyOf` axioms, if we have something like

> SubClassOf(C, P some D)
> SubClassOf(C, Q some D)
> SubObjectPropertyOf(Q, P)

then the first `SubClassOf` axiom can be considered redundant and removed (#1208).

By including `SubPropertyChainOf` axioms, if we have

> SubClassOf(C, P some D)
> SubClassOf(C, P some E)
> SubClassOf(D, Q some E)
> SubObjectPropertyOf(ObjectPropertyChain(P Q) P)

then the second `SubClassOf` axiom (_SubClassOf(C, P some E)_) can be considered redundant and removed (#1014).