### PR TITLE
Update relation-graph version

### DIFF
--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -301,7 +301,7 @@
     <dependency>
 	  <groupId>org.geneontology</groupId>
 	  <artifactId>relation-graph_${scala.version}</artifactId>
-	  <version>2.3.2</version>
+	  <version>2.3.3</version>
 	  <exclusions>
         <exclusion>
           <groupId>org.apache.jena</groupId>


### PR DESCRIPTION
This version of relation-graph only updates its dependencies, including the parallel processing framework (zio). I'm interested to see if that has an effect on #1254.