### PR TITLE
Fix typo in `--clean-obo` option values.

### DIFF
--- a/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/IOHelper.java
@@ -1901,7 +1901,7 @@ public class IOHelper {
     // Dropping the unstranslatable axioms is delegated to the OWLAPI's built-in feature
     OWLAPIOwl2Obo oboConverter = new OWLAPIOwl2Obo(ontology.getOWLOntologyManager());
     oboConverter.setDiscardUntranslatable(
-        options.contains(OBOWriteOption.DROP_UNSTRANSLATABLE_AXIOMS));
+        options.contains(OBOWriteOption.DROP_UNTRANSLATABLE_AXIOMS));
     return oboConverter.convert(ontology);
   }
 }

--- a/robot-core/src/main/java/org/obolibrary/robot/OBOWriteOption.java
+++ b/robot-core/src/main/java/org/obolibrary/robot/OBOWriteOption.java
@@ -21,7 +21,7 @@ public enum OBOWriteOption {
    * Drop axioms that cannot be represented in OBO format, instead of writing them in a {@code
    * owl-axioms} header tag.
    */
-  DROP_UNSTRANSLATABLE_AXIOMS,
+  DROP_UNTRANSLATABLE_AXIOMS,
 
   /** Drop general concept inclusion axioms. */
   DROP_GCI_AXIOMS;
@@ -54,8 +54,8 @@ public enum OBOWriteOption {
           set.add(MERGE_COMMENTS);
           break;
 
-        case "drop-unstranslatable-axioms":
-          set.add(DROP_UNSTRANSLATABLE_AXIOMS);
+        case "drop-untranslatable-axioms":
+          set.add(DROP_UNTRANSLATABLE_AXIOMS);
           break;
 
         case "drop-gci-axioms":
@@ -64,7 +64,7 @@ public enum OBOWriteOption {
 
         case "simple":
           // "simple" is a shortcut for all the options above except "merge-comments"
-          set.add(DROP_UNSTRANSLATABLE_AXIOMS);
+          set.add(DROP_UNTRANSLATABLE_AXIOMS);
           set.add(DROP_GCI_AXIOMS);
           // Fall-through
 


### PR DESCRIPTION
- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [ ] `CHANGELOG.md` has been updated

This PR fixes an unfortunate typo that has been introduced in #1236. The option to forcibly remove axioms that cannot be represented in OBO format is supposed to be `--clean-obo drop-untranslatable-axioms` (that’s what the documentation says), but the code that handles the `--clean-obo` values expects `drop-unstranslatable-axioms` -- note the added `s`.

Sorry for not having caught that sooner. It’d be nice if it could be fixed before the upcoming 1.10 release, so that the `drop-unstranslatable-axioms` variant is never actually used by anyone.