### PR TITLE
Allow selecting punned entities in `remove` and `filter` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `--clean-obo` option to [`convert`] [#995]
 - Allow interpolation of ontology IRI and version IRI within annotation values [#1241]
+- Allow selecting punned entities in [`remove`] and [`filter`]
 
 ### Fixed
 - Update owl-diff dependency for stable ordering and to avoid large string creation [#1227]

--- a/docs/examples/uo_mole_subset.ofn
+++ b/docs/examples/uo_mole_subset.ofn
@@ -1,0 +1,183 @@
+Prefix(:=<http://purl.obolibrary.org/obo/uo.owl#>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://purl.obolibrary.org/obo/uo.owl>
+
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000000>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000006>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000013>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000039>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000040>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000041>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000042>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000043>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000044>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000046>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000297>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000299>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000300>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000302>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000303>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000304>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_1000013>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/has_prefix>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000013>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000039>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000040>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000041>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000042>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000043>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000044>))
+Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>))
+Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>))
+
+
+
+############################
+#   Classes
+############################
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000000> (unit)
+
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000000> "\"A unit of measurement is a standardized quantity of a physical quality.\" [Wikipedia:Wikipedia]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000000> "unit")
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000006> (substance unit)
+
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000006> "\"A unit which is a standardised quantity of an element or compound with uniform composition.\" [Wikipedia:Wikipedia]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000006> "substance unit")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000006> <http://purl.obolibrary.org/obo/UO_0000000>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000013> (mole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000013> "mol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000013> "\"A substance unit which is equal to the amount of substance of a molecular system which contains as many elementary entities as there are atoms in 0.012 kilogram of carbon 12.\" [BIPM:BIPM, NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000013> "mole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000013> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000013>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000013> <http://purl.obolibrary.org/obo/UO_0000000>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000013> <http://purl.obolibrary.org/obo/UO_1000013>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000039> (micromole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000039> "umol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000039> "\"A substance unit equal to a millionth of a mol or 10^[-6] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000039> "micromole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000039> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000299>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000039> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000039>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000039> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000039> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000299>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000040> (millimole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000040> "mmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000040> "\"A substance unit equal to a thousandth of a mol or 10^[-3] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000040> "millimole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000040> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000297>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000040> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000040>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000040> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000040> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000297>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000041> (nanomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000041> "nmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000041> "\"A substance unit equal to one thousandth of one millionth of a mole or 10^[-9] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000041> "nanomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000041> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000300>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000041> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000041>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000041> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000041> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000300>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000042> (picomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000042> "pmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000042> "\"A substance unit equal to 10^[-12] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000042> "picomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000042> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000302>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000042> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000042>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000042> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000042> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000302>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000043> (femtomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000043> "fmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000043> "\"A substance unit equal to 10^[-15] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000043> "femtomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000043> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000303>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000043> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000043>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000043> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000043> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000303>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000044> (attomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000044> "amol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000044> "\"A substance unit equal to 10^[-18] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000044> "attomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000044> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000304>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000044> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000044>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000044> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000044> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000304>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000046> (prefix)
+
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000046> "prefix")
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000297> (milli)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000297> "10^[-3]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000297> "m")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000297> "\"A prefix in the metric system denoting a factor of one thousand.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000297> "milli")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000297> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000299> (micro)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000299> "10^[-6]")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000299> "\"A prefix in the metric system denoting a factor of 10 to the power of -6.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000299> "micro")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000299> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000300> (nano)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000300> "10^[-9]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000300> "n")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000300> "\"A prefix in the metric system denoting a factor of 10 to the power of -9.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000300> "nano")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000300> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000302> (pico)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000302> "10^[-12]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000302> "n")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000302> "\"A prefix in the metric system denoting a factor of 10 to the power of -12.\" [GVG:UO]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000302> "pico")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000302> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000303> (femto)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000303> "10^[-15]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000303> "f")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000303> "\"A prefix in the metric system denoting a factor of 10 to the power of -15.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000303> "femto")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000303> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000304> (atto)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000304> "a")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/UO_0000304> "10^[-18]")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000304> "\"A prefix in the metric system denoting a factor of 10 to the power of -18.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000304> "atto")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000304> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_1000013> (mole based unit)
+
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_1000013> "mole based unit")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_1000013> <http://purl.obolibrary.org/obo/UO_0000006>)
+
+
+
+)

--- a/docs/examples/uo_no_micromole.ofn
+++ b/docs/examples/uo_no_micromole.ofn
@@ -1,0 +1,171 @@
+Prefix(:=<http://purl.obolibrary.org/obo/uo.owl#>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://purl.obolibrary.org/obo/uo.owl>
+
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000000>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000006>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000013>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000040>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000041>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000042>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000043>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000044>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000046>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000297>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000299>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000300>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000302>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000303>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000304>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_1000013>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/has_prefix>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000013>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000040>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000041>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000042>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000043>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000044>))
+Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>))
+Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>))
+
+
+
+############################
+#   Classes
+############################
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000000> (unit)
+
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000000> "\"A unit of measurement is a standardized quantity of a physical quality.\" [Wikipedia:Wikipedia]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000000> "unit")
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000006> (substance unit)
+
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000006> "\"A unit which is a standardised quantity of an element or compound with uniform composition.\" [Wikipedia:Wikipedia]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000006> "substance unit")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000006> <http://purl.obolibrary.org/obo/UO_0000000>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000013> (mole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000013> "mol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000013> "\"A substance unit which is equal to the amount of substance of a molecular system which contains as many elementary entities as there are atoms in 0.012 kilogram of carbon 12.\" [BIPM:BIPM, NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000013> "mole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000013> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000013>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000013> <http://purl.obolibrary.org/obo/UO_0000000>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000013> <http://purl.obolibrary.org/obo/UO_1000013>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000040> (millimole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000040> "mmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000040> "\"A substance unit equal to a thousandth of a mol or 10^[-3] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000040> "millimole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000040> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000297>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000040> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000040>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000040> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000040> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000297>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000041> (nanomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000041> "nmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000041> "\"A substance unit equal to one thousandth of one millionth of a mole or 10^[-9] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000041> "nanomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000041> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000300>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000041> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000041>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000041> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000041> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000300>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000042> (picomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000042> "pmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000042> "\"A substance unit equal to 10^[-12] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000042> "picomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000042> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000302>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000042> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000042>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000042> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000042> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000302>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000043> (femtomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000043> "fmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000043> "\"A substance unit equal to 10^[-15] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000043> "femtomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000043> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000303>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000043> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000043>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000043> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000043> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000303>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000044> (attomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000044> "amol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000044> "\"A substance unit equal to 10^[-18] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000044> "attomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000044> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000304>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000044> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000044>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000044> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000044> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000304>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000046> (prefix)
+
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000046> "prefix")
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000297> (milli)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000297> "10^[-3]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000297> "m")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000297> "\"A prefix in the metric system denoting a factor of one thousand.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000297> "milli")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000297> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000299> (micro)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000299> "10^[-6]")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000299> "\"A prefix in the metric system denoting a factor of 10 to the power of -6.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000299> "micro")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000299> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000300> (nano)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000300> "10^[-9]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000300> "n")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000300> "\"A prefix in the metric system denoting a factor of 10 to the power of -9.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000300> "nano")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000300> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000302> (pico)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000302> "10^[-12]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000302> "n")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000302> "\"A prefix in the metric system denoting a factor of 10 to the power of -12.\" [GVG:UO]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000302> "pico")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000302> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000303> (femto)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000303> "10^[-15]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000303> "f")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000303> "\"A prefix in the metric system denoting a factor of 10 to the power of -15.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000303> "femto")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000303> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000304> (atto)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000304> "a")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/UO_0000304> "10^[-18]")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000304> "\"A prefix in the metric system denoting a factor of 10 to the power of -18.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000304> "atto")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000304> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_1000013> (mole based unit)
+
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_1000013> "mole based unit")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_1000013> <http://purl.obolibrary.org/obo/UO_0000006>)
+
+
+
+)

--- a/docs/examples/uo_no_micromole_individual.ofn
+++ b/docs/examples/uo_no_micromole_individual.ofn
@@ -1,0 +1,181 @@
+Prefix(:=<http://purl.obolibrary.org/obo/uo.owl#>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://purl.obolibrary.org/obo/uo.owl>
+
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000000>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000006>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000013>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000039>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000040>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000041>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000042>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000043>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000044>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000046>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000297>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000299>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000300>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000302>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000303>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000304>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_1000013>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/has_prefix>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000013>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000040>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000041>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000042>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000043>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000044>))
+Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>))
+Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>))
+
+
+
+############################
+#   Classes
+############################
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000000> (unit)
+
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000000> "\"A unit of measurement is a standardized quantity of a physical quality.\" [Wikipedia:Wikipedia]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000000> "unit")
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000006> (substance unit)
+
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000006> "\"A unit which is a standardised quantity of an element or compound with uniform composition.\" [Wikipedia:Wikipedia]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000006> "substance unit")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000006> <http://purl.obolibrary.org/obo/UO_0000000>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000013> (mole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000013> "mol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000013> "\"A substance unit which is equal to the amount of substance of a molecular system which contains as many elementary entities as there are atoms in 0.012 kilogram of carbon 12.\" [BIPM:BIPM, NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000013> "mole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000013> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000013>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000013> <http://purl.obolibrary.org/obo/UO_0000000>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000013> <http://purl.obolibrary.org/obo/UO_1000013>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000039> (micromole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000039> "umol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000039> "\"A substance unit equal to a millionth of a mol or 10^[-6] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000039> "micromole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000039> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000299>)))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000039> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000039> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000299>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000040> (millimole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000040> "mmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000040> "\"A substance unit equal to a thousandth of a mol or 10^[-3] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000040> "millimole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000040> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000297>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000040> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000040>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000040> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000040> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000297>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000041> (nanomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000041> "nmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000041> "\"A substance unit equal to one thousandth of one millionth of a mole or 10^[-9] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000041> "nanomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000041> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000300>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000041> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000041>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000041> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000041> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000300>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000042> (picomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000042> "pmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000042> "\"A substance unit equal to 10^[-12] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000042> "picomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000042> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000302>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000042> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000042>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000042> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000042> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000302>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000043> (femtomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000043> "fmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000043> "\"A substance unit equal to 10^[-15] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000043> "femtomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000043> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000303>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000043> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000043>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000043> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000043> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000303>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000044> (attomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000044> "amol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000044> "\"A substance unit equal to 10^[-18] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000044> "attomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000044> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000304>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000044> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000044>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000044> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000044> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000304>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000046> (prefix)
+
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000046> "prefix")
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000297> (milli)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000297> "10^[-3]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000297> "m")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000297> "\"A prefix in the metric system denoting a factor of one thousand.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000297> "milli")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000297> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000299> (micro)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000299> "10^[-6]")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000299> "\"A prefix in the metric system denoting a factor of 10 to the power of -6.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000299> "micro")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000299> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000300> (nano)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000300> "10^[-9]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000300> "n")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000300> "\"A prefix in the metric system denoting a factor of 10 to the power of -9.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000300> "nano")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000300> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000302> (pico)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000302> "10^[-12]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000302> "n")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000302> "\"A prefix in the metric system denoting a factor of 10 to the power of -12.\" [GVG:UO]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000302> "pico")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000302> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000303> (femto)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000303> "10^[-15]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000303> "f")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000303> "\"A prefix in the metric system denoting a factor of 10 to the power of -15.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000303> "femto")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000303> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000304> (atto)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000304> "a")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/UO_0000304> "10^[-18]")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000304> "\"A prefix in the metric system denoting a factor of 10 to the power of -18.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000304> "atto")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000304> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_1000013> (mole based unit)
+
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_1000013> "mole based unit")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_1000013> <http://purl.obolibrary.org/obo/UO_0000006>)
+
+
+
+)

--- a/docs/remove.md
+++ b/docs/remove.md
@@ -56,6 +56,11 @@ Finally `--drop-axiom-annotations` option lets you to specify an annotation prop
 
 The `remove` and `filter` operations maintains structural integrity by default: lineage is maintained, and gaps will be filled where classes have been removed. If you wish to *not* preserve the hierarchy, include `--preserve-structure false`.
 
+## Selecting punned entities
+
+By default, if a single term IRI corresponds to several entities of different types (so-called “punned” entities), the corresponding entities are completely ignored when assembling the initial target set. To force the command to consider punned entities, use the `--allow-punning true`. You may then use a subset selector (see below) to further restrict the removal operation to a specific type of entity.
+
+For example, if `A` is both a class and an individual, `--term A` will fail to select anything. To select both entities, use `--term A --allow-punning true`. To select only the class `A`, use `--term A --allow-punning true --select classes`.`
 
 ## Selectors
 
@@ -238,6 +243,22 @@ Extracts a base module, then removing _all_ `oboInOwl:hasDbXref` annotations on 
       --drop-axiom-annotations oboInOwl:source=~'GO.*' \
       --drop-axiom-annotations oboInOwl:hasDbXref \
       --output results/filter_annotations_drop_axioms.owl
+
+Remove all punned entities with the IRI UO:0000039:
+
+    robot remove --input uo_mole_subset.ofn
+      --allow-punning true
+      --term UO:0000039
+      --output results/uo_no_micromole.ofn
+
+Remove only the _individual_ UO:0000039, leaving aside the class that has the same IRI (note that here we need to restrict the removal operations to logical and declaration axioms, to avoid removing annotation assertions axioms that apply to both the class and the individual):
+
+    robot remove --input uo_mole_subset.ofn
+      --allow-punning true
+      --term UO:0000039
+      --select individuals
+      --axioms "logical Declaration"
+      --output results/uo_no_micromole_individual.ofn
 
 Remove all `oboInOwl:hasDbXref` annotations, both on entities and on axioms, but without removing the annotated axioms themselves:
 

--- a/robot-command/src/main/java/org/obolibrary/robot/FilterCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/FilterCommand.java
@@ -49,6 +49,7 @@ public class FilterCommand implements Command {
         "drop-axiom-annotations",
         true,
         "drop all axiom annotations involving a particular annotation property");
+    o.addOption(null, "allow-punning", true, "if true, allow selecting punned entities");
     options = o;
   }
 

--- a/robot-command/src/main/java/org/obolibrary/robot/RemoveCommand.java
+++ b/robot-command/src/main/java/org/obolibrary/robot/RemoveCommand.java
@@ -51,6 +51,7 @@ public class RemoveCommand implements Command {
         "drop-axiom-annotations",
         true,
         "drop all axiom annotations involving a particular annotation property");
+    o.addOption(null, "allow-punning", true, "if true, allow selecting punned entities");
     options = o;
   }
 
@@ -238,10 +239,11 @@ public class RemoveCommand implements Command {
     Set<OWLObject> objects = new HashSet<>();
     // track if a set of input IRIs were provided
     boolean hasInputIRIs = false;
+    boolean punning = CommandLineHelper.getBooleanValue(line, "allow-punning", false);
     if (line.hasOption("term") || line.hasOption("term-file")) {
       Set<IRI> entityIRIs = CommandLineHelper.getTerms(ioHelper, line, "term", "term-file");
       if (!entityIRIs.isEmpty()) {
-        objects.addAll(OntologyHelper.getEntities(ontology, entityIRIs));
+        objects.addAll(OntologyHelper.getEntities(ontology, entityIRIs, punning));
         hasInputIRIs = true;
       }
     }
@@ -282,7 +284,7 @@ public class RemoveCommand implements Command {
       Set<IRI> includeIRIs =
           CommandLineHelper.getTerms(ioHelper, line, "include-term", "include-terms");
       Set<OWLObject> includeObjects =
-          new HashSet<>(OntologyHelper.getEntities(ontology, includeIRIs));
+          new HashSet<>(OntologyHelper.getEntities(ontology, includeIRIs, punning));
       relatedObjects.addAll(includeObjects);
     }
 
@@ -291,7 +293,7 @@ public class RemoveCommand implements Command {
       Set<IRI> excludeIRIs =
           CommandLineHelper.getTerms(ioHelper, line, "exclude-term", "exclude-terms");
       Set<OWLObject> excludeObjects =
-          new HashSet<>(OntologyHelper.getEntities(ontology, excludeIRIs));
+          new HashSet<>(OntologyHelper.getEntities(ontology, excludeIRIs, punning));
       relatedObjects.removeAll(excludeObjects);
     }
 
@@ -300,7 +302,7 @@ public class RemoveCommand implements Command {
       Set<IRI> includeIRIs =
           CommandLineHelper.getTerms(ioHelper, line, "include-term", "include-terms");
       Set<OWLObject> includeObjects =
-          new HashSet<>(OntologyHelper.getEntities(ontology, includeIRIs));
+          new HashSet<>(OntologyHelper.getEntities(ontology, includeIRIs, punning));
       relatedObjects.addAll(includeObjects);
     }
 

--- a/robot-core/src/test/java/org/obolibrary/robot/OntologyHelperTest.java
+++ b/robot-core/src/test/java/org/obolibrary/robot/OntologyHelperTest.java
@@ -1,6 +1,7 @@
 package org.obolibrary.robot;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -184,5 +185,24 @@ public class OntologyHelperTest extends CoreTest {
     Set<String> actual = OntologyHelper.getAnnotationStrings(ontology, prop, testIRI);
     Set<String> expected = Collections.singleton("Test 1 Test one");
     assertEquals(expected, actual);
+  }
+
+  /**
+   * Test selecting punning entities.
+   *
+   * @throws IOException on issue loading ontology
+   */
+  @Test
+  public void testGetPunnedEntities() throws IOException {
+    OWLOntology ontology = loadOntology("/uo_mole_subset.ofn");
+    Set<IRI> iris = Collections.singleton(IRI.create("http://purl.obolibrary.org/obo/UO_0000039"));
+
+    // No punning, expect empty set
+    Set<OWLEntity> entities = OntologyHelper.getEntities(ontology, iris, false);
+    assertTrue(entities.isEmpty());
+
+    // Allow punning, expect class + individual
+    entities = OntologyHelper.getEntities(ontology, iris, true);
+    assertEquals(2, entities.size());
   }
 }

--- a/robot-core/src/test/resources/uo_mole_subset.ofn
+++ b/robot-core/src/test/resources/uo_mole_subset.ofn
@@ -1,0 +1,183 @@
+Prefix(:=<http://purl.obolibrary.org/obo/uo.owl#>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+
+
+Ontology(<http://purl.obolibrary.org/obo/uo.owl>
+
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000000>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000006>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000013>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000039>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000040>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000041>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000042>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000043>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000044>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000046>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000297>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000299>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000300>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000302>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000303>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_0000304>))
+Declaration(Class(<http://purl.obolibrary.org/obo/UO_1000013>))
+Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/has_prefix>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000013>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000039>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000040>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000041>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000042>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000043>))
+Declaration(NamedIndividual(<http://purl.obolibrary.org/obo/UO_0000044>))
+Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym>))
+Declaration(AnnotationProperty(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym>))
+
+
+
+############################
+#   Classes
+############################
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000000> (unit)
+
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000000> "\"A unit of measurement is a standardized quantity of a physical quality.\" [Wikipedia:Wikipedia]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000000> "unit")
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000006> (substance unit)
+
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000006> "\"A unit which is a standardised quantity of an element or compound with uniform composition.\" [Wikipedia:Wikipedia]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000006> "substance unit")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000006> <http://purl.obolibrary.org/obo/UO_0000000>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000013> (mole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000013> "mol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000013> "\"A substance unit which is equal to the amount of substance of a molecular system which contains as many elementary entities as there are atoms in 0.012 kilogram of carbon 12.\" [BIPM:BIPM, NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000013> "mole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000013> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000013>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000013> <http://purl.obolibrary.org/obo/UO_0000000>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000013> <http://purl.obolibrary.org/obo/UO_1000013>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000039> (micromole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000039> "umol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000039> "\"A substance unit equal to a millionth of a mol or 10^[-6] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000039> "micromole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000039> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000299>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000039> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000039>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000039> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000039> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000299>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000040> (millimole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000040> "mmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000040> "\"A substance unit equal to a thousandth of a mol or 10^[-3] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000040> "millimole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000040> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000297>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000040> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000040>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000040> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000040> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000297>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000041> (nanomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000041> "nmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000041> "\"A substance unit equal to one thousandth of one millionth of a mole or 10^[-9] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000041> "nanomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000041> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000300>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000041> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000041>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000041> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000041> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000300>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000042> (picomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000042> "pmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000042> "\"A substance unit equal to 10^[-12] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000042> "picomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000042> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000302>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000042> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000042>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000042> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000042> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000302>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000043> (femtomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000043> "fmol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000043> "\"A substance unit equal to 10^[-15] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000043> "femtomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000043> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000303>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000043> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000043>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000043> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000043> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000303>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000044> (attomole)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000044> "amol")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000044> "\"A substance unit equal to 10^[-18] mol.\" [NIST:NIST]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000044> "attomole")
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000044> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/UO_1000013> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000304>)))
+EquivalentClasses(<http://purl.obolibrary.org/obo/UO_0000044> ObjectOneOf(<http://purl.obolibrary.org/obo/UO_0000044>))
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000044> <http://purl.obolibrary.org/obo/UO_1000013>)
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000044> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/has_prefix> <http://purl.obolibrary.org/obo/UO_0000304>))
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000046> (prefix)
+
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000046> "prefix")
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000297> (milli)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000297> "10^[-3]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000297> "m")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000297> "\"A prefix in the metric system denoting a factor of one thousand.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000297> "milli")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000297> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000299> (micro)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000299> "10^[-6]")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000299> "\"A prefix in the metric system denoting a factor of 10 to the power of -6.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000299> "micro")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000299> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000300> (nano)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000300> "10^[-9]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000300> "n")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000300> "\"A prefix in the metric system denoting a factor of 10 to the power of -9.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000300> "nano")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000300> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000302> (pico)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000302> "10^[-12]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000302> "n")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000302> "\"A prefix in the metric system denoting a factor of 10 to the power of -12.\" [GVG:UO]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000302> "pico")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000302> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000303> (femto)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000303> "10^[-15]")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000303> "f")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000303> "\"A prefix in the metric system denoting a factor of 10 to the power of -15.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000303> "femto")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000303> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_0000304> (atto)
+
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/UO_0000304> "a")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/UO_0000304> "10^[-18]")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/UO_0000304> "\"A prefix in the metric system denoting a factor of 10 to the power of -18.\" [UO:GVG]")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_0000304> "atto")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_0000304> <http://purl.obolibrary.org/obo/UO_0000046>)
+
+# Class: <http://purl.obolibrary.org/obo/UO_1000013> (mole based unit)
+
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/UO_1000013> "mole based unit")
+SubClassOf(<http://purl.obolibrary.org/obo/UO_1000013> <http://purl.obolibrary.org/obo/UO_0000006>)
+
+
+
+)


### PR DESCRIPTION
- [x] `docs/` have been added/updated
- [x] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

Currently, the `remove` and `filter` commands completely ignore punned entities. That is, if the ontology contains, for example, both a class and an individual with the same IRI `http://purl.obolibrary.org/obo/UO_0000039`, then `robot remove --term UO:0000039` will fail to remove anything.

This is because the `OntologyHelper#getEntities()` method, and the `OntologyHelper#getEntity()` it calls in turn, does not expect any IRI to match more than exactly one entity (`OntologyHelper#getEntity()` explicitly throws an exception if it finds more than one entity).

This PR adds a `--allow-punning` (defaulting to false, preserving the default behaviour) to the `remove` and `filter` command. When set to true, whenever a term IRI matches several entities, all matching entities will be selected.

This is particularly useful when dealing with the UO ontology, which makes intensive use of punning (most if not all units in that ontology are defined both as a class and as an individual).
