### PR TITLE
Update relation-graph version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix regression with guessing local catalog file [#1274]
+- Fix intermittent robot extract test failures [#1277]
 
 ## [1.9.9] - 2026-02-18
 

--- a/robot-core/pom.xml
+++ b/robot-core/pom.xml
@@ -301,7 +301,7 @@
     <dependency>
 	  <groupId>org.geneontology</groupId>
 	  <artifactId>relation-graph_${scala.version}</artifactId>
-	  <version>2.3.3</version>
+	  <version>2.3.4</version>
 	  <exclusions>
         <exclusion>
           <groupId>org.apache.jena</groupId>


### PR DESCRIPTION
Resolves #1166 (probably)

- [ ] `docs/` have been added/updated
- [ ] tests have been added/updated
- [x] `mvn verify` says all tests pass
- [x] `mvn site` says all JavaDocs correct
- [x] `CHANGELOG.md` has been updated

Revised asynchronous queue termination handling within relation-graph. There was a race condition that only occurred with low numbers of CPU cores.